### PR TITLE
[TAO-9473] WTP-1466 - [ACT] [TTS - FE] Create TTS plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.12",
+    "version": "0.11.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.12",
+    "version": "0.11.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation.js
@@ -526,7 +526,7 @@ function initDefaultItemNavigation(testRunner) {
 function initTTSNavigation(testRunner) {
     const pluginName = 'apiptts';
     const actionPrefix = `tool-${pluginName}-`;
-    const $itemElement = $(`[data-control="${pluginName}"]`);
+    const $itemElement = $(`.${pluginName}-plugin`);
     const id = `${pluginName}_navigation_group`;
 
     const test1Navigator = keyNavigator({
@@ -693,14 +693,14 @@ export default pluginFactory({
                 pluginConfig.contentNavigatorType = type;
             })
             .on('plugin-open.apiptts', () => {
-                const $itemElement = $('[data-control="apiptts"]');
+                const $itemElement = $('.apiptts-plugin');
 
                 $itemElement.addClass(ignoredClass);
 
                 this.groupNavigator.goto('apiptts_navigation_group');
             })
             .on('plugin-close.apiptts', () => {
-                const $itemElement = $('[data-control="apiptts"]');
+                const $itemElement = $('.apiptts-plugin');
 
                 $itemElement.removeClass(ignoredClass);
             });

--- a/src/plugins/content/accessibility/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation.js
@@ -47,12 +47,6 @@ var defaultPluginConfig = {
 };
 
 /**
- * initialized test runner navigator
- * @type {Object}
- */
-let testRunnerNavigatorItem;
-
-/**
  * Init the navigation in the toolbar
  *
  * @param {Object} testRunner
@@ -523,30 +517,6 @@ function initDefaultItemNavigation(testRunner) {
     return itemNavigators;
 }
 
-function initTTSNavigation(testRunner) {
-    const pluginName = 'apiptts';
-    const actionPrefix = `tool-${pluginName}-`;
-    const $itemElement = $(`.${pluginName}-plugin`);
-    const id = `${pluginName}_navigation_group`;
-
-    const test1Navigator = keyNavigator({
-        id: id,
-        elements: navigableDomElement.createFromDoms($itemElement),
-        group: $itemElement,
-        replace: true,
-    });
-
-    test1Navigator
-        .on('tab', () => {
-            testRunner.trigger(`${actionPrefix}next`);
-        })
-        .on('shift+tab', () => {
-            testRunner.trigger(`${actionPrefix}previous`);
-        });
-
-    return [test1Navigator];
-}
-
 /**
  * Init test runner navigation
  * @param testRunner
@@ -569,8 +539,7 @@ function initTestRunnerNavigation(testRunner, config) {
                 initToolbarNavigation(testRunner),
                 initNavigatorNavigation(testRunner),
                 initHeaderNavigation(testRunner),
-                initDefaultItemNavigation(testRunner),
-                initTTSNavigation(testRunner)
+                initDefaultItemNavigation(testRunner)
             );
             break;
 
@@ -581,8 +550,7 @@ function initTestRunnerNavigation(testRunner, config) {
                 initToolbarNavigation(testRunner),
                 initNavigatorNavigation(testRunner),
                 initHeaderNavigation(testRunner),
-                initDefaultItemNavigation(testRunner),
-                initTTSNavigation(testRunner)
+                initDefaultItemNavigation(testRunner)
             );
             break;
     }
@@ -671,7 +639,6 @@ export default pluginFactory({
         testRunner
             .after('renderitem', function() {
                 self.groupNavigator = initTestRunnerNavigation(testRunner, pluginConfig);
-                testRunnerNavigatorItem = self.groupNavigator;
 
                 shortcut.add('tab shift+tab', function(e) {
                     if (!allowedToNavigateFrom(e.target)) {
@@ -691,18 +658,6 @@ export default pluginFactory({
              */
             .on('setcontenttabtype', function(type) {
                 pluginConfig.contentNavigatorType = type;
-            })
-            .on('plugin-open.apiptts', () => {
-                const $itemElement = $('.apiptts-plugin');
-
-                $itemElement.addClass(ignoredClass);
-
-                this.groupNavigator.goto('apiptts_navigation_group');
-            })
-            .on('plugin-close.apiptts', () => {
-                const $itemElement = $('.apiptts-plugin');
-
-                $itemElement.removeClass(ignoredClass);
             });
     },
 

--- a/src/plugins/content/accessibility/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation.js
@@ -523,6 +523,30 @@ function initDefaultItemNavigation(testRunner) {
     return itemNavigators;
 }
 
+function initTTSNavigation(testRunner) {
+    const pluginName = 'apiptts';
+    const actionPrefix = `tool-${pluginName}-`;
+    const $itemElement = $(`[data-control="${pluginName}"]`);
+    const id = `${pluginName}_navigation_group`;
+
+    const test1Navigator = keyNavigator({
+        id: id,
+        elements: navigableDomElement.createFromDoms($itemElement),
+        group: $itemElement,
+        replace: true,
+    });
+
+    test1Navigator
+        .on('tab', () => {
+            testRunner.trigger(`${actionPrefix}next`);
+        })
+        .on('shift+tab', () => {
+            testRunner.trigger(`${actionPrefix}previous`);
+        });
+
+    return [test1Navigator];
+}
+
 /**
  * Init test runner navigation
  * @param testRunner
@@ -545,7 +569,8 @@ function initTestRunnerNavigation(testRunner, config) {
                 initToolbarNavigation(testRunner),
                 initNavigatorNavigation(testRunner),
                 initHeaderNavigation(testRunner),
-                initDefaultItemNavigation(testRunner)
+                initDefaultItemNavigation(testRunner),
+                initTTSNavigation(testRunner)
             );
             break;
 
@@ -556,7 +581,8 @@ function initTestRunnerNavigation(testRunner, config) {
                 initToolbarNavigation(testRunner),
                 initNavigatorNavigation(testRunner),
                 initHeaderNavigation(testRunner),
-                initDefaultItemNavigation(testRunner)
+                initDefaultItemNavigation(testRunner),
+                initTTSNavigation(testRunner)
             );
             break;
     }
@@ -665,6 +691,18 @@ export default pluginFactory({
              */
             .on('setcontenttabtype', function(type) {
                 pluginConfig.contentNavigatorType = type;
+            })
+            .on('plugin-open.apiptts', () => {
+                const $itemElement = $('[data-control="apiptts"]');
+
+                $itemElement.addClass(ignoredClass);
+
+                this.groupNavigator.goto('apiptts_navigation_group');
+            })
+            .on('plugin-close.apiptts', () => {
+                const $itemElement = $('[data-control="apiptts"]');
+
+                $itemElement.removeClass(ignoredClass);
             });
     },
 

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -76,7 +76,7 @@ export default pluginFactory({
          * @fires plugin-open.apiptts
          */
         const enablePlugin = () => {
-            this.navigationGroup.focus();
+            this.navigationGroup && this.navigationGroup.focus();
 
             this.button.turnOn();
             this.setState('active', true);
@@ -90,7 +90,7 @@ export default pluginFactory({
          * @fires plugin-close.apiptts
          */
         const disablePlugin = () => {
-            this.navigationGroup.blur();
+            this.navigationGroup && this.navigationGroup.blur();
 
             this.setState('active', false);
 

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -1,0 +1,209 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016-2019  (original work) Open Assessment Technologies SA;
+ *
+ * @author Anton Tsymuk <anton@taotesting.com>
+ */
+
+import _ from 'lodash';
+import __ from 'i18n';
+import 'ui/hider';
+import shortcut from 'util/shortcut';
+import namespaceHelper from 'util/namespace';
+import pluginFactory from 'taoTests/runner/plugin';
+import mapHelper from 'taoQtiTest/runner/helpers/map';
+
+const pluginName = 'apiptts';
+
+const actionPrefix = `tool-${pluginName}-`;
+
+/**
+ * Returns the configured plugin
+ */
+export default pluginFactory({
+    name: pluginName,
+
+    /**
+     * Initialize the plugin (called during runner's init)
+     */
+    init: function init() {
+        const testRunner = this.getTestRunner();
+        const testRunnerOptions = testRunner.getOptions();
+        const pluginShortcuts = (testRunnerOptions.shortcuts || {})[this.getName()] || {};
+
+        /**
+         * Checks if the plugin is currently available.
+         * To be activated with the special category x-tao-option-apiptts
+         *
+         * @returns {Boolean}
+         */
+        const isConfigured = () => mapHelper.hasItemCategory(
+            testRunner.getTestMap(),
+            testRunner.getTestContext().itemIdentifier,
+            'apiptts',
+            true
+        );
+
+        /**
+         * Is plugin activated ? if not, then we hide the plugin
+         */
+        const togglePlugin = () => {
+            if (isConfigured()) {
+                this.show();
+            } else {
+                this.hide();
+            }
+        };
+
+        /**
+         * Show the plugin panel
+         *
+         * @fires plugin-open.apiptts
+         */
+        const enablePlugin = () => {
+            this.button.turnOn();
+            this.setState('active', true);
+
+            testRunner.trigger(`plugin-open.${pluginName}`);
+        };
+
+        /**
+         * Hide the plugin panel
+         *
+         * @fires plugin-close.apiptts
+         */
+        const disablePlugin = () => {
+            this.setState('active', false);
+
+            this.button.turnOff();
+            testRunner.trigger(`plugin-close.${pluginName}`);
+        };
+
+        /**
+         * Shows/hides the plugin
+         */
+        const toggleTool = () => {
+            if (this.getState('enabled')) {
+                if (this.getState('active')) {
+                    disablePlugin();
+                } else {
+                    enablePlugin();
+                }
+            }
+        };
+
+        // Add plugin button to toolbox
+        this.button = this.getAreaBroker()
+            .getToolbox()
+            .createEntry({
+                control: 'apiptts',
+                icon: 'headphones',
+                text: __('Text To Speech'),
+                title: __('Enable text to speech'),
+            });
+
+        // Handle plugin button click
+        this.button.on('click', (e) => {
+            e.preventDefault();
+            testRunner.trigger(`${actionPrefix}toggle`);
+        });
+
+        // Register plugin shortcuts
+        if (testRunnerOptions.allowShortcuts) {
+            _.forEach(pluginShortcuts, (command, key) => {
+                shortcut.add(
+                    namespaceHelper.namespaceAll(command, pluginName, true),
+                    () => {
+                        const eventKey = key.endsWith('TogglePlayback') ? 'togglePlayback' : key;
+
+                        testRunner.trigger(actionPrefix + eventKey);
+                    },
+                    {
+                        avoidInput: true
+                    }
+                );
+            });
+        }
+
+        //start disabled
+        togglePlugin();
+        this.disable();
+
+        //update plugin state based on changes
+        testRunner
+            .on('loaditem', () => {
+                togglePlugin();
+                this.disable();
+            })
+            .on('enabletools renderitem', () => {
+                this.enable();
+            })
+            .on('disabletools unloaditem', () => {
+                this.disable();
+            })
+            .on(`${actionPrefix}toggle`, () => {
+                if (isConfigured()) {
+                    toggleTool();
+                }
+            })
+            .on(`${actionPrefix}togglePlayback`, () => {
+            })
+            .on(`${actionPrefix}next`, () => {
+                if (this.getState('enabled')) {
+                    if (this.getState('active')) {
+                        // handling goes here
+                    }
+                }
+            })
+            .on(`${actionPrefix}previous`, () => {
+                if (this.getState('enabled')) {
+                    if (this.getState('active')) {
+                        // handling goes here
+                    }
+                }
+            });
+    },
+    /**
+     * Called during the runner's destroy phase
+     */
+    destroy: function destroy() {
+        shortcut.remove(`.${this.getName()}`);
+    },
+    /**
+     * Enable the button
+     */
+    enable: function enable() {
+        this.button.enable();
+    },
+    /**
+     * Disable the button
+     */
+    disable: function disable() {
+        this.button.disable();
+    },
+    /**
+     * Show the button
+     */
+    show: function show() {
+        this.button.show();
+    },
+    /**
+     * Hide the button
+     */
+    hide: function hide() {
+        this.button.hide();
+    }
+});

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -39,7 +39,7 @@ export default pluginFactory({
     /**
      * Initialize the plugin (called during runner's init)
      */
-    init: function init() {
+    init() {
         const testRunner = this.getTestRunner();
         const testRunnerOptions = testRunner.getOptions();
         const pluginShortcuts = (testRunnerOptions.shortcuts || {})[this.getName()] || {};
@@ -77,7 +77,7 @@ export default pluginFactory({
             this.button.turnOn();
             this.setState('active', true);
 
-            testRunner.trigger(`plugin-open.${pluginName}`);
+            this.trigger('open');
         };
 
         /**
@@ -89,7 +89,7 @@ export default pluginFactory({
             this.setState('active', false);
 
             this.button.turnOff();
-            testRunner.trigger(`plugin-close.${pluginName}`);
+            this.trigger('close');
         };
 
         /**
@@ -109,7 +109,8 @@ export default pluginFactory({
         this.button = this.getAreaBroker()
             .getToolbox()
             .createEntry({
-                control: 'apiptts',
+                className: `${this.getName()}-plugin`,
+                control: this.getName(),
                 icon: 'headphones',
                 text: __('Text To Speech'),
                 title: __('Enable text to speech'),
@@ -179,31 +180,31 @@ export default pluginFactory({
     /**
      * Called during the runner's destroy phase
      */
-    destroy: function destroy() {
+    destroy() {
         shortcut.remove(`.${this.getName()}`);
     },
     /**
      * Enable the button
      */
-    enable: function enable() {
+    enable() {
         this.button.enable();
     },
     /**
      * Disable the button
      */
-    disable: function disable() {
+    disable() {
         this.button.disable();
     },
     /**
      * Show the button
      */
-    show: function show() {
+    show() {
         this.button.show();
     },
     /**
      * Hide the button
      */
-    hide: function hide() {
+    hide() {
         this.button.hide();
     }
 });

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -25,6 +25,8 @@ import shortcut from 'util/shortcut';
 import namespaceHelper from 'util/namespace';
 import pluginFactory from 'taoTests/runner/plugin';
 import mapHelper from 'taoQtiTest/runner/helpers/map';
+import keyNavigator from 'ui/keyNavigation/navigator';
+import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
 
 const pluginName = 'apiptts';
 
@@ -74,6 +76,8 @@ export default pluginFactory({
          * @fires plugin-open.apiptts
          */
         const enablePlugin = () => {
+            this.navigationGroup.focus();
+
             this.button.turnOn();
             this.setState('active', true);
 
@@ -86,6 +90,8 @@ export default pluginFactory({
          * @fires plugin-close.apiptts
          */
         const disablePlugin = () => {
+            this.navigationGroup.blur();
+
             this.setState('active', false);
 
             this.button.turnOff();
@@ -175,6 +181,28 @@ export default pluginFactory({
                         // handling goes here
                     }
                 }
+            })
+            .on('renderitem', () => {
+                const $navigationGroupElement = this.button.getElement();
+                const groupNavigationId = `${pluginName}_navigation_group`;
+
+                if (!$navigationGroupElement) {
+                    return;
+                }
+
+                this.navigationGroup = keyNavigator({
+                    id: groupNavigationId,
+                    elements: navigableDomElement.createFromDoms($navigationGroupElement),
+                    group: $navigationGroupElement,
+                    replace: true,
+                    propagateTab: false,
+                })
+                    .on('tab', () => {
+                        testRunner.trigger(`${actionPrefix}next`);
+                    })
+                    .on('shift+tab', () => {
+                        testRunner.trigger(`${actionPrefix}previous`);
+                    });
             });
     },
     /**

--- a/test/plugins/tools/apipTextToSpeech/plugin/test.html
+++ b/test/plugins/tools/apipTextToSpeech/plugin/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner Plugin - Apip Text To Speech</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['taoQtiTest/test/runner/plugins/tools/apipTextToSpeech/plugin/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/plugins/tools/apipTextToSpeech/plugin/test.js
+++ b/test/plugins/tools/apipTextToSpeech/plugin/test.js
@@ -1,0 +1,342 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Anton Tsymuk <anton@taotesting.com>
+ */
+define([
+    'lodash',
+    'ui/hider',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/runner/plugins/tools/apipTextToSpeech/plugin',
+    'lib/simulator/jquery.simulate'
+], function (_, hider, runnerFactory, providerMock, pluginFactory) {
+    'use strict';
+
+    const providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    const sampleTestContext = {
+        itemIdentifier: 'item-1'
+    };
+    const sampleTestMap = {
+        parts: {
+            p1: {
+                sections: {
+                    s1: {
+                        items: {
+                            'item-1': {
+                                categories: ['x-tao-option-apiptts']
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        jumps: [{
+            identifier: 'item-1',
+            section: 's1',
+            part: 'p1',
+            position: 0
+        }]
+    };
+
+    /**
+     * The following tests applies to all plugins
+     */
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', (assert) => {
+        const runner = runnerFactory(providerName);
+
+        assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(
+            pluginFactory(runner),
+            pluginFactory(runner),
+            'The plugin factory provides a different instance on each call'
+        );
+    });
+
+    const pluginApi = [
+        { name: 'init', title: 'init' },
+        { name: 'render', title: 'render' },
+        { name: 'finish', title: 'finish' },
+        { name: 'destroy', title: 'destroy' },
+        { name: 'trigger', title: 'trigger' },
+        { name: 'getTestRunner', title: 'getTestRunner' },
+        { name: 'getAreaBroker', title: 'getAreaBroker' },
+        { name: 'getConfig', title: 'getConfig' },
+        { name: 'setConfig', title: 'setConfig' },
+        { name: 'getState', title: 'getState' },
+        { name: 'setState', title: 'setState' },
+        { name: 'show', title: 'show' },
+        { name: 'hide', title: 'hide' },
+        { name: 'enable', title: 'enable' },
+        { name: 'disable', title: 'disable' }
+    ];
+
+    QUnit.cases.init(pluginApi).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const timer = pluginFactory(runner);
+
+        assert.equal(
+            typeof timer[data.name],
+            'function',
+            `The pluginFactory instances expose a "${data.name}" function`
+        );
+    });
+
+    QUnit.test('pluginFactory.init', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        plugin
+            .init()
+            .then(() => {
+                assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
+
+                ready();
+            })
+            .catch((err) => {
+                assert.ok(false, `The init failed: ${err}`);
+                ready();
+            });
+    });
+
+    /**
+     * The following tests applies to buttons-type plugins
+     */
+    QUnit.module('plugin button');
+
+    QUnit.test('render/destroy button', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        assert.expect(3);
+
+        plugin
+            .init()
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
+                let $button;
+
+                areaBroker.getToolbox().render($container);
+
+                $button = $container.find('[data-control="apiptts"]');
+
+                assert.equal($button.length, 1, 'The trigger button has been inserted');
+                assert.equal($button.hasClass('disabled'), true, 'The trigger button has been rendered disabled');
+
+                areaBroker.getToolbox().destroy();
+
+                $button = $container.find('[data-control="apiptts"]');
+
+                assert.equal($button.length, 0, 'The trigger button has been removed');
+                ready();
+            })
+            .catch((err) => {
+                assert.ok(false, `Error in init method: ${err}`);
+                ready();
+            });
+    });
+
+    QUnit.test('enable/disable button', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        assert.expect(2);
+
+        plugin
+            .init()
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
+
+                areaBroker.getToolbox().render($container);
+
+                return plugin.enable().then(() => {
+                    const $button = $container.find('[data-control="apiptts"]');
+
+                    assert.equal($button.hasClass('disabled'), false, 'The trigger button has been enabled');
+
+                    return plugin.disable().then(() => {
+                        assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
+
+                        ready();
+                    });
+                });
+            })
+            .catch((err) => {
+                assert.ok(false, `Unexpected error: ${err}`);
+                ready();
+            });
+    });
+
+    QUnit.test('show/hide button', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        assert.expect(3);
+
+        plugin
+            .init()
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
+
+                areaBroker.getToolbox().render($container);
+
+                return plugin.hide().then(() => {
+                    const $button = $container.find('[data-control="apiptts"]');
+
+                    assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden');
+
+                    return plugin.show().then(() => {
+                        assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
+
+                        return plugin.hide().then(() => {
+                            assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden again');
+
+                            ready();
+                        });
+                    });
+                });
+            })
+            .catch((err) => {
+                assert.ok(false, `Unexpected error: ${err}`);
+                ready();
+            });
+    });
+
+    QUnit.test('runner events: loaditem / unloaditem', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        assert.expect(3);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+
+        plugin
+            .init()
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
+
+                areaBroker.getToolbox().render($container);
+
+                const $button = $container.find('[data-control="apiptts"]');
+
+                runner.trigger('loaditem');
+
+                assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
+
+                runner.trigger('unloaditem');
+
+                assert.equal(hider.isHidden($button), false, 'The trigger button is still visible');
+
+                assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
+
+                ready();
+            })
+            .catch((err) => {
+                assert.ok(false, `Error in init method: ${err}`);
+                ready();
+            });
+    });
+
+    QUnit.test('runner events: renderitem', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        assert.expect(2);
+
+        plugin
+            .init()
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
+
+                areaBroker.getToolbox().render($container);
+
+                const $button = $container.find('[data-control="apiptts"]');
+
+                runner.trigger('renderitem');
+
+                assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
+
+                assert.equal($button.hasClass('disabled'), false, 'The trigger button is not disabled');
+
+                ready();
+            })
+            .catch((err) => {
+                assert.ok(false, `Error in init method: ${err}`);
+                ready();
+            });
+    });
+
+    QUnit.test('Toggle on click', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+
+        assert.expect(3);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+
+        plugin
+            .init()
+            .then(function () {
+                const $container = areaBroker.getToolboxArea();
+
+                runner.trigger('renderitem');
+
+                areaBroker.getToolbox().render($container);
+
+                return plugin.enable().then(() => {
+                    const $button = $container.find('[data-control="apiptts"]');
+
+                    assert.equal(plugin.getState('active'), false, 'The plugin should not be active by default');
+
+                    $button.click();
+
+                    assert.equal(plugin.getState('active'), true, 'The button should toggle the plugin to active state');
+
+                    $button.click();
+
+                    assert.equal(plugin.getState('active'), false, 'If the plugin is active, the button should toggle the plugin to non active state');
+
+                    ready();
+                });
+            })
+            .catch(function (err) {
+                assert.ok(false, `Unexpected error: ${err}`);
+                ready();
+            });
+    });
+});


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-9474, https://oat-sa.atlassian.net/browse/TAO-9476
 
Create adapter for new APIP Text To Speech plugin. Update keyNavigation plugin to be able to handle TTS plugin tab navigation

#### How to test
 
- Go to `config/taoTests/test_runner_plugin_registry.conf.php` and change `active` to `true` for APIP Text To Speech plugin
- Prepare an instance of tao with taoAct extension
- Prepare a test with enabled APIP Text To Speech plugin
- Execute test as a test taker
- Make sure that APIP Text To Speech plugin is available in custom toolbox

Requires :
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/1258
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1626