### PR TITLE
[TAO-8934] WK-1401 - TCiaB : Magnifying glass does not magnify contents correctly.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.7",
+    "version": "0.10.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.7",
+    "version": "0.10.8",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/magnifier/magnifierPanel.js
+++ b/src/plugins/tools/magnifier/magnifierPanel.js
@@ -364,11 +364,11 @@ function magnifierPanelFactory(config) {
             const $currentElement = $(elements.shift());
             const scrollLeft = $currentElement.scrollLeft();
             const scrollTop = $currentElement.scrollTop();
+            let scrollId = $currentElement.data('magnifier-scroll');
 
             elements.push(...Array.from($currentElement.children()));
 
-            if (scrollLeft > 0 || scrollTop > 0) {
-                let scrollId = $currentElement.data('magnifier-scroll');
+            if (scrollLeft > 0 || scrollTop > 0 || scrollId) {
                 scrollOffsetsChanged = true;
 
                 if (scrollId) {


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-8934
 
Magnifying glass does not magnify contents correctly after navigation.
  
#### How to test
 - prepare an instance of tao with taoAct extension
- prepare a test item which will not fit the size of the page, so user will have scroll on the page during delivery execution
- create a delivery with a few test items and enabled back navigation
- execute the delivery as a test taker
- on the item enable Magnifying glass tool and scroll to the very bottom of the page
- navigate to the next test item and then return back
- enable the tool again and check that it magnify correctly without any dispositions