### PR TITLE
Fix/nex 240 deprecate qti item info in context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.9.4",
+    "version": "0.9.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/allowSkipping.js
+++ b/src/plugins/navigation/allowSkipping.js
@@ -83,10 +83,10 @@ export default pluginFactory({
 
                 if (!allowSkipping) {
                     return new Promise((resolve, reject) => {
-                        if (_.size(currentItemHelper.getDeclarations(self)) === 0) {
+                        if (_.size(currentItemHelper.getDeclarations(testRunner)) === 0) {
                             return resolve();
                         }
-                        if (currentItemHelper.isAnswered(self, pluginConfig.allowPartial)) {
+                        if (currentItemHelper.isAnswered(testRunner, pluginConfig.allowPartial)) {
                             return resolve();
                         }
 

--- a/src/plugins/navigation/validateResponses.js
+++ b/src/plugins/navigation/validateResponses.js
@@ -88,10 +88,11 @@ export default pluginFactory({
                             testRunner.trigger('alert.notallowed', __('A valid response to this item is required.'), () => {
                                 testRunner.trigger('resumeitem');
                                 reject();
-                                setestRunner.setState('alerted.notallowed', false);
+                                testRunner.setState('alerted.notallowed', false);
                             });
                         }
                     });
+                }
             }
         });
 

--- a/src/plugins/navigation/validateResponses.js
+++ b/src/plugins/navigation/validateResponses.js
@@ -66,7 +66,7 @@ export default pluginFactory({
                 return Promise.resolve();
             }
 
-            if (isInteracting && testRunnerOptions.enableValidateResponses && testContext.validateResponses) {
+            if (isInteracting && testRunnerOptions.enableValidateResponses) {
 
                 const currenItem = testRunner.getCurrentItem();
                 //@deprecated use validateResponses from testMap instead of the testContext
@@ -76,10 +76,10 @@ export default pluginFactory({
 
                 if (validateResponses) {
                     return new Promise((resolve, reject) => {
-                        if (_.size(currentItemHelper.getDeclarations(self)) === 0) {
+                        if (_.size(currentItemHelper.getDeclarations(testRunner)) === 0) {
                             return resolve();
                         }
-                        if (currentItemHelper.isAnswered(self, false)) {
+                        if (currentItemHelper.isAnswered(testRunner, false)) {
                             return resolve();
                         }
                         if (!testRunner.getState('alerted.notallowed')) {

--- a/src/plugins/tools/comment/comment.js
+++ b/src/plugins/tools/comment/comment.js
@@ -39,7 +39,7 @@ export default pluginFactory({
     /**
      * Initialize the plugin (called during runner's init)
      */
-    init: function init() {
+    init() {
         const self = this;
 
         const testRunner = this.getTestRunner();
@@ -52,6 +52,13 @@ export default pluginFactory({
          * @returns {Boolean}
          */
         function isEnabled() {
+
+            const currentItem = testRunner.getCurrentItem();
+            if (typeof currentItem.allowComment === 'boolean') {
+                return currentItem.allowComment;
+            }
+
+            //@deprecated use allowComment from the testMap
             const testContext = testRunner.getTestContext();
             const contextOptions = testContext.options || {};
             return !!contextOptions.allowComment;

--- a/test/plugins/navigation/allowSkipping/test.js
+++ b/test/plugins/navigation/allowSkipping/test.js
@@ -135,20 +135,24 @@ define([
             {
                 title: 'when the option is not enabled',
                 context: {
-                    itemIdentifier: 'item-1',
-                    enableAllowSkipping: false,
-                    allowSkipping: false
+                    itemIdentifier: 'item-1'
                 },
+                options : {
+                    enableAllowSkipping: false
+                },
+                allowSkipping: false,
                 answered: false,
                 responses: ['foo']
             },
             {
                 title: 'when the item has no interactions',
                 context: {
-                    itemIdentifier: 'item-1',
-                    enableAllowSkipping: true,
-                    allowSkipping: false
+                    itemIdentifier: 'item-1'
                 },
+                options : {
+                    enableAllowSkipping: true
+                },
+                allowSkipping: false,
                 answered: false,
                 responses: []
             },
@@ -156,9 +160,12 @@ define([
                 title: 'when the item is allowed to be skipped',
                 context: {
                     itemIdentifier: 'item-1',
-                    enableAllowSkipping: true,
                     allowSkipping: true
                 },
+                options : {
+                    enableAllowSkipping: true
+                },
+                allowSkipping: true,
                 answered: false,
                 responses: ['foo']
             },
@@ -166,17 +173,23 @@ define([
                 title: 'when the item is answered',
                 context: {
                     itemIdentifier: 'item-1',
-                    enableAllowSkipping: true,
-                    allowSkipping: false
                 },
+                options : {
+                    enableAllowSkipping: true
+                },
+                allowSkipping: false,
                 answered: true,
                 responses: ['foo']
             }
         ])
         .test('Moving is allowed ', function(data, assert) {
-            var ready = assert.async();
-            var runner = runnerFactory(providerName);
-            var plugin = pluginFactory(runner, runner.getAreaBroker());
+            const ready = assert.async();
+            const runner = runnerFactory(providerName, {
+                options : data.options
+            });
+            const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+            runner.getCurrentItem = () => ({ allowSkipping : data.allowSkipping });
 
             assert.expect(1);
 
@@ -206,11 +219,11 @@ define([
                 title: 'when the item not answered',
                 context: {
                     itemIdentifier: 'item-1',
-                    allowSkipping: false
                 },
                 options : {
                     enableAllowSkipping: true
                 },
+                allowSkipping: false,
                 answered: false,
                 responses: ['foo']
             }
@@ -222,6 +235,11 @@ define([
                 options: data.options
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+            runner.getCurrentItem = () => ({
+                allowSkipping : data.allowSkipping,
+                answered : data.answered
+            });
 
             assert.expect(2);
 

--- a/test/plugins/navigation/validateResponses/test.js
+++ b/test/plugins/navigation/validateResponses/test.js
@@ -91,48 +91,48 @@ define([
             {
                 title: 'when the option is not enabled',
                 context: {
-                    itemIdentifier: 'item-1',
-                    validateResponses: true
+                    itemIdentifier: 'item-1'
                 },
                 options : {
                     enableValidateResponses: false,
                 },
+                validateResponses: true,
                 answered: false,
                 responses: ['foo']
             },
             {
                 title: 'when the item has no interactions',
                 context: {
-                    itemIdentifier: 'item-1',
-                    validateResponses: true
+                    itemIdentifier: 'item-1'
                 },
                 options : {
                     enableValidateResponses: true
                 },
+                validateResponses: true,
                 answered: false,
                 responses: []
             },
             {
                 title: 'when the item is configured without the validation',
                 context: {
-                    itemIdentifier: 'item-1',
-                    validateResponses: false
+                    itemIdentifier: 'item-1'
                 },
                 options : {
                     enableValidateResponses: true
                 },
                 answered: false,
+                validateResponses: false,
                 responses: ['foo']
             },
             {
                 title: 'when the item is answered',
                 context: {
-                    itemIdentifier: 'item-1',
-                    validateResponses: true
+                    itemIdentifier: 'item-1'
                 },
                 options : {
                     enableValidateResponses: true
                 },
+                validateResponses: true,
                 answered: true,
                 responses: ['foo']
             }
@@ -143,6 +143,8 @@ define([
                 options: data.options
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+            runner.getCurrentItem = () => ({ validateResponses : data.validateResponses });
 
             assert.expect(1);
 
@@ -170,12 +172,12 @@ define([
             {
                 title: 'when the item not answered',
                 context: {
-                    itemIdentifier: 'item-1',
-                    validateResponses: true
+                    itemIdentifier: 'item-1'
                 },
                 options : {
                     enableValidateResponses: true
                 },
+                validateResponses: true,
                 answered: false,
                 responses: ['foo']
             }
@@ -187,6 +189,11 @@ define([
                 options : data.options
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+            runner.getCurrentItem = () => ({
+                validateResponses : data.validateResponses,
+                answered : data.answered
+            });
 
             assert.expect(2);
 
@@ -226,8 +233,7 @@ define([
             {
                 title: 'when the item not answered, but the `validateOnPreviousMove` flag is set to `false`',
                 context: {
-                    itemIdentifier: 'item-1',
-                    validateResponses: true
+                    itemIdentifier: 'item-1'
                 },
                 options :  {
                     enableValidateResponses: true,
@@ -235,6 +241,7 @@ define([
                 pluginConfig : {
                     validateOnPreviousMove: false
                 },
+                validateResponses: true,
                 answered: false,
                 responses: ['foo']
             }
@@ -245,6 +252,8 @@ define([
                 options: data.options
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker(), data.pluginConfig);
+
+            runner.getCurrentItem = () => ({ validateResponses : data.validateResponses });
 
             assert.expect(1);
 


### PR DESCRIPTION
 - deprecate the usage `allowComment`, `allowSkipping` and `validateResponse` from the testContext. Take them from the `testMap`'s current item instead.

How to test : 
 - `npm run test`
 - Try a regressions on a test with the configured properties `allowComment`, `allowSkipping` and `validateResponse` on some items