### PR TITLE
Fix/nex 240 iscatadaptive from testmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/previous.js
+++ b/src/plugins/navigation/previous.js
@@ -54,6 +54,7 @@ export default pluginFactory({
         var canDoPrevious = function canDoPrevious() {
             const testMap = testRunner.getTestMap();
             const context = testRunner.getTestContext();
+            const currentSection = testRunner.getCurrentSection();
             const noExitTimedSectionWarning = mapHelper.hasItemCategory(
                 testMap,
                 context.itemIdentifier,
@@ -78,7 +79,7 @@ export default pluginFactory({
             if (navigationHelper.isFirstOf(testMap, context.itemIdentifier, 'section')) {
                 //when entering an adaptive section,
                 //you can't leave the section from the beginning
-                if (context.isCatAdaptive) {
+                if (currentSection.isCatAdaptive) {
                     return false;
                 }
 

--- a/test/navigator/offlineNavigator/resources/testContext.json
+++ b/test/navigator/offlineNavigator/resources/testContext.json
@@ -5,7 +5,6 @@
   "itemIdentifier": "Q01",
   "attempt": 1,
   "itemSessionState": 1,
-  "isCatAdaptive": false,
   "needMapUpdate": false,
   "isLast": false,
   "itemPosition": 0,


### PR DESCRIPTION
The property `isCatAdaptive` should be read from the `testMap` and not the `testContext`.
This PR: replaces all occurrences of `isCatAdaptive` from the `testContext`

How to test this PR : 
 - `npm run test`
 - Try to navigate back and forward in a test (there's no way from our side to setup a CAT engine)