### PR TITLE
fix magnifier tool zoomed area position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.11",
+    "version": "0.10.12",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.11",
+    "version": "0.10.12",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/magnifier/magnifierPanel.js
+++ b/src/plugins/tools/magnifier/magnifierPanel.js
@@ -250,8 +250,8 @@ function magnifierPanelFactory(config) {
              */
             translate: function translate(x, y) {
                 return {
-                    top: translateMagnifier(y, targetHeight, dynamicComponentInstance.config.height),
-                    left: translateMagnifier(x, targetWidth, dynamicComponentInstance.config.width)
+                    top: translateMagnifier(y, targetHeight, dynamicComponentInstance.position.height),
+                    left: translateMagnifier(x, targetWidth, dynamicComponentInstance.position.width)
                 };
             },
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9364
Replace the opened magnifier tool size with correct value to calculate  magnified area position,
#### Steps to reproduce
- login to prepared ACT enviroment as administrator, prepare test and enable magnifier tool for items in test
- login as guest user, run test and open magnifier tool
- move magnifier tool to right or bottom edge of screen
- edges of screen must be visible inside magnified area