### PR TITLE
Fix/tao 9218/linereader mask

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.2",
+    "version": "0.10.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.3",
+    "version": "0.10.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/lineReader/compoundMask.js
+++ b/src/plugins/tools/lineReader/compoundMask.js
@@ -339,17 +339,14 @@ export default function compoundMaskFactory(options, dimensions, position) {
                     $dragIcon = $('<div>', {
                         class: 'icon icon-move'
                     });
-
+                $element.css('touch-action', 'none');
                 $element.addClass('line-reader-inner-drag');
                 $element.css({ background: 'none' });
                 $element.append($dragIcon);
-                $element.on('mousedown touchstart', function(e) {
-                    e.stopPropagation();
-                    bringAllToFront();
-                });
             })
             .on('dragstart', function() {
                 closer.hide();
+                bringAllToFront();
                 invokeOnMasks('setState', ['resizing', true]);
             })
             .on('dragmove', function(xOffsetRelative, yOffsetRelative) {


### PR DESCRIPTION
**Task:** [TAO-9218](https://oat-sa.atlassian.net/browse/TAO-9218)
**Description:** masking zone inside lineReader plugin is impossible to move on IPads only.

**reproduce:**
open test/plugins/tools/lineReader/compoundMask/test.html unit test and try playground section on iPad. 
Try to move masking area with its handle pictogram - it is not moving.
(problem is visible only on iPad physical device)

**what was made:** 
some events dispatched were rewritten to modern "pointer events".