### PR TITLE
[TAO-9120] WTP-1440 Masking Tool doesn't fully cover an area under it.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.10",
+    "version": "0.10.11",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.10",
+    "version": "0.10.11",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_area-masking.scss
+++ b/scss/inc/_area-masking.scss
@@ -1,5 +1,5 @@
 
-.mask-container {
+.mask-container.mask-container {
     background-color: transparent;
 
     .dynamic-component-title-bar {
@@ -50,6 +50,7 @@
                 background-color: $uiGeneralContentBg;
                 opacity: 1;
                 box-sizing: content-box;
+                padding-bottom: 30px;
             }
 
             .controls {


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-9120
 
Fix layout issue with area masking tool
  
#### How to test
 
- prepare instance of TAO with taoAct extension 
- prepare a delivery with enabled area masking tool
- run delivery and check that there is no transparent space at the bottom of the area masking plugin
- change debug mode to false and check one again