### PR TITLE
Release 0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/currentItem.js
+++ b/src/helpers/currentItem.js
@@ -99,7 +99,7 @@ var currentItemHelper = {
         let transform = v => v;
         if (baseType === 'boolean') {
             transform = v => v === true || v === 'true';
-        } else if (baseType === 'directedPair') {
+        } else if (baseType === 'directedPair' || baseType === 'pair') {
             transform = v => {
                 if (_.isString(v)) {
                     return v.split(' ');

--- a/test/helpers/currentItem/test.js
+++ b/test/helpers/currentItem/test.js
@@ -149,7 +149,7 @@ define(['lodash', 'taoQtiTest/runner/helpers/currentItem'], function(_, currentI
     });
 
     QUnit.test('helpers/currentItem.toResponse', function(assert) {
-        assert.expect(8);
+        assert.expect(9);
 
         assert.deepEqual(
             currentItemHelper.toResponse(null, 'string', 'single'),
@@ -179,6 +179,11 @@ define(['lodash', 'taoQtiTest/runner/helpers/currentItem'], function(_, currentI
         assert.deepEqual(
             currentItemHelper.toResponse(['choice_2 choice_3', 'choice_2 choice_4'], 'directedPair', 'multiple'),
             { list: { directedPair: [['choice_2', 'choice_3'], ['choice_2', 'choice_4']] } },
+            'The helper has built the right response'
+        );
+        assert.deepEqual(
+            currentItemHelper.toResponse(['choice_2 choice_3', 'choice_2 choice_4'], 'pair', 'multiple'),
+            { list: { pair: [['choice_2', 'choice_3'], ['choice_2', 'choice_4']] } },
             'The helper has built the right response'
         );
         assert.deepEqual(


### PR DESCRIPTION
Release 0.10.2

**Release notes :**
- [fix] [TAO-9038](https://oat-sa.atlassian.net/browse/TAO-9038) Correct response for a directed pair interaction [#47](https://github.com/oat-sa/tao-test-runner-qti-fe/pull/47)