### PR TITLE
Default item navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.9.5",
+    "version": "0.10.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8933

Added item content navigator

How to test:
With **tab** button you will stop on the content of the item and you can scroll content with **up** and **down** buttons

to test it you can change package.json of the taoQtiTest extension:
```
    "@oat-sa/tao-test-runner-qti": "oat-sa/tao-test-runner-qti-fe#feature/TAO-8933/item-key-navigation"
```