### PR TITLE
Fix/nex 240 itemanswered from testmap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/stats.js
+++ b/src/helpers/stats.js
@@ -42,11 +42,11 @@ export default {
 
         if (!item.informational) {
             const isItemCurrentlyAnswered = currentItemHelper.isAnswered(runner);
-            if (!isItemCurrentlyAnswered && context.itemAnswered) {
+            if (!isItemCurrentlyAnswered && item.answered) {
                 stats.answered--;
-            } else if ((isItemCurrentlyAnswered || sync) && !context.itemAnswered) {
+            } else if ((isItemCurrentlyAnswered || sync) && !item.answered) {
                 stats.answered++;
-            } else if (sync && !isItemCurrentlyAnswered && context.itemAnswered && testPart.isLinear) {
+            } else if (sync && !isItemCurrentlyAnswered && item.answered && testPart.isLinear) {
                 stats.answered++;
             }
         }

--- a/src/helpers/testContextBuilder.js
+++ b/src/helpers/testContextBuilder.js
@@ -94,12 +94,10 @@ function getTestContext(testContext, testMap, item, section, part, position) {
             {
                 itemIdentifier: item.id,
                 itemPosition: position,
-                itemAnswered: item.answered || part.isLinear,
                 remainingAttempts: Math.max(-1, item.remainingAttempts - 1),
                 sectionId: section.id,
                 sectionTitle: section.label,
                 testPartId: part.id,
-                isLinear: part.isLinear,
                 canMoveBackward: !part.isLinear && !navigationHelper.isFirst(testMap, item.id)
             },
             testContext

--- a/src/plugins/controls/progressbar/progress.js
+++ b/src/plugins/controls/progressbar/progress.js
@@ -217,12 +217,14 @@ var indicators = {
  * @returns {Object} The fixed test map
  */
 function getFixedMap(testMap, testContext) {
-    var item;
-    const testPart = mapHelper.getPart(testMap, testContext.testPartId);
-    if (testContext.itemAnswered && testPart && testPart.isLinear) {
-        testMap = _.cloneDeep(testMap);
-        item = mapHelper.getItemAt(testMap, testContext.itemPosition);
-        item.answered = false;
+    const currentTestPart = mapHelper.getPart(testMap, testContext.testPartId);
+    const currentItem = mapHelper.getItemAt(testMap, testContext.itemPosition);
+
+    if (currentItem.answered && currentTestPart.isLinear) {
+        const fixedTestMap = _.cloneDeep(testMap);
+        const fixedCurrentItem = mapHelper.getItemAt(fixedTestMap, testContext.itemPosition);
+        fixedCurrentItem.answered = false;
+        return fixedTestMap;
     }
     return testMap;
 }

--- a/src/provider/dataUpdater.js
+++ b/src/provider/dataUpdater.js
@@ -140,11 +140,6 @@ export default function dataUpdaterFactory(testDataHolder) {
                     //flag as viewed, always
                     item.viewed = true;
 
-                    //flag as answered only if a response has been set
-                    if (!_.isUndefined(testContext.itemAnswered)) {
-                        item.answered = testContext.itemAnswered;
-                    }
-
                     updatedTestMap = mapHelper.updateItemStats(testMap, testContext.itemPosition);
                 }
             }

--- a/src/provider/dataUpdater.js
+++ b/src/provider/dataUpdater.js
@@ -128,17 +128,21 @@ export default function dataUpdaterFactory(testDataHolder) {
          * @returns {Object} the updated testMap
          */
         updateStats: function updateStats() {
-            var testMap = testDataHolder.get('testMap');
-            var testContext = testDataHolder.get('testContext');
-            var updatedTestMap = null;
-            var item;
+            const testMap = testDataHolder.get('testMap');
+            const testContext = testDataHolder.get('testContext');
+            let updatedTestMap = null;
 
             if (testMap && testContext && _.isNumber(testContext.itemPosition)) {
-                item = mapHelper.getItemAt(testMap, testContext.itemPosition);
+                const item = mapHelper.getItemAt(testMap, testContext.itemPosition);
 
                 if (item && testContext.state === states.testSession.interacting) {
+                    const testPart = mapHelper.getPart(testMap, testContext.testPartId);
+
                     //flag as viewed, always
                     item.viewed = true;
+                    if (testPart && testPart.isLinear) {
+                        item.answered = true;
+                    }
 
                     updatedTestMap = mapHelper.updateItemStats(testMap, testContext.itemPosition);
                 }

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -247,9 +247,6 @@ var qtiProvider = {
             const context = self.getTestContext();
             const currentItem = self.getCurrentItem();
 
-
-            console.log('original testmap', self.getTestMap());
-
             //catch server errors
             var submitError = function submitError(err) {
                 //some server errors are valid, so we don't fail (prevent empty responses)
@@ -301,9 +298,7 @@ var qtiProvider = {
                         // when the test part is linear, the item is always answered as we cannot come back to it
                         const testPart = self.getCurrentPart();
                         const isLinear = testPart && testPart.isLinear;
-                        console.log('before', currentItem.position,  currentItem.answered);
                         currentItem.answered = isLinear || currentItemHelper.isAnswered(self);
-                        console.log('after', currentItem.position,  currentItem.answered);
                     }
                     resolve();
                 }
@@ -321,8 +316,6 @@ var qtiProvider = {
                     // ensure the answered state of the current item is correctly set and the stats are aligned
                     self.setTestMap(self.dataUpdater.updateStats());
 
-
-                    console.log('built testmap', self.getTestMap());
                     //to be sure load start after unload...
                     //we add an intermediate ns event on unload
                     self.on(`unloaditem.${action}`, function() {

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -247,6 +247,9 @@ var qtiProvider = {
             const context = self.getTestContext();
             const currentItem = self.getCurrentItem();
 
+
+            console.log('original testmap', self.getTestMap());
+
             //catch server errors
             var submitError = function submitError(err) {
                 //some server errors are valid, so we don't fail (prevent empty responses)
@@ -277,7 +280,7 @@ var qtiProvider = {
                         )
                         .then( results => {
                             if (results.itemSession) {
-                                context.itemAnswered = results.itemSession.itemAnswered;
+                                currentItem.answered = results.itemSession.itemAnswered;
 
                                 if (results.displayFeedbacks === true && results.feedbacks) {
                                     self.itemRunner.renderFeedbacks(results.feedbacks, results.itemSession, function(
@@ -293,14 +296,15 @@ var qtiProvider = {
                         .catch(submitError);
                 } else {
                     if (action === 'skip') {
-                        context.itemAnswered = false;
+                        currentItem.answered = false;
                     } else {
                         // when the test part is linear, the item is always answered as we cannot come back to it
                         const testPart = self.getCurrentPart();
                         const isLinear = testPart && testPart.isLinear;
-                        context.itemAnswered = isLinear || currentItemHelper.isAnswered(self);
+                        console.log('before', currentItem.position,  currentItem.answered);
+                        currentItem.answered = isLinear || currentItemHelper.isAnswered(self);
+                        console.log('after', currentItem.position,  currentItem.answered);
                     }
-                    self.setTestContext(context);
                     resolve();
                 }
             });
@@ -316,6 +320,9 @@ var qtiProvider = {
 
                     // ensure the answered state of the current item is correctly set and the stats are aligned
                     self.setTestMap(self.dataUpdater.updateStats());
+
+
+                    console.log('built testmap', self.getTestMap());
                     //to be sure load start after unload...
                     //we add an intermediate ns event on unload
                     self.on(`unloaditem.${action}`, function() {

--- a/test/dataUpdater/testContext.json
+++ b/test/dataUpdater/testContext.json
@@ -7,7 +7,6 @@
   "itemSessionState": 1,
   "needMapUpdate": false,
   "itemPosition": 0,
-  "itemAnswered": false,
   "timeConstraints": [],
   "extraTime": {
     "total": 0,

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -182,7 +182,6 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
         .test('helpers/messages.getExitMessage (enabled)', function(testData, assert) {
             var context = {
                 itemPosition: 1,
-                itemAnswered: testData.currentItemAnswered,
                 sectionId: 'section1',
                 testPartId: 'part1',
                 itemIdentifier: 'item1'
@@ -201,7 +200,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                         sections: {
                             section1: {
                                 items: {
-                                    item1: {},
+                                    item1: {
+                                        answered : testData.currentItemAnswered
+                                    },
                                     item2: {},
                                     item3: {}
                                 },

--- a/test/navigator/navigator/test.js
+++ b/test/navigator/navigator/test.js
@@ -186,7 +186,7 @@ define([
     QUnit.test('is moving to the next item over a testPart', function(assert) {
         var updatedContext;
 
-        assert.expect(5);
+        assert.expect(4);
 
         updatedContext = testNavigator(testContexts.context3, testMap).nextItem();
 
@@ -202,7 +202,6 @@ define([
             'The updated context contains the correct section id'
         );
         assert.equal(updatedContext.testPartId, 'testPart-2', 'The updated context contains the correct test part id');
-        assert.equal(updatedContext.itemAnswered, true, 'The item has been answered since the test part is linear');
     });
 
     QUnit.test('is moving to the next item over timed sections', function(assert) {
@@ -254,7 +253,7 @@ define([
     QUnit.test('is moving to the previous item inside a section', function(assert) {
         var updatedContext;
 
-        assert.expect(5);
+        assert.expect(4);
 
         updatedContext = testNavigator(testContexts.context2, testMap).previousItem();
 
@@ -264,7 +263,6 @@ define([
             'The updated context contains the correct item identifier'
         );
         assert.equal(updatedContext.itemPosition, 1, 'The updated context contains the correct item position');
-        assert.equal(updatedContext.itemAnswered, true, 'The item has already been answered');
         assert.equal(
             updatedContext.sectionId,
             'assessmentSection-1',

--- a/test/navigator/navigator/testContexts.json
+++ b/test/navigator/navigator/testContexts.json
@@ -8,7 +8,6 @@
     "itemSessionState": 1,
     "needMapUpdate": false,
     "itemPosition": 0,
-    "itemAnswered": false,
     "timeConstraints": [],
     "extraTime": {
       "total": 0,
@@ -39,7 +38,6 @@
     "itemSessionState": 1,
     "needMapUpdate": false,
     "itemPosition": 2,
-    "itemAnswered": false,
     "timeConstraints": [],
     "extraTime": {
       "total": 0,
@@ -70,7 +68,6 @@
     "itemSessionState": 1,
     "needMapUpdate": false,
     "itemPosition": 13,
-    "itemAnswered": false,
     "timeConstraints": [],
     "extraTime": {
       "total": 0,
@@ -102,7 +99,6 @@
     "itemSessionState": 1,
     "needMapUpdate": false,
     "itemPosition": 5,
-    "itemAnswered": false,
     "timeConstraints": [{
       "label": "Item 3",
       "source": "item-6",
@@ -147,7 +143,6 @@
     "itemSessionState": 1,
     "needMapUpdate": false,
     "itemPosition": 16,
-    "itemAnswered": false,
     "timeConstraints": [],
     "extraTime": {
       "total": 0,

--- a/test/navigator/offlineNavigator/resources/testContext.json
+++ b/test/navigator/offlineNavigator/resources/testContext.json
@@ -7,7 +7,6 @@
   "itemSessionState": 1,
   "needMapUpdate": false,
   "itemPosition": 0,
-  "itemAnswered": true,
   "timeConstraints": [],
   "testPartId": "P01",
   "sectionId": "S01",

--- a/test/plugins/controls/progressbar/progress/test.js
+++ b/test/plugins/controls/progressbar/progress/test.js
@@ -59,8 +59,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 9,
@@ -111,8 +110,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 5,
@@ -163,8 +161,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 2,
@@ -219,8 +216,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 9,
@@ -279,8 +275,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 5,
@@ -339,8 +334,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 2,
@@ -402,8 +396,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 9,
@@ -462,8 +455,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 5,
@@ -522,8 +514,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 2,
@@ -585,8 +576,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 9,
@@ -645,8 +635,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 5,
@@ -705,8 +694,7 @@ define([
             testContext: {
                 itemPosition: 3,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-1',
-                itemAnswered: true
+                sectionId: 'assessmentSection-1'
             },
             expected: {
                 questions: 2,
@@ -767,8 +755,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 9,
@@ -819,8 +806,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 5,
@@ -871,8 +857,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 3,
@@ -927,8 +912,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 9,
@@ -987,8 +971,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 5,
@@ -1047,8 +1030,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 3,
@@ -1110,8 +1092,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 9,
@@ -1170,8 +1151,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 5,
@@ -1230,8 +1210,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 3,
@@ -1293,8 +1272,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 9,
@@ -1353,8 +1331,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 5,
@@ -1413,8 +1390,7 @@ define([
             testContext: {
                 itemPosition: 5,
                 testPartId: 'testPart-1',
-                sectionId: 'assessmentSection-2',
-                itemAnswered: true
+                sectionId: 'assessmentSection-2'
             },
             expected: {
                 questions: 3,
@@ -1753,8 +1729,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 3,
@@ -1774,8 +1749,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 6,
@@ -1795,8 +1769,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 3,
@@ -1816,8 +1789,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 2,
@@ -1838,8 +1810,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 3,
@@ -1859,8 +1830,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 3,
@@ -1880,8 +1850,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 4,
@@ -1901,8 +1870,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 3,
@@ -1922,8 +1890,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 2,
@@ -1944,8 +1911,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 3,
@@ -1965,8 +1931,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 1,
@@ -1986,8 +1951,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 1,
@@ -2007,8 +1971,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 1,
@@ -2028,8 +1991,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 1,
@@ -2050,8 +2012,7 @@ define([
             testPartId: 'testPart-1',
             sectionId: 'assessmentSection-2',
             numberCompleted: 6,
-            numberItems: 12,
-            itemAnswered: true
+            numberItems: 12
         },
         expected: {
             position: 1,

--- a/test/plugins/navigation/review/navigator/data.json
+++ b/test/plugins/navigation/review/navigator/data.json
@@ -251,7 +251,6 @@
     "itemSessionState": 1,
     "needMapUpdate": false,
     "itemPosition": 0,
-    "itemAnswered": false,
     "timeConstraints": [{
       "label": "Section 1",
       "source": "assessmentSection-1",


### PR DESCRIPTION
Uses the `answered` value from the `testMap` instead of `itemAnswered` from the `testContext`.

How to test : 
 - `npm test`
 - Check regressions on tests (linear and non linear) with the review panel enabled