### PR TITLE
Fix/tao 9603/alllow keyboard on offline sync modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.14",
+    "version": "0.10.15",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.14",
+    "version": "0.10.15",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -77,11 +77,9 @@ function offlineSyncModalFactory(proxy) {
             globalShortcut.disable();
             dialogShortcut.enable();
         })
-        .on('proceed secondaryaction', () => {
+        .on('destroy', () => {
             globalShortcut.enable();
             dialogShortcut.disable();
-        })
-        .on('destroy', () => {
             dialogShortcut.clear();
         })
         .on('wait', () => {

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -27,14 +27,16 @@ import hider from 'ui/hider';
 import waitingDialogFactory from 'ui/waitingDialog/waitingDialog';
 import offlineSyncModalCountdownTpl from 'taoQtiTest/runner/helpers/templates/offlineSyncModalCountdown';
 import offlineSyncModalWaitContentTpl from 'taoQtiTest/runner/helpers/templates/offlineSyncModalWaitContent';
+import shortcutRegistry from 'util/shortcut/registry';
+import globalShortcut from 'util/shortcut';
 
 /**
  * Display the waiting dialog, while waiting the connection to be back
  * @param {Object} [proxy] - test runner proxy
  * @returns {waitingDialog} resolves once the wait is over and the user click on 'proceed'
  */
-var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
-    var waitingConfig = {
+function offlineSyncModalFactory(proxy) {
+    const waitingConfig = {
         message: __('You are encountering a prolonged connectivity loss.'),
         waitContent: offlineSyncModalWaitContentTpl(),
         proceedContent: __('The connection seems to be back, please proceed.'),
@@ -45,40 +47,56 @@ var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
         buttonSeparatorText: __('or'),
         width: '600px'
     };
-    var $secondaryButton;
-    var secondaryButtonWait = 60; // seconds to wait until it enables
-    var $countdown = $(offlineSyncModalCountdownTpl());
-    var countdownPolling;
+    let $secondaryButton;
+    const secondaryButtonWait = 60; // seconds to wait until it enables
+    const $countdown = $(offlineSyncModalCountdownTpl());
+    let countdownPolling;
+
+    const dialogShortcut = shortcutRegistry($('body'), {
+        propagate: false,
+        prevent: true
+    });
+
+    // starts with shortcuts disabled, prevents the TAB key to be used to move outside the dialog box
+    dialogShortcut.disable().set('Tab Shift+Tab');
 
     //creates the waiting modal dialog
-    var waitingDialog = waitingDialogFactory(waitingConfig)
-        .on('render', function() {
+    const waitingDialog = waitingDialogFactory(waitingConfig)
+        .on('render', () => {
             $secondaryButton = $('div.preview-modal-feedback.modal').find('button[data-control="secondary"]');
 
             $countdown.insertAfter($secondaryButton);
 
-            proxy.off('reconnect.waiting').after('reconnect.waiting', function() {
-                waitingDialog.endWait();
-            });
+            proxy.off('reconnect.waiting').after('reconnect.waiting', () => waitingDialog.endWait());
 
             // if render comes before beginWait:
             if (waitingDialog.is('waiting')) {
                 waitingDialog.trigger('begincountdown');
             }
+
+            globalShortcut.disable();
+            dialogShortcut.enable();
         })
-        .on('wait', function() {
+        .on('proceed secondaryaction', () => {
+            globalShortcut.enable();
+            dialogShortcut.disable();
+        })
+        .on('destroy', () => {
+            dialogShortcut.clear();
+        })
+        .on('wait', () => {
             // if beginWait comes before render:
             if (waitingDialog.is('rendered')) {
                 waitingDialog.trigger('begincountdown');
             }
         })
-        .on('begincountdown', function() {
-            var delaySec = secondaryButtonWait;
+        .on('begincountdown', () => {
+            let delaySec = secondaryButtonWait;
             // Set up secondary button time delay:
             // it can only be clicked after 60 seconds have passed
             $secondaryButton.prop('disabled', true);
             countdownPolling = polling({
-                action: function() {
+                action: function countdownAction() {
                     delaySec--;
                     $countdown.html(__('The download will be available in <strong>%d</strong> seconds', delaySec));
                     if (delaySec < 1) {
@@ -91,7 +109,7 @@ var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
                 autoStart: true
             });
         })
-        .on('unwait', function() {
+        .on('unwait', () => {
             countdownPolling.stop();
             $secondaryButton.prop('disabled', true);
             $countdown.remove();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9603

Allows the keyboard navigation on the wait dialog displayed at the end of an offline test when the connectivity is down.

Step to check:
- take a test with the offline mode set up
- pass through the test, before the end disconnect from the network
- try to end the test, the wait popup should be diplayed
- wait for the countdown to finish
- try to reach the download button