### PR TITLE
Bug/tao 8691/line reader resize pointers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-test-runner-qti",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-test-runner-qti",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_line-reader.scss
+++ b/scss/inc/_line-reader.scss
@@ -50,6 +50,7 @@ $lrMaskBgTransparent: rgba($lrMaskBg, 0.8);
             position: absolute;
             right: 0;
             bottom: 0;
+            cursor: nwse-resize;
         }
     }
 
@@ -62,6 +63,7 @@ $lrMaskBgTransparent: rgba($lrMaskBg, 0.8);
             left: -10px;
             border-right: 1px solid $pluginLink;
             border-bottom: 1px solid $pluginLink;
+            cursor: nesw-resize;
         }
     }
 

--- a/scss/inc/_line-reader.scss
+++ b/scss/inc/_line-reader.scss
@@ -56,10 +56,12 @@ $lrMaskBgTransparent: rgba($lrMaskBg, 0.8);
     &.e {
         .resize-control {
             position: absolute;
-            width: 10px;
+            width: 20px;
             height: 20px;
             bottom: -10px;
+            left: -10px;
             border-right: 1px solid $pluginLink;
+            border-bottom: 1px solid $pluginLink;
         }
     }
 

--- a/src/plugins/tools/lineReader/compoundMask.js
+++ b/src/plugins/tools/lineReader/compoundMask.js
@@ -755,6 +755,7 @@ export default function compoundMaskFactory(options, dimensions, position) {
 
             beforeResize: function beforeResize(width, height, fromLeft) {
                 this.config.maxWidth = dimensions.rightWidth + (dimensions.innerWidth - constrains.minWidth);
+                this.config.minWidth = constrains.minWidth;
                 this.config.maxHeight =  dimensions.outerHeight - dimensions.topHeight - constrains.minBottomHeight;
             },
 

--- a/src/plugins/tools/lineReader/compoundMask.js
+++ b/src/plugins/tools/lineReader/compoundMask.js
@@ -754,9 +754,7 @@ export default function compoundMaskFactory(options, dimensions, position) {
             },
 
             beforeResize: function beforeResize(width, height, fromLeft) {
-                this.config.maxWidth = fromLeft
-                    ? dimensions.rightWidth + (dimensions.innerWidth - constrains.minWidth)
-                    : null;
+                this.config.maxWidth = dimensions.rightWidth + (dimensions.innerWidth - constrains.minWidth);
                 this.config.maxHeight =  dimensions.outerHeight - dimensions.topHeight - constrains.minBottomHeight;
             },
 

--- a/src/plugins/tools/lineReader/compoundMask.js
+++ b/src/plugins/tools/lineReader/compoundMask.js
@@ -589,6 +589,14 @@ export default function compoundMaskFactory(options, dimensions, position) {
     }
 
     /**
+     * Update the transform model during a resize affecting inner height
+     * @param {Number} newHeight
+     */
+    const setInnerHeight = (newHeight) => {
+        dimensions.innerHeight = newHeight;
+        dimensions.bottomHeight = dimensions.outerHeight - dimensions.innerHeight - dimensions.topHeight;
+    };
+    /**
      * ======================================
      * Mask parts and other elements creation
      * ======================================
@@ -692,7 +700,7 @@ export default function compoundMaskFactory(options, dimensions, position) {
         // East
         createPart({
             id: 'e',
-            edges: { top: false, right: false, bottom: false, left: '.resize-control' },
+            edges: { top: false, right: false, bottom: '.resize-control', left: '.resize-control' },
             edgesBorders: { top: false, right: true, bottom: false, left: true },
             resizeControll: true,
 
@@ -715,10 +723,12 @@ export default function compoundMaskFactory(options, dimensions, position) {
                 this.config.maxWidth = fromLeft
                     ? dimensions.rightWidth + (dimensions.innerWidth - constrains.minWidth)
                     : null;
+                this.config.maxHeight =  dimensions.outerHeight - dimensions.topHeight - constrains.minBottomHeight;
             },
 
             onResize: function onResize(width, height, fromLeft, fromTop, x) {
                 setRightWidth(width, x, fromLeft);
+                setInnerHeight(height);
                 applyTransformsToMasks();
             }
         });
@@ -726,10 +736,9 @@ export default function compoundMaskFactory(options, dimensions, position) {
         // South
         createPart({
             id: 's',
-            edges: { top: '.resize-control', right: false, bottom: false, left: false },
+            edges: { top: false, right: false, bottom: false, left: false },
             edgesBorders: { top: true, right: false, bottom: true, left: false },
             minHeight: constrains.minBottomHeight,
-            resizeControll: true,
 
             place: function place() {
                 this.moveTo(position.innerX, position.innerY + dimensions.innerHeight).setSize(

--- a/src/plugins/tools/lineReader/compoundMask.js
+++ b/src/plugins/tools/lineReader/compoundMask.js
@@ -697,6 +697,40 @@ export default function compoundMaskFactory(options, dimensions, position) {
             }
         });
 
+        // South
+        createPart({
+            id: 's',
+            edges: { top: false, right: false, bottom: false, left: false },
+            edgesBorders: { top: true, right: false, bottom: true, left: false },
+            minHeight: constrains.minBottomHeight,
+
+            place: function place() {
+                this.moveTo(position.innerX, position.innerY + dimensions.innerHeight).setSize(
+                    dimensions.innerWidth,
+                    dimensions.bottomHeight
+                );
+            },
+
+            placeOverlay: function placeOverlay(overlay) {
+                var pos = this.getPosition(),
+                    size = this.getSize();
+                overlay
+                    .moveTo(pos.x, pos.y + options.resizeHandleSize)
+                    .setSize(size.width, size.height - options.resizeHandleSize * 2);
+            },
+
+            beforeResize: function beforeResize(width, height, fromLeft, fromTop) {
+                this.config.maxHeight = fromTop
+                    ? dimensions.bottomHeight + (dimensions.innerHeight - constrains.minHeight)
+                    : null;
+            },
+
+            onResize: function onResize(width, height, fromLeft, fromTop, x, y) {
+                setBottomHeight(height, y, fromTop);
+                applyTransformsToMasks();
+            }
+        });
+
         // East
         createPart({
             id: 'e',
@@ -729,40 +763,6 @@ export default function compoundMaskFactory(options, dimensions, position) {
             onResize: function onResize(width, height, fromLeft, fromTop, x) {
                 setRightWidth(width, x, fromLeft);
                 setInnerHeight(height);
-                applyTransformsToMasks();
-            }
-        });
-
-        // South
-        createPart({
-            id: 's',
-            edges: { top: false, right: false, bottom: false, left: false },
-            edgesBorders: { top: true, right: false, bottom: true, left: false },
-            minHeight: constrains.minBottomHeight,
-
-            place: function place() {
-                this.moveTo(position.innerX, position.innerY + dimensions.innerHeight).setSize(
-                    dimensions.innerWidth,
-                    dimensions.bottomHeight
-                );
-            },
-
-            placeOverlay: function placeOverlay(overlay) {
-                var pos = this.getPosition(),
-                    size = this.getSize();
-                overlay
-                    .moveTo(pos.x, pos.y + options.resizeHandleSize)
-                    .setSize(size.width, size.height - options.resizeHandleSize * 2);
-            },
-
-            beforeResize: function beforeResize(width, height, fromLeft, fromTop) {
-                this.config.maxHeight = fromTop
-                    ? dimensions.bottomHeight + (dimensions.innerHeight - constrains.minHeight)
-                    : null;
-            },
-
-            onResize: function onResize(width, height, fromLeft, fromTop, x, y) {
-                setBottomHeight(height, y, fromTop);
                 applyTransformsToMasks();
             }
         });

--- a/test/plugins/tools/lineReader/compoundMask/test.js
+++ b/test/plugins/tools/lineReader/compoundMask/test.js
@@ -333,8 +333,8 @@ define(['jquery', 'lodash', 'taoQtiTest/runner/plugins/tools/lineReader/compound
             {
                 title: 'topHeight too short',
                 positionIn: { innerY: 10 },
-                positionOut: { innerY: 50 },
-                dimensionsOut: { topHeight: 50, outerHeight: 240, bottomHeight: 200 - (50 + 10) }
+                positionOut: { innerY: 38 },
+                dimensionsOut: { topHeight: 38, outerHeight: 228, bottomHeight: 200 - (50 + 10) }
             },
             {
                 title: 'innerHeight too short',


### PR DESCRIPTION
**task:**  https://oat-sa.atlassian.net/browse/TAO-8691

**description:**
resize controls had wrong cursors, because inner mask resize control was in fact two different controls: vertical resize and horizontal.

**solution:**
one of the controls was disabled and other was extended to be able resize mask both horizontally and vertically.
