### PR TITLE
Fixed keyNavigation in the testRunner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation.js
@@ -455,7 +455,9 @@ function initInteractionNavigation($interaction, testRunner) {
  */
 function showElementsContent($el, $visibleContainer) {
     const $wrapper = $visibleContainer.closest('.content-wrapper');
-    $wrapper.scrollTop($el.offset().top + $wrapper.scrollTop() - $wrapper.offset().top);
+    if ($wrapper.length && $el.length) {
+        $wrapper.scrollTop($el.offset().top + $wrapper.scrollTop() - $wrapper.offset().top);
+    }
 }
 
 /**
@@ -500,26 +502,15 @@ function initDefaultItemNavigation(testRunner) {
     const $container = $(testRunner.getAreaBroker().getContainer());
     const $wrapper = $container.find('.content-wrapper');
     let keyNavigatorItem;
-    const $group = $wrapper.closest('.test-runner-sections');
     const navigables = navigableDomElement.createFromDoms($wrapper);
 
     $wrapper.addClass('key-navigation-scrollable');
     if (navigables.length) {
         keyNavigatorItem = keyNavigator({
-            id: 'item-content-wrapper',
-            group: $group,
+            id: 'item-content-wrapper_'.testRunner.getCurrentItem().id,
+            group: $wrapper,
             elements: navigables,
             propagateTab: false, // inner item navigators will send tab to this element
-        });
-
-        keyNavigatorItem.on('tab', function (elem) {
-            if ($(elem).closest('.key-navigation-group').get(0) === $group.get(0) && allowedToNavigateFrom(elem)) {
-                runTestRunnerNextTab();
-            }
-        }).on('shift+tab', function (elem) {
-            if ($(elem).closest('.key-navigation-group').get(0) === $group.get(0) && allowedToNavigateFrom(elem)) {
-                runTestRunnerPrevTab();
-            }
         });
 
         itemNavigators.push(
@@ -528,14 +519,6 @@ function initDefaultItemNavigation(testRunner) {
     }
 
     return itemNavigators;
-}
-
-function runTestRunnerNextTab() {
-    testRunnerNavigatorItem.trigger('tab');
-}
-
-function runTestRunnerPrevTab() {
-    testRunnerNavigatorItem.trigger('shift+tab');
 }
 
 /**
@@ -582,7 +565,10 @@ function initTestRunnerNavigation(testRunner, config) {
         id: 'test-runner',
         replace: true,
         loop: true,
-        elements: navigators
+        elements: navigators,
+        // we don't need to propagate tabs for the main navigation, because we've rewritten them and this is not an element
+        // there is an issue with nested navigators
+        propagateTab: false,
     });
 
     keyNavigatorItem

--- a/src/plugins/content/accessibility/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation.js
@@ -512,6 +512,7 @@ function initDefaultItemNavigation(testRunner) {
             group: $wrapper,
             elements: navigables,
             propagateTab: false, // inner item navigators will send tab to this element
+            replace: true,
         });
 
         itemNavigators.push(

--- a/src/plugins/content/accessibility/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation.js
@@ -506,8 +506,9 @@ function initDefaultItemNavigation(testRunner) {
 
     $wrapper.addClass('key-navigation-scrollable');
     if (navigables.length) {
+        const itemId = testRunner.getCurrentItem().id;
         keyNavigatorItem = keyNavigator({
-            id: 'item-content-wrapper_'.testRunner.getCurrentItem().id,
+            id: `item-content-wrapper_${itemId}`,
             group: $wrapper,
             elements: navigables,
             propagateTab: false, // inner item navigators will send tab to this element


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/TAO-8933
 
After the previous changes were broken some parts of the keyNavigation:
 
#### Steps to reproduce and How to test
 - Goto the next item, then come back to the previous, you will see error message in the console (*reason*: keyNavigation creates on the page loading with the same unique id, so when you go back - keyNavigation tries to create the same id, *solution*: use `replace: true` parameter )
 - Check TAB button in the test runner: all active blocks should be in the queue.