### PR TITLE
fix wrong logger levels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/timer/timers.js
+++ b/src/plugins/controls/timer/timers.js
@@ -168,9 +168,9 @@ export default function getTimers(timeConstraints, isLinear, config) {
         constraintData.scope = getScope(timeConstraint.scope || timeConstraint.qtiClassName);
 
         if (!constraintData.scope) {
-            logger.warning('Wrong data, a time constraint should apply to a valid scope, skipping');
+            logger.warn('Wrong data, a time constraint should apply to a valid scope, skipping');
         } else if (constraintData.minTime === false && constraintData.maxTime === false) {
-            logger.warning('Time constraint defined with no time, skipping');
+            logger.warn('Time constraint defined with no time, skipping');
 
             // minTime = maxTime -> one locked timer
         } else if (


### PR DESCRIPTION
wrong log levels were used in the timer plugin. 

How to test : 
 - the server should not send a scope in the time constraint (needs some hacks)