### PR TITLE
[TAO-8713] NFERlightweight: Passing a test with an offline test runner leads to different and incorrect displaying of the final test score

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/proxy/cache/actionStore.js
+++ b/src/proxy/cache/actionStore.js
@@ -58,11 +58,11 @@ export default function actionStoreFatory(id) {
          * @param {Object} params - the action parameters
          * @returns {Promise} resolves when the action is stored
          */
-        push: function push(action, params) {
+        push: function push(action, params, timestamp) {
             return loadStore().then(function(actionStore) {
                 actionQueue.push({
                     action: action,
-                    timestamp: Date.now(),
+                    timestamp: timestamp || Date.now(),
                     parameters: params
                 });
                 return actionStore.setItem(storeKey, actionQueue);

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -288,7 +288,7 @@ export default _.defaults(
                             if (self.isConnectivityError(err)) {
                                 self.setOffline('communicator');
                                 _.forEach(actions, function(action) {
-                                    self.actionStore.push(action.action, action.parameters);
+                                    self.actionStore.push(action.action, action.parameters, action.timestamp);
                                 });
                             }
 
@@ -321,7 +321,7 @@ export default _.defaults(
                         .flush()
                         .then(function(actions) {
                             _.forEach(actions, function(action) {
-                                self.actionStore.push(action.action, action.parameters);
+                                self.actionStore.push(action.action, action.parameters, action.timestamp);
                             });
 
                             return actions;


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8713
 
While passing the test with offline test runner without internet connection, if test taker will download test data then it will cause reset of test taker action timestamp

#### How to test
- Run delivery as a test taker with offline test runner
- Break the connection
- At the end of the test download the test data
- Restore the connection and finish the test
- Check that data with correct timestamp sent to /taoQtiTest/OfflineRunner/messages endpoint   