### PR TITLE
Use isLinear from the testMap 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/stats.js
+++ b/src/helpers/stats.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
  */
 /**
  * This helper provides more statistics about the test
@@ -24,34 +24,33 @@ import _ from 'lodash';
 import mapHelper from 'taoQtiTest/runner/helpers/map';
 import currentItemHelper from 'taoQtiTest/runner/helpers/currentItem';
 
-/**
- * Return scope stats that takes into account any test taker interaction made since the item has been loaded
- * @param {String} scope - scope to consider for calculating the stats
- * @param {Object} runner - testRunner instance
- * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox. Default false
- * @returns {Object}
- */
-function getInstantStats(scope, runner, sync) {
-    var map = runner.getTestMap(),
-        context = runner.getTestContext(),
-        stats = _.clone(mapHelper.getScopeStats(map, context.itemPosition, scope)),
-        item = mapHelper.getItemAt(map, context.itemPosition),
-        isItemCurrentlyAnswered;
-
-    if (!item.informational) {
-        isItemCurrentlyAnswered = currentItemHelper.isAnswered(runner);
-        if (!isItemCurrentlyAnswered && context.itemAnswered) {
-            stats.answered--;
-        } else if ((isItemCurrentlyAnswered || sync) && !context.itemAnswered) {
-            stats.answered++;
-        } else if (sync && !isItemCurrentlyAnswered && context.itemAnswered && context.isLinear) {
-            stats.answered++;
-        }
-    }
-
-    return stats;
-}
-
 export default {
-    getInstantStats: getInstantStats
+
+    /**
+     * Return scope stats that takes into account any test taker interaction made since the item has been loaded
+     * @param {String} scope - scope to consider for calculating the stats
+     * @param {Object} runner - testRunner instance
+     * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox. Default false
+     * @returns {Object} the stats
+     */
+    getInstantStats(scope, runner, sync) {
+        const map      = runner.getTestMap();
+        const context  = runner.getTestContext();
+        const item     = runner.getCurrentItem();
+        const testPart = runner.getCurrentPart();
+        const stats = _.clone(mapHelper.getScopeStats(map, context.itemPosition, scope));
+
+        if (!item.informational) {
+            const isItemCurrentlyAnswered = currentItemHelper.isAnswered(runner);
+            if (!isItemCurrentlyAnswered && context.itemAnswered) {
+                stats.answered--;
+            } else if ((isItemCurrentlyAnswered || sync) && !context.itemAnswered) {
+                stats.answered++;
+            } else if (sync && !isItemCurrentlyAnswered && context.itemAnswered && testPart.isLinear) {
+                stats.answered++;
+            }
+        }
+
+        return stats;
+    }
 };

--- a/src/plugins/controls/progressbar/progress.js
+++ b/src/plugins/controls/progressbar/progress.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -218,7 +218,8 @@ var indicators = {
  */
 function getFixedMap(testMap, testContext) {
     var item;
-    if (testContext.itemAnswered && testContext.isLinear) {
+    const testPart = mapHelper.getPart(testMap, testContext.testPartId);
+    if (testContext.itemAnswered && testPart && testPart.isLinear) {
         testMap = _.cloneDeep(testMap);
         item = mapHelper.getItemAt(testMap, testContext.itemPosition);
         item.answered = false;
@@ -469,11 +470,12 @@ export default {
      * @param {Array} config.categories - categories to count by them
      * @returns {progressData}
      */
-    computeStats: function computeStats(testMap, testContext, config) {
-        var statsComputer = (config.scope && scopes[config.scope]) || scopes.test;
-        var stats = statsComputer(testMap, testContext, config || defaultConfig);
+    computeStats(testMap, testContext, config) {
+        const testPart = mapHelper.getPart(testMap, testContext.testPartId);
+        const statsComputer = (config.scope && scopes[config.scope]) || scopes.test;
+        const stats = statsComputer(testMap, testContext, config || defaultConfig);
         stats.overall = testMap.stats.total;
-        if(testContext.isLinear){
+        if(testPart && testPart.isLinear){
             stats.overallCompleted = testMap.stats.answered - 1;
         } else {
             stats.overallCompleted = testMap.stats.answered  ;

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -43,20 +43,22 @@ export default pluginFactory({
     /**
      * Install step, add behavior before the lifecycle
      */
-    install: function install() {
-        var testRunner = this.getTestRunner();
+    install() {
+        const testRunner = this.getTestRunner();
 
         /**
          * Load the timers, from the given timeConstraints and reading the current value in the store
          * @param {store} timeStore - where the values are read
          * @param {Object} config - the current config, especially for the warnings
-         * @return {Promise<Object[]>} the list of timers for the current context
+         * @returns {Promise<Object[]>} the list of timers for the current context
          */
         this.loadTimers = function loadTimers(timeStore, config) {
-            var testContext = testRunner.getTestContext();
-            var timeConstraints = testContext.timeConstraints;
-            var isLinear = !!testContext.isLinear;
-            var timers = timersFactory(timeConstraints, isLinear, config);
+            const testContext = testRunner.getTestContext();
+            const testPart = testRunner.getCurrentPart();
+            const isLinear = testPart && testPart.isLinear;
+            const timeConstraints = testContext.timeConstraints;
+            const timers = timersFactory(timeConstraints, isLinear, config);
+
             return Promise.all(
                 _.map(timers, function(timer) {
                     return timeStore.getItem(`consumed_${timer.id}`).then(function(savedConsumedTime) {
@@ -74,7 +76,7 @@ export default pluginFactory({
          * Save consumed time values into the store
          * @param {store} timeStore - where the values are saved
          * @param {Object[]} timers - the timers to save
-         * @return {Promise} resolves once saved
+         * @returns {Promise} resolves once saved
          */
         this.saveTimers = function saveTimers(timeStore, timers) {
             return Promise.all(

--- a/src/plugins/controls/timer/strategy/enforcedStay.js
+++ b/src/plugins/controls/timer/strategy/enforcedStay.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -33,9 +33,14 @@
  * @returns {strategy|Boolean} the strategy if applies or false
  */
 export default function enforcedStayStrategy(testRunner, timer) {
-    var testContext = testRunner.getTestContext();
+    const testPart = testRunner.getCurrentPart();
 
-    if (timer && timer.type === 'min' && timer.scope === 'item' && testContext.isLinear) {
+    if (
+        timer &&
+        timer.type === 'min' &&
+        timer.scope === 'item' &&
+        testPart && testPart.isLinear
+    ) {
         return {
             name: 'enforcedStay',
 

--- a/src/plugins/controls/timer/strategy/guidedNavigation.js
+++ b/src/plugins/controls/timer/strategy/guidedNavigation.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2018-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -35,15 +35,15 @@
  * @returns {strategy|Boolean} the strategy if applies or false
  */
 export default function guidedNavigationStrategy(testRunner, timer) {
-    var testContext = testRunner.getTestContext();
-    var testRunnerOptions = testRunner.getOptions();
+    const testRunnerOptions = testRunner.getOptions();
+    const testPart = testRunner.getCurrentPart();
 
     if (
         timer &&
         timer.type === 'locked' &&
         timer.scope === 'item' &&
         testRunnerOptions.guidedNavigation === true &&
-        testContext.isLinear === true
+        testPart && testPart.isLinear
     ) {
         return {
             name: 'guidedNavigation',

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -125,6 +125,7 @@ export default pluginFactory({
         function doNext(nextItemWarning) {
             const testContext = testRunner.getTestContext();
             const testMap = testRunner.getTestMap();
+            const testPart = testRunner.getCurrentPart();
             const nextItemPosition = testContext.itemPosition + 1;
             const itemIdentifier = testContext.itemIdentifier;
 
@@ -152,7 +153,7 @@ export default pluginFactory({
                 const warningHelper = nextWarningHelper({
                     endTestWarning: endTestWarning,
                     isLast: isLastItem(),
-                    isLinear: testContext.isLinear,
+                    isLinear: testPart.isLinear,
                     nextItemWarning: nextItemWarning,
                     nextPartWarning: nextPartWarning,
                     nextPart: mapHelper.getItemPart(testMap, nextItemPosition),

--- a/src/plugins/navigation/next/linearNextItemWarning.js
+++ b/src/plugins/navigation/next/linearNextItemWarning.js
@@ -37,7 +37,7 @@ export default pluginFactory({
     /**
      * Initialize the plugin (called during runner's init)
      */
-    init: function init() {
+    init() {
         const self = this;
         const testRunner = this.getTestRunner();
         const testRunnerOptions = testRunner.getOptions();
@@ -167,27 +167,28 @@ export default pluginFactory({
                 });
             })
             .before('move skip', function(e, type, scope) {
-                const context = testRunner.getTestContext();
-                const map = testRunner.getTestMap();
-                const item = mapHelper.getItemAt(map, context.itemPosition);
-                const categories = getNextItemCategories();
+                const context     = testRunner.getTestContext();
+                const item        = testRunner.getCurrentItem();
+                const currentPart = testRunner.getCurrentPart();
+                const categories  = getNextItemCategories();
 
-                if (context.isLinear) {
+                if (currentPart && currentPart.isLinear) {
                     // Do nothing if nextSection warning imminent:
                     if (scope === 'section' && categories.nextSectionWarning) {
                         return;
-                    }
+
                     // Do nothing if endOfPart warning imminent:
-                    else if (categories.nextPartWarning) {
+                    } else if (categories.nextPartWarning) {
                         return;
-                    }
+
                     // Do nothing if 'informational item':
-                    else if (item.informational) {
+                    } else if (item.informational) {
                         return;
-                    }
+
                     // Show dialog if conditions met:
-                    else if (type === 'next' && !context.isLast && testRunnerOptions.forceEnableLinearNextItemWarning) {
+                    } else if (type === 'next' && !context.isLast && testRunnerOptions.forceEnableLinearNextItemWarning) {
                         return doNextWarning('next');
+
                     } else if (e.name === 'skip' && !context.isLast && testRunnerOptions.forceEnableLinearNextItemWarning) {
                         return doNextWarning('skip');
                     }

--- a/src/plugins/navigation/previous.js
+++ b/src/plugins/navigation/previous.js
@@ -41,7 +41,7 @@ export default pluginFactory({
     /**
      * Initialize the plugin (called during runner's init)
      */
-    init: function init() {
+    init() {
         const self = this;
 
         const testRunner = this.getTestRunner();
@@ -60,6 +60,7 @@ export default pluginFactory({
                 'noExitTimedSectionWarning',
                 true
             );
+            const currentPart = testRunner.getCurrentPart();
             let previousSection;
             let previousPart;
 
@@ -98,7 +99,7 @@ export default pluginFactory({
                     return false;
                 }
             }
-            return context.isLinear === false && context.canMoveBackward === true;
+            return currentPart.isLinear === false && context.canMoveBackward === true;
         };
 
         /**

--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
@@ -266,17 +266,17 @@ var navigatorApi = {
      * @returns {navigatorApi}
      * @fires navigator#update
      */
-    update: function update(map, context) {
-        var scopedMap = this.getScopedMap(map, context);
-        var progression = scopedMap.stats || {
+    update(map, context) {
+        const scopedMap = this.getScopedMap(map, context);
+        const testPart  = mapHelper.getPart(map, context.testPartId);
+        const progression = scopedMap.stats || {
             questions: 0,
             answered: 0,
             flagged: 0,
             viewed: 0,
             total: 0
         };
-        var totalQuestions = this.getProgressionTotal(progression, 'questions');
-        var activeItem, isSkipaheadEnabled;
+        const totalQuestions = this.getProgressionTotal(progression, 'questions');
 
         this.map = map;
         this.progression = progression;
@@ -289,17 +289,17 @@ var navigatorApi = {
         this.writeCount(this.controls.$infoAll, totalQuestions, null);
 
         // rebuild the tree
-        if (!context.isLinear) {
+        if (!testPart.isLinear) {
             this.controls.$filterBar.show();
             this.controls.$linearState.hide();
             this.controls.$tree.html(navigatorTreeTpl(scopedMap));
 
             this.autoScroll();
 
-            activeItem = mapHelper.getActiveItem(scopedMap);
+            let activeItem = mapHelper.getActiveItem(scopedMap);
             this.setState('prevents-unseen', this.config.preventsUnseen);
 
-            isSkipaheadEnabled =
+            let isSkipaheadEnabled =
                 activeItem &&
                 activeItem.categories &&
                 _.indexOf(activeItem.categories, 'x-tao-option-review-skipahead') >= 0;

--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -296,10 +296,10 @@ var navigatorApi = {
 
             this.autoScroll();
 
-            let activeItem = mapHelper.getActiveItem(scopedMap);
+            const activeItem = mapHelper.getActiveItem(scopedMap);
             this.setState('prevents-unseen', this.config.preventsUnseen);
 
-            let isSkipaheadEnabled =
+            const isSkipaheadEnabled =
                 activeItem &&
                 activeItem.categories &&
                 _.indexOf(activeItem.categories, 'x-tao-option-review-skipahead') >= 0;

--- a/src/plugins/navigation/review/review.js
+++ b/src/plugins/navigation/review/review.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -126,7 +126,8 @@ function updateButton(button, data) {
 function canFlag(testRunner) {
     const testContext = testRunner.getTestContext();
     const testMap = testRunner.getTestMap();
-    const item = mapHelper.getItemAt(testMap, testContext.itemPosition);
+    const item = testRunner.getCurrentItem();
+    const testPart = testRunner.getCurrentPart();
     const markReviewCategory = mapHelper.hasItemCategory(
         testMap,
         testContext.itemIdentifier,
@@ -134,7 +135,7 @@ function canFlag(testRunner) {
         true
     );
 
-    return !!(!testContext.isLinear && markReviewCategory && !(item && item.informational));
+    return !!(!testPart.isLinear && markReviewCategory && !(item && item.informational));
 }
 
 /**
@@ -345,6 +346,7 @@ export default pluginFactory({
             .on('loaditem', function() {
                 const context = testRunner.getTestContext();
                 const map = testRunner.getTestMap();
+                const testPart = testRunner.getCurrentPart();
                 const categories = getReviewCategories();
 
                 if (isPluginAllowed()) {
@@ -353,7 +355,7 @@ export default pluginFactory({
                         getFlagItemButtonData(isItemFlagged(map, context.itemPosition))
                     );
                     self.navigator.update(map, context).updateConfig({
-                        canFlag: !context.isLinear && categories.markReview
+                        canFlag: !testPart.isLinear && categories.markReview
                     });
                     self.show();
                     updateButton(self.toggleButton, getToggleButtonData(self.navigator));

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -172,7 +172,7 @@ var qtiProvider = {
 
         /**
          * Convenience function to load the current item from the testMap
-         * @returns {Object?} the current item if any
+         * @returns {Object?} the current item if any or falsy
          */
         this.getCurrentItem = function getCurrentItem() {
             const testContext = this.getTestContext();
@@ -180,12 +180,11 @@ var qtiProvider = {
             if (testContext && testMap && testContext.itemIdentifier) {
                 return mapHelper.getItem(testMap, testContext.itemIdentifier);
             }
-            return null;
         };
 
         /**
          * Convenience function to load the current section from the testMap
-         * @returns {Object?} the current section if any
+         * @returns {Object?} the current section if any or falsy
          */
         this.getCurrentSection = function getCurrentSection() {
             const testContext = this.getTestContext();
@@ -193,12 +192,11 @@ var qtiProvider = {
             if (testContext && testMap && testContext.sectionId) {
                 return mapHelper.getSection(testMap, testContext.sectionId);
             }
-            return null;
         };
 
         /**
          * Convenience function to load the current part from the testMap
-         * @returns {Object?} the current part if any
+         * @returns {Object?} the current part if any or falsy
          */
         this.getCurrentPart = function getCurrentPart() {
             const testContext = this.getTestContext();
@@ -206,7 +204,6 @@ var qtiProvider = {
             if (testContext && testMap && testContext.testPartId) {
                 return mapHelper.getPart(testMap, testContext.testPartId);
             }
-            return null;
         };
     },
 

--- a/test/dataUpdater/testContext.json
+++ b/test/dataUpdater/testContext.json
@@ -1,7 +1,6 @@
 {
   "state": 1,
   "remainingAttempts": -1,
-  "isLinear": false,
   "attempt": 1,
   "isTimeout": false,
   "itemIdentifier": "item-1",

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -59,6 +59,12 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
             getOptions() {
                 return data;
             },
+            getCurrentItem(){
+                return map.parts[context.testPartId].sections[context.sectionId].items[context.itemIdentifier];
+            },
+            getCurrentPart(){
+                return map.parts[context.testPartId];
+            },
             itemRunner: {
                 _item: {
                     responses: declarations
@@ -176,7 +182,10 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
         .test('helpers/messages.getExitMessage (enabled)', function(testData, assert) {
             var context = {
                 itemPosition: 1,
-                itemAnswered: testData.currentItemAnswered
+                itemAnswered: testData.currentItemAnswered,
+                sectionId: 'section1',
+                testPartId: 'part1',
+                itemIdentifier: 'item1'
             };
             var data = {
                 enableUnansweredItemsWarning: true

--- a/test/navigator/navigator/test.js
+++ b/test/navigator/navigator/test.js
@@ -186,7 +186,7 @@ define([
     QUnit.test('is moving to the next item over a testPart', function(assert) {
         var updatedContext;
 
-        assert.expect(6);
+        assert.expect(5);
 
         updatedContext = testNavigator(testContexts.context3, testMap).nextItem();
 
@@ -202,14 +202,13 @@ define([
             'The updated context contains the correct section id'
         );
         assert.equal(updatedContext.testPartId, 'testPart-2', 'The updated context contains the correct test part id');
-        assert.equal(updatedContext.isLinear, true, 'The updated context contains the correct isLinear option');
         assert.equal(updatedContext.itemAnswered, true, 'The item has been answered since the test part is linear');
     });
 
     QUnit.test('is moving to the next item over timed sections', function(assert) {
         var updatedContext;
 
-        assert.expect(6);
+        assert.expect(5);
 
         updatedContext = testNavigator(testContexts.context4, testMap).nextItem();
 
@@ -225,7 +224,6 @@ define([
             'The updated context contains the correct section id'
         );
         assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
-        assert.equal(updatedContext.isLinear, false, 'The updated context contains the correct isLinear option');
         assert.deepEqual(
             updatedContext.timeConstraints,
             [
@@ -280,7 +278,7 @@ define([
     QUnit.test('is moving to the next section', function(assert) {
         var updatedContext;
 
-        assert.expect(6);
+        assert.expect(5);
 
         updatedContext = testNavigator(testContexts.context4, testMap).nextSection();
 
@@ -296,7 +294,6 @@ define([
             'The updated context contains the correct section id'
         );
         assert.equal(updatedContext.testPartId, 'testPart-1', 'The updated context contains the correct test part id');
-        assert.equal(updatedContext.isLinear, false, 'The updated context contains the correct isLinear option');
         assert.deepEqual(
             updatedContext.timeConstraints,
             [

--- a/test/navigator/navigator/testContexts.json
+++ b/test/navigator/navigator/testContexts.json
@@ -2,7 +2,6 @@
   "context1": {
     "state": 1,
     "remainingAttempts": -1,
-    "isLinear": false,
     "attempt": 1,
     "isTimeout": false,
     "itemIdentifier": "item-1",
@@ -35,7 +34,6 @@
   "context2": {
     "state": 1,
     "remainingAttempts": -1,
-    "isLinear": false,
     "attempt": 1,
     "isTimeout": false,
     "itemIdentifier": "item-3",
@@ -68,7 +66,6 @@
   "context3": {
     "state": 1,
     "remainingAttempts": -1,
-    "isLinear": false,
     "attempt": 1,
     "isTimeout": false,
     "itemIdentifier": "item-14",
@@ -102,7 +99,6 @@
   "context4": {
     "state": 1,
     "remainingAttempts": -1,
-    "isLinear": false,
     "attempt": 1,
     "isTimeout": false,
     "itemIdentifier": "item-6",
@@ -149,7 +145,6 @@
   "context5": {
     "state": 1,
     "remainingAttempts": -1,
-    "isLinear": true,
     "attempt": 1,
     "isTimeout": false,
     "itemIdentifier": "item-17",

--- a/test/navigator/offlineNavigator/resources/testContext.json
+++ b/test/navigator/offlineNavigator/resources/testContext.json
@@ -1,7 +1,6 @@
 {
   "state": 1,
   "remainingAttempts": 0,
-  "isLinear": true,
   "isTimeout": false,
   "itemIdentifier": "Q01",
   "attempt": 1,

--- a/test/plugins/controls/progressbar/progress/test.js
+++ b/test/plugins/controls/progressbar/progress/test.js
@@ -26,6 +26,11 @@ define([
 ], function(_, progressHelper, mapSample) {
     'use strict';
 
+    const linearMapSample = _.cloneDeep(mapSample);
+    Object.values(linearMapSample.parts).forEach( part => {
+        part.isLinear = true;
+    });
+
     QUnit.module('helpers/progress');
 
     QUnit.test('module', function(assert) {
@@ -55,7 +60,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -108,7 +112,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -161,7 +164,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -218,7 +220,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -279,7 +280,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -340,7 +340,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -404,7 +403,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -465,7 +463,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -526,7 +523,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -590,7 +586,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -651,7 +646,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -712,7 +706,6 @@ define([
                 itemPosition: 3,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-1',
-                isLinear: false,
                 itemAnswered: true
             },
             expected: {
@@ -770,12 +763,11 @@ define([
                 scope: 'test',
                 categories: []
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -823,12 +815,11 @@ define([
                 scope: 'testPart',
                 categories: []
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -876,12 +867,11 @@ define([
                 scope: 'testSection',
                 categories: []
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -933,12 +923,11 @@ define([
                 indicator: 'categories',
                 categories: []
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -994,12 +983,11 @@ define([
                 indicator: 'categories',
                 categories: []
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1055,12 +1043,11 @@ define([
                 indicator: 'categories',
                 categories: []
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1119,12 +1106,11 @@ define([
                 indicator: 'categories',
                 categories: ['SCORED']
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1180,12 +1166,11 @@ define([
                 indicator: 'categories',
                 categories: ['SCORED']
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1241,12 +1226,11 @@ define([
                 indicator: 'categories',
                 categories: ['SCORED']
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1305,12 +1289,11 @@ define([
                 indicator: 'categories',
                 categories: ['SCORED', 'CAT2']
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1366,12 +1349,11 @@ define([
                 indicator: 'categories',
                 categories: ['SCORED', 'CAT2']
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1427,12 +1409,11 @@ define([
                 indicator: 'categories',
                 categories: ['SCORED', 'CAT2']
             },
-            testMap: mapSample,
+            testMap: linearMapSample,
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
                 sectionId: 'assessmentSection-2',
-                isLinear: true,
                 itemAnswered: true
             },
             expected: {
@@ -1773,7 +1754,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1795,7 +1775,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1817,7 +1796,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1839,7 +1817,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1862,7 +1839,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1884,7 +1860,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1906,7 +1881,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1928,7 +1902,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1950,7 +1923,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1973,7 +1945,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -1995,7 +1966,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -2017,7 +1987,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -2039,7 +2008,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -2061,7 +2029,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {
@@ -2084,7 +2051,6 @@ define([
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
             numberItems: 12,
-            isLinear: false,
             itemAnswered: true
         },
         expected: {

--- a/test/plugins/navigation/next/linearNextItemWarning/test.js
+++ b/test/plugins/navigation/next/linearNextItemWarning/test.js
@@ -45,68 +45,52 @@ define([
         );
     });
 
-    pluginApi = [
-        {
-            name: 'init',
-            title: 'init'
-        },
-        {
-            name: 'render',
-            title: 'render'
-        },
-        {
-            name: 'finish',
-            title: 'finish'
-        },
-        {
-            name: 'destroy',
-            title: 'destroy'
-        },
-        {
-            name: 'trigger',
-            title: 'trigger'
-        },
-        {
-            name: 'getTestRunner',
-            title: 'getTestRunner'
-        },
-        {
-            name: 'getAreaBroker',
-            title: 'getAreaBroker'
-        },
-        {
-            name: 'getConfig',
-            title: 'getConfig'
-        },
-        {
-            name: 'setConfig',
-            title: 'setConfig'
-        },
-        {
-            name: 'getState',
-            title: 'getState'
-        },
-        {
-            name: 'setState',
-            title: 'setState'
-        },
-        {
-            name: 'show',
-            title: 'show'
-        },
-        {
-            name: 'hide',
-            title: 'hide'
-        },
-        {
-            name: 'enable',
-            title: 'enable'
-        },
-        {
-            name: 'disable',
-            title: 'disable'
-        }
-    ];
+    pluginApi = [{
+        name: 'init',
+        title: 'init'
+    }, {
+        name: 'render',
+        title: 'render'
+    }, {
+        name: 'finish',
+        title: 'finish'
+    }, {
+        name: 'destroy',
+        title: 'destroy'
+    }, {
+        name: 'trigger',
+        title: 'trigger'
+    }, {
+        name: 'getTestRunner',
+        title: 'getTestRunner'
+    }, {
+        name: 'getAreaBroker',
+        title: 'getAreaBroker'
+    }, {
+        name: 'getConfig',
+        title: 'getConfig'
+    }, {
+        name: 'setConfig',
+        title: 'setConfig'
+    }, {
+        name: 'getState',
+        title: 'getState'
+    }, {
+        name: 'setState',
+        title: 'setState'
+    }, {
+        name: 'show',
+        title: 'show'
+    }, {
+        name: 'hide',
+        title: 'hide'
+    }, {
+        name: 'enable',
+        title: 'enable'
+    }, {
+        name: 'disable',
+        title: 'disable'
+    }];
 
     QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
         assert.expect(1);
@@ -125,221 +109,225 @@ define([
     QUnit.module('Behavior');
 
     // No dialog expected
-    QUnit.cases
-        .init([
-            {
-                title: 'when the next part warning is set',
-                testContext: {
-                    enableAllowSkipping: false,
-                    allowSkipping: false,
-                    options: {
-                        nextPartWarning: true,
-                        nextSectionWarning: false
-                    }
-                },
-                item: {
-                    informational: false
-                }
-            },
-            {
-                title: 'when the next section warning is set',
-                testContext: {
-                    isLinear: true,
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: true
-                    }
-                },
-                scope: 'section',
-                item: {
-                    informational: false
-                }
-            },
-            {
-                title: 'when the item is informational',
-                testContext: {
-                    isLinear: true,
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: false
-                    }
-                },
-                item: {
-                    informational: true
-                }
-            },
-            {
-                title: 'when the item is the last item',
-                testContext: {
-                    isLinear: true,
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: false
-                    },
-                    isLast: true
-                },
-                item: {
-                    informational: false
-                }
-            },
-            {
-                title: 'when the config setting is undefined',
-                testContext: {
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: false
-                    },
-                    isLinear: true
-                },
-                item: {
-                    informational: false
-                }
-            },
-            {
-                title: 'when the config setting is explicitly false',
-                testContext: {
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: false
-                    },
-                    isLinear: true
-                },
-                testConfig: {
-                    forceEnableLinearNextItemWarning: false
-                },
-                item: {
-                    informational: false
-                }
-            },
-            {
-                title: 'when the test is not linear',
-                testContext: {
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: false
-                    },
-                    isLinear: false
-                },
-                item: {
-                    informational: false
-                }
+    QUnit.cases.init([{
+        title: 'when the next part warning is set',
+        testContext: {
+            enableAllowSkipping: false,
+            allowSkipping: false,
+            options: {
+                nextPartWarning: true,
+                nextSectionWarning: false
             }
-        ])
-        .test('No dialog is triggered ', function(caseData, assert) {
-            var ready = assert.async();
-            var runner = runnerFactory(providerName, {}, {
-                options : caseData.testConfig
-            });
-            var plugin = pluginFactory(runner, runner.getAreaBroker());
-
-            // mock test store init
-            runner.getTestStore = function() {
-                return {
-                    setVolatile: function() {}
-                };
-            };
-            // mock the item we will get (informational or not)
-            mapHelper.getItemAt = function() {
-                return caseData.item;
-            };
-
-            assert.expect(1);
-
-            plugin
-                .init()
-                .then(function() {
-                    runner.setTestContext(caseData.testContext);
-
-                    // dialog would be instantiated *before* move occurs
-                    runner.on('move', function() {
-                        assert.ok(true, 'The move took place without interruption');
-                        runner.destroy();
-                        ready();
-                        return Promise.reject();
-                    });
-                    runner.trigger('move', 'next', caseData.scope);
-                })
-                .catch(function(err) {
-                    assert.ok(false, err.message);
-                    ready();
-                });
+        },
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: true
+        }
+    }, {
+        title: 'when the next section warning is set',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: true
+            }
+        },
+        scope: 'section',
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: true
+        }
+    }, {
+        title: 'when the item is informational',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: false
+            }
+        },
+        item: {
+            informational: true
+        },
+        part: {
+            isLinear: true
+        }
+    }, {
+        title: 'when the item is the last item',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: false
+            },
+            isLast: true
+        },
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: true
+        }
+    }, {
+        title: 'when the config setting is undefined',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: false
+            }
+        },
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: true
+        }
+    }, {
+        title: 'when the config setting is explicitly false',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: false
+            }
+        },
+        testConfig: {
+            forceEnableLinearNextItemWarning: false
+        },
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: true
+        }
+    }, {
+        title: 'when the test is not linear',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: false
+            }
+        },
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: false
+        }
+    }]).test('No dialog is triggered ', function(caseData, assert) {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName, {}, {
+            options: caseData.testConfig
         });
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        // mock test store init
+        runner.getTestStore = function() {
+            return {
+                setVolatile: function() {}
+            };
+        };
+        runner.getCurrentItem = () => caseData.item;
+        runner.getCurrentPart = () => caseData.part;
+
+        assert.expect(1);
+
+        plugin
+            .init()
+            .then(function() {
+                runner.setTestContext(caseData.testContext);
+
+                // dialog would be instantiated *before* move occurs
+                runner.on('move', function() {
+                    assert.ok(true, 'The move took place without interruption');
+                    runner.destroy();
+                    ready();
+                    return Promise.reject();
+                });
+                runner.trigger('move', 'next', caseData.scope);
+            })
+            .catch(function(err) {
+                assert.ok(false, err.message);
+                ready();
+            });
+    });
 
     // Dialog expected
-    QUnit.cases
-        .init([
-            {
-                title: 'when a next warning is needed',
-                event: 'next',
-                testContext: {
-                    isLinear: true,
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: false
-                    },
-                    isLast: false
-                },
-                testConfig: {
-                    forceEnableLinearNextItemWarning: true
-                },
-                item: {
-                    informational: false
-                }
+    QUnit.cases.init([{
+        title: 'when a next warning is needed',
+        event: 'next',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: false
             },
-            {
-                title: 'when a skip warning is needed',
-                event: 'skip',
-                testContext: {
-                    isLinear: true,
-                    options: {
-                        nextPartWarning: false,
-                        nextSectionWarning: false
-                    },
-                    isLast: false
-                },
-                testConfig: {
-                    forceEnableLinearNextItemWarning: true
-                },
-                item: {
-                    informational: false
-                }
-            }
-        ])
-        .test('Dialog will be triggered ', function(caseData, assert) {
-            var ready = assert.async();
+            isLast: false
+        },
+        testConfig: {
+            forceEnableLinearNextItemWarning: true
+        },
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: true
+        }
+    }, {
+        title: 'when a skip warning is needed',
+        event: 'skip',
+        testContext: {
+            options: {
+                nextPartWarning: false,
+                nextSectionWarning: false
+            },
+            isLast: false
+        },
+        testConfig: {
+            forceEnableLinearNextItemWarning: true
+        },
+        item: {
+            informational: false
+        },
+        part: {
+            isLinear: true
+        }
+    }]).test('Dialog will be triggered ', function(caseData, assert) {
+        const ready = assert.async();
 
-            var runner = runnerFactory(providerName, {}, {
-                options : caseData.testConfig
-            });
-            var plugin = pluginFactory(runner, runner.getAreaBroker());
+        const runner = runnerFactory(providerName, {}, {
+            options: caseData.testConfig
+        });
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-            // mock test store init
-            runner.getTestStore = function() {
-                return {
-                    getStore: function() {
-                        return Promise.reject();
-                    },
-                    setVolatile: function() {}
-                };
+        // mock test store init
+        runner.getTestStore = function() {
+            return {
+                getStore: function() {
+                    return Promise.reject();
+                },
+                setVolatile: function() {}
             };
+        };
+        runner.getCurrentItem = () => caseData.item;
+        runner.getCurrentPart = () => caseData.part;
 
-            assert.expect(1);
+        assert.expect(1);
 
-            plugin
-                .init()
-                .then(function() {
-                    runner.setTestContext(caseData.testContext);
+        plugin
+            .init()
+            .then(function() {
+                runner.setTestContext(caseData.testContext);
 
-                    runner.on('disablenav', function() {
-                        assert.ok(true, 'The dialog interrupted the move');
-                        runner.destroy();
-                        ready();
-                    });
-                    runner.trigger('move', caseData.event);
-                })
-                .catch(function(err) {
-                    assert.ok(false, err.message);
+                runner.on('disablenav', function() {
+                    assert.ok(true, 'The dialog interrupted the move');
+                    runner.destroy();
                     ready();
                 });
+                runner.trigger('move', caseData.event);
+            })
+            .catch(function(err) {
+                assert.ok(false, err.message);
+                ready();
+            });
         });
 });

--- a/test/plugins/navigation/review/navigator/data.json
+++ b/test/plugins/navigation/review/navigator/data.json
@@ -245,7 +245,6 @@
   "context": {
     "state": 1,
     "remainingAttempts": -1,
-    "isLinear": false,
     "attempt": 1,
     "isTimeout": false,
     "itemIdentifier": "item-1",

--- a/test/provider/qti/test.html
+++ b/test/provider/qti/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner - QTI Provider</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['taoQtiTest/test/runner/provider/qti/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/provider/qti/test.js
+++ b/test/provider/qti/test.js
@@ -1,0 +1,222 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'taoTests/runner/runner',
+    'taoQtiTest/runner/provider/qti',
+    'json!taoQtiTest/test/runner/provider/qti/testMap.json'
+], function(runnerFactory, qtiProvider, testMapData) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module', assert => {
+        assert.expect(1);
+
+        assert.equal(typeof qtiProvider, 'object', 'The module exports and object');
+    });
+
+    QUnit.cases.init([
+        { title: 'destroy' },
+        { title: 'finish' },
+        { title: 'flush' },
+        { title: 'getPersistentState' },
+        { title: 'init' },
+        { title: 'install' },
+        { title: 'loadAreaBroker' },
+        { title: 'loadItem' },
+        { title: 'loadPersistentStates' },
+        { title: 'loadProbeOverseer' },
+        { title: 'loadProxy' },
+        { title: 'loadTestStore' },
+        { title: 'render' },
+        { title: 'setPersistentState' },
+        { title: 'unloadItem' },
+    ]).test('The runner provider expose the method ', (data, assert) => {
+        assert.equal(typeof qtiProvider[data.title], 'function', 'The method is exposed');
+    });
+
+    QUnit.module('Installed behavior', {
+        beforeEach(){
+            runnerFactory.registerProvider(qtiProvider.name, Object.assign({}, qtiProvider, {
+                init(){},
+                render(){}
+            }));
+            this.runner = runnerFactory('qti', {
+                mockPlugin(){
+                    return {
+                        name : 'mock-plugin',
+                        getName(){
+                            return this.name;
+                        },
+                        init(){},
+                    };
+                }
+            });
+        },
+        afterEach(){
+            runnerFactory.clearProviders();
+        }
+    });
+
+    QUnit.test('getCurrentItem', function(assert) {
+
+        assert.expect(8);
+
+        const item1 = testMapData.parts.Introduction.sections['assessmentSection-1'].items['item-1'];
+        const item8 = testMapData.parts.QTIExamples.sections['assessmentSection-2'].items['item-8'];
+        const done = assert.async();
+
+        assert.equal(typeof this.runner.getCurrentItem, 'undefined', 'The method getCurrentItem is not installed');
+
+        this.runner.on('init', () => {
+
+            assert.equal(typeof this.runner.getCurrentItem, 'function', 'The method getCurrentItem is now installed');
+
+            assert.notOk(this.runner.getCurrentItem(), 'The testMap is not set so no item');
+
+            this.runner.setTestMap(testMapData);
+
+            assert.notOk(this.runner.getCurrentItem(), 'The testContext is not set so no item');
+
+            this.runner.setTestContext({});
+            assert.notOk(this.runner.getCurrentItem(), 'The context is wrong, so no current item');
+
+            this.runner.setTestContext({
+                itemIdentifier: 'item-12438',
+                itemPosition: 12437
+            });
+            assert.notOk(this.runner.getCurrentItem(), 'The context is wrong, so no current');
+
+            this.runner.setTestContext({
+                itemIdentifier: 'item-8',
+                itemPosition: 7
+            });
+            assert.deepEqual(this.runner.getCurrentItem(), item8, 'The current item is returned');
+
+            this.runner.setTestContext({
+                itemIdentifier: 'item-1',
+                itemPosition: 0
+            });
+            assert.deepEqual(this.runner.getCurrentItem(), item1, 'The current item is returned');
+
+            done();
+        })
+        .on('error', err => {
+            assert.ok(false, err.message);
+            done();
+        })
+        .init();
+    });
+
+    QUnit.test('getCurrentSection', function(assert) {
+
+        assert.expect(8);
+
+        const section1 = testMapData.parts.Introduction.sections['assessmentSection-1'];
+        const section2 = testMapData.parts.QTIExamples.sections['assessmentSection-2'];
+        const done = assert.async();
+
+        assert.equal(typeof this.runner.getCurrentSection, 'undefined', 'The method getCurrentSection is not installed');
+
+        this.runner.on('init', () => {
+
+            assert.equal(typeof this.runner.getCurrentSection, 'function', 'The method getCurrentSection is now installed');
+
+            assert.notOk(this.runner.getCurrentSection(), 'The testMap is not set so no section');
+
+            this.runner.setTestMap(testMapData);
+
+            assert.notOk(this.runner.getCurrentSection(), 'The testContext is not set so no section');
+
+            this.runner.setTestContext({});
+            assert.notOk(this.runner.getCurrentSection(), 'The context is wrong, so no current section');
+
+            this.runner.setTestContext({
+                sectionId: 'area-51'
+            });
+            assert.notOk(this.runner.getCurrentSection(), 'The context is wrong, so no current section');
+
+            this.runner.setTestContext({
+                sectionId: 'assessmentSection-1'
+            });
+            assert.deepEqual(this.runner.getCurrentSection(), section1, 'The current section is returned');
+
+            this.runner.setTestContext({
+                sectionId: 'assessmentSection-2'
+            });
+            assert.deepEqual(this.runner.getCurrentSection(), section2, 'The current section is returned');
+
+            done();
+        })
+        .on('error', err => {
+            assert.ok(false, err.message);
+            done();
+        })
+        .init();
+    });
+
+    QUnit.test('getCurrentPart', function(assert) {
+
+        assert.expect(8);
+
+        const part1 = testMapData.parts.Introduction;
+        const part2 = testMapData.parts.QTIExamples;
+        const done = assert.async();
+
+        assert.equal(typeof this.runner.getCurrentPart, 'undefined', 'The method getCurrentPart is not installed');
+
+        this.runner.on('init', () => {
+
+            assert.equal(typeof this.runner.getCurrentPart, 'function', 'The method getCurrentPart is now installed');
+
+            assert.notOk(this.runner.getCurrentPart(), 'The testMap is not set so no part');
+
+            this.runner.setTestMap(testMapData);
+
+            assert.notOk(this.runner.getCurrentPart(), 'The testContext is not set so no part');
+
+            this.runner.setTestContext({});
+            assert.notOk(this.runner.getCurrentPart(), 'The context is wrong, so no current part');
+
+            this.runner.setTestContext({
+                sectionId: 'part-66'
+            });
+            assert.notOk(this.runner.getCurrentPart(), 'The context is wrong, so no current part');
+
+            this.runner.setTestContext({
+                testPartId: 'Introduction'
+            });
+            assert.deepEqual(this.runner.getCurrentPart(), part1, 'The current section is returned');
+
+            this.runner.setTestContext({
+                testPartId: 'QTIExamples'
+            });
+            assert.deepEqual(this.runner.getCurrentPart(), part2, 'The current part is returned');
+
+            done();
+        })
+        .on('error', err => {
+            assert.ok(false, err.message);
+            done();
+        })
+        .init();
+    });
+});

--- a/test/provider/qti/testMap.json
+++ b/test/provider/qti/testMap.json
@@ -1,0 +1,237 @@
+ {
+   "scope": "test",
+   "title": "QTI Example Test",
+   "identifier": "Test-1",
+   "className": "assessmentTest",
+   "toolName": "tao",
+   "exclusivelyLinear": false,
+   "hasTimeLimits": true,
+   "parts": {
+     "Introduction": {
+       "id": "Introduction",
+       "label": "Introduction",
+       "position": 0,
+       "isLinear": false,
+       "sections": {
+         "assessmentSection-1": {
+           "id": "assessmentSection-1",
+           "label": "Section 1",
+           "isCatAdaptive": false,
+           "position": 0,
+           "items": {
+             "item-1": {
+               "id": "item-1",
+               "label": "Example_0_Introduction",
+               "position": 0,
+               "occurrence": 0,
+               "remainingAttempts": 0,
+               "answered": false,
+               "flagged": false,
+               "viewed": true,
+               "categories": [],
+               "informational": true
+             }
+           },
+           "stats": {
+             "questions": 0,
+             "answered": 0,
+             "flagged": 0,
+             "viewed": 1,
+             "total": 1,
+             "questionsViewed": 0
+           }
+         }
+       },
+       "stats": {
+         "questions": 0,
+         "answered": 0,
+         "flagged": 0,
+         "viewed": 1,
+         "total": 1,
+         "questionsViewed": 0
+       }
+     },
+     "QTIExamples": {
+       "id": "QTIExamples",
+       "label": "QTIExamples",
+       "position": 1,
+       "isLinear": true,
+       "sections": {
+         "assessmentSection-2": {
+           "id": "assessmentSection-2",
+           "label": "Section 1",
+           "isCatAdaptive": false,
+           "position": 1,
+           "items": {
+             "item-2": {
+               "id": "item-2",
+               "label": "example_1_TAO",
+               "position": 1,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             },
+             "item-3": {
+               "id": "item-3",
+               "label": "example_2_Math",
+               "position": 2,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             },
+             "item-4": {
+               "id": "item-4",
+               "label": "Example_3_Baudelaire",
+               "position": 3,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             },
+             "item-5": {
+               "id": "item-5",
+               "label": "Example_4_Appearance",
+               "position": 4,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             },
+             "item-6": {
+               "id": "item-6",
+               "label": "Example_5_picasso",
+               "position": 5,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             },
+             "item-7": {
+               "id": "item-7",
+               "label": "Example_6_Geography",
+               "position": 6,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             },
+             "item-8": {
+               "id": "item-8",
+               "label": "Example_7_Geo 2",
+               "position": 7,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             },
+             "item-9": {
+               "id": "item-9",
+               "label": "Example_8_Geo 3",
+               "position": 8,
+               "occurrence": 0,
+               "remainingAttempts": 1,
+               "answered": false,
+               "flagged": false,
+               "viewed": false,
+               "categories": [],
+               "informational": false
+             }
+           },
+           "stats": {
+             "questions": 8,
+             "answered": 0,
+             "flagged": 0,
+             "viewed": 0,
+             "total": 8,
+             "questionsViewed": 0
+           }
+         }
+       },
+       "stats": {
+         "questions": 8,
+         "answered": 0,
+         "flagged": 0,
+         "viewed": 0,
+         "total": 8,
+         "questionsViewed": 0
+       }
+     }
+   },
+   "stats": {
+     "questions": 8,
+     "answered": 0,
+     "flagged": 0,
+     "viewed": 1,
+     "total": 9,
+     "questionsViewed": 0
+   },
+   "jumps" : [{
+       "identifier": "item-1",
+        "section": "assessmentSection-1",
+        "part": "Introduction",
+        "position": 0
+    }, {
+       "identifier": "item-2",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 1
+    }, {
+       "identifier": "item-3",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 2
+    }, {
+       "identifier": "item-4",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 3
+    }, {
+       "identifier": "item-5",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 4
+    }, {
+       "identifier": "item-6",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 5
+    }, {
+       "identifier": "item-7",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 6
+    }, {
+       "identifier": "item-8",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 7
+    }, {
+       "identifier": "item-9",
+        "section": "assessmentSection-2",
+        "part": "QTIExamples",
+        "position": 8
+    }]
+}


### PR DESCRIPTION
The property `isLinear` should be read from the `testMap` and not the `testContext`.
This Pr : 
 - introduces 3 conveniences methods on the Qti runner provider : `getCurrentItem`, `getCurrentSection` and `getCurrentMap` in order to ease retrieving the values from the current position in a test
- replaces all occurences of reading `isLinear` from the `testContext`

How to test this PR : 
 - `npm run test`
 - Try some tests within TAO (the navigation, the review panel, and the linear warning messages)