### PR TITLE
Fix/timer config restore from client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.9",
+    "version": "0.10.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.9",
+    "version": "0.10.10",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -123,7 +123,7 @@ export default pluginFactory({
             /**
              * Restore timer from client.
              */
-            restoreTimerFromClient: testRunnerOptions.restoreTimerFromClient
+            restoreTimerFromClient: testRunnerOptions.timer && testRunnerOptions.timer.restoreTimerFromClient
         }, this.getConfig());
 
         /**


### PR DESCRIPTION
The configuration `restoreTimerFromClient` is under the `timer` key in taoQtiTest. 
Applying the fix from  #61 
