### PR TITLE
enable development mode commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,25 @@
 
 TAO Test Runner QTI implementation
 
+## Install
+
+```
+npm i --save @oat-sa/tao-test-runner
+```
+
+## Development
+
 Available scripts in the project:
 
--   `npm run test <testname>`: run test suite
-    -   `testname` (optional): Specific test to run. If it is not provided, all will be ran.
--   `npm run test:keepAlive`: start test server
--   `npm run test:cov`: run `build:cov` and run tests
--   `npm run coverage`: show coverage report in terminal
--   `npm run coverage:html`: show coverage report in browser
--   `npm run build`: build for production into `dist` directory
--   `npm run build:cov`: build for coverage into `dist` directory
--   `npm run build:watch`: same as `build`, but watch changes
--   `npm run lint`: check syntax of code
+- `npm run test <testname>`: run test suite
+  - `testname` (optional): Specific test to run. If it is not provided, all will be ran.
+- `npm run test:keepAlive`: start test server
+- `npm run test:cov`: run `build:cov` and run tests
+- `npm run test:dev`: test in development mode (watch changes and source maps)
+- `npm run coverage`: show coverage report in terminal
+- `npm run coverage:html`: show coverage report in browser
+- `npm run build`: build for production into `dist` directory
+- `npm run build:watch`: build for production into `dist` directory and watch for changes
+- `npm run build:cov`: build for coverage into `dist` directory
+- `npm run build:dev`: watch changes and build with source maps
+- `npm run lint`: check syntax of code

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -29,6 +29,8 @@ import { copyFile, mkdirp } from 'fs-extra';
 const { srcDir, outputDir, aliases } = require('./path');
 const Handlebars = require('handlebars');
 
+const isDev = process.env.NODE_ENV === 'development';
+
 /**
  * Support of handlebars 1.3.0
  * TODO remove once migrated to hbs >= 3.0.0
@@ -67,6 +69,7 @@ export default inputs.map(input => {
         output: {
             dir: path.join(outputDir, dir),
             format: 'amd',
+            sourcemap: isDev,
             name
         },
         watch: {

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -69,6 +69,9 @@ export default inputs.map(input => {
             format: 'amd',
             name
         },
+        watch: {
+            clearScreen : false
+        },
         external: [
             ...localExternals,
             'handlebars',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.7.3",
+    "version": "0.8.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1936,6 +1936,35 @@
                 "is-arrayish": "^0.2.1"
             }
         },
+        "es-abstract": {
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
+            "integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.0",
+                "is-callable": "^1.1.4",
+                "is-regex": "^1.0.4",
+                "object-inspect": "^1.6.0",
+                "object-keys": "^1.1.1",
+                "string.prototype.trimleft": "^2.0.0",
+                "string.prototype.trimright": "^2.0.0"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
         "es6-error": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -2610,6 +2639,15 @@
                 "har-schema": "^2.0.0"
             }
         },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2849,6 +2887,18 @@
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
+        "is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
+        },
+        "is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
+        },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2891,11 +2941,29 @@
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
             "dev": true
         },
+        "is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.1"
+            }
+        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.0"
+            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -3313,6 +3381,12 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "memorystream": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+            "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
             "dev": true
         },
         "meow": {
@@ -3882,6 +3956,23 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
+        "npm-run-all": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+            "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "pidtree": "^0.3.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -3949,6 +4040,12 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-inspect": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
             "dev": true
         },
         "object-keys": {
@@ -4194,6 +4291,12 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
+        "pidtree": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
+            "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+            "dev": true
+        },
         "pify": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -4408,7 +4511,7 @@
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
             }
         },
         "raw-body": {
@@ -5230,6 +5333,12 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
+        "shell-quote": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+            "dev": true
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -5352,6 +5461,37 @@
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^5.1.0"
+            }
+        },
+        "string.prototype.padend": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+            "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.4.3",
+                "function-bind": "^1.0.2"
+            }
+        },
+        "string.prototype.trimleft": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
+            "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.0.2"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
+            "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.0.2"
             }
         },
         "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.7.3",
+    "version": "0.8.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",
@@ -12,14 +12,16 @@
         "test": "npx qunit-testrunner",
         "test:keepAlive": "npx qunit-testrunner --keepalive",
         "test:cov": "npm run build:cov && npx qunit-testrunner --cov",
+        "test:dev": "NODE_ENV=development run-p test:keepAlive build:watch",
         "coverage": "nyc report",
         "coverage:html": "nyc report --reporter=lcov && open-cli coverage/lcov-report/index.html",
         "build": "rollup --config ./build/rollup.config.js",
+        "build:dev": "NODE_ENV=development npm run build:watch",
         "build:cov": "rollup --config ./build/rollup.config.js --environment COVERAGE",
         "build:watch": "rollup --config ./build/rollup.config.js --watch",
-        "buildScss": "node ./build/scss.js",
+        "build:scss": "node ./build/scss.js",
         "lint": "eslint src test",
-        "prepare": "npm run buildScss && npm run build"
+        "prepare": "run-s build:scss build"
     },
     "repository": {
         "type": "git",
@@ -70,6 +72,7 @@
         "lodash": "2.4.1",
         "moment": "2.11.1",
         "moment-timezone": "0.5.10",
+        "npm-run-all": "^4.1.5",
         "nyc": "^14.1.1",
         "open-cli": "^5.0.0",
         "popper.js": "1.15.0",


### PR DESCRIPTION
Adds 2 new commands for development purpose : 

Watch and rebuild sources, including source maps : 
```
npm run build:dev
``` 

Watch and tests tests, including source maps. Start the static webserver : 
```
npm run test:dev
``` 