### PR TITLE
check is online before resolve offlineAction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.15",
+    "version": "0.10.16",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.15",
+    "version": "0.10.16",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -70,9 +70,12 @@ function offlineSyncModalFactory(proxy) {
 
             proxy.after('reconnect', () => waitingDialog.endWait());
             proxy.before('disconnect', () => {
-                // need to open dialog again!!!
-                // waitingDialog.getElement().modal('open'); - not working 
-                waitingDialog.beginWait()
+                // need to open dialog again if it is closed
+                const waitingDialogModal = $('.preview-modal-feedback');
+                if (!waitingDialogModal.hasClass('opened')){
+                    waitingDialogModal('open');
+                }
+                waitingDialog.beginWait();
             });
 
             // if render comes before beginWait:

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -48,6 +48,7 @@ function offlineSyncModalFactory(proxy) {
         width: '600px'
     };
     let $secondaryButton;
+    const betweenButtonTextSelector = 'div.preview-modal-feedback.modal .between-buttons-text';
     const secondaryButtonWait = 60; // seconds to wait until it enables
     let delaySec;
     const $countdown = $(offlineSyncModalCountdownTpl());
@@ -91,8 +92,7 @@ function offlineSyncModalFactory(proxy) {
             dialogShortcut.clear();
         })
         .on('wait', () => {
-
-            hider.show('.between-buttons-text');
+            hider.show(betweenButtonTextSelector);
             // if beginWait comes before render:
             if (waitingDialog.is('rendered')) {
                 waitingDialog.trigger('begincountdown');
@@ -121,7 +121,7 @@ function offlineSyncModalFactory(proxy) {
             countdownPolling.stop();
             $secondaryButton.prop('disabled', true);
             $countdown.html('');
-            hider.hide('.between-buttons-text');
+            hider.hide(betweenButtonTextSelector);
         });
 
     return waitingDialog;

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -48,7 +48,7 @@ function offlineSyncModalFactory(proxy) {
         width: '600px'
     };
     let $secondaryButton;
-    const betweenButtonTextSelector = 'div.preview-modal-feedback.modal .between-buttons-text';
+    const betweenButtonTextSelector = '.between-buttons-text';
     const secondaryButtonWait = 60; // seconds to wait until it enables
     let delaySec;
     const $countdown = $(offlineSyncModalCountdownTpl());
@@ -63,10 +63,14 @@ function offlineSyncModalFactory(proxy) {
     dialogShortcut.disable().set('Tab Shift+Tab');
 
     //creates the waiting modal dialog
-    const waitingDialog = waitingDialogFactory(waitingConfig)
+    const waitingDialog = waitingDialogFactory(waitingConfig);
+
+    const getDialogEl = selector => waitingDialog.dialog.getDom().find(selector);
+
+    waitingDialog
         .on('render', () => {
             delaySec = secondaryButtonWait;
-            $secondaryButton = $('div.preview-modal-feedback.modal').find('button[data-control="secondary"]');
+            $secondaryButton = getDialogEl('button[data-control="secondary"]');
             $countdown.insertAfter($secondaryButton);
 
             proxy.after('reconnect.waiting', () => waitingDialog.endWait());
@@ -85,14 +89,13 @@ function offlineSyncModalFactory(proxy) {
             dialogShortcut.enable();
         })
         .on('destroy', () => {
-            proxy.off('reconnect.waiting');
-            proxy.off('disconnect.waiting');
+            proxy.off('.waiting');
             globalShortcut.enable();
             dialogShortcut.disable();
             dialogShortcut.clear();
         })
         .on('wait', () => {
-            hider.show(betweenButtonTextSelector);
+            hider.show(getDialogEl(betweenButtonTextSelector));
             // if beginWait comes before render:
             if (waitingDialog.is('rendered')) {
                 waitingDialog.trigger('begincountdown');
@@ -121,7 +124,7 @@ function offlineSyncModalFactory(proxy) {
             countdownPolling.stop();
             $secondaryButton.prop('disabled', true);
             $countdown.html('');
-            hider.hide(betweenButtonTextSelector);
+            hider.hide(getDialogEl(betweenButtonTextSelector));
         });
 
     return waitingDialog;

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -68,8 +68,8 @@ function offlineSyncModalFactory(proxy) {
             $secondaryButton = $('div.preview-modal-feedback.modal').find('button[data-control="secondary"]');
             $countdown.insertAfter($secondaryButton);
 
-            proxy.after('reconnect', () => waitingDialog.endWait());
-            proxy.before('disconnect', () => {
+            proxy.after('reconnect.waiting', () => waitingDialog.endWait());
+            proxy.before('disconnect.waiting', () => {
                 // need to open dialog again if it is closed
                 waitingDialog.dialog.show();
                 waitingDialog.beginWait();
@@ -84,6 +84,8 @@ function offlineSyncModalFactory(proxy) {
             dialogShortcut.enable();
         })
         .on('destroy', () => {
+            proxy.off('reconnect.waiting');
+            proxy.off('disconnect.waiting');
             globalShortcut.enable();
             dialogShortcut.disable();
             dialogShortcut.clear();

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -71,10 +71,7 @@ function offlineSyncModalFactory(proxy) {
             proxy.after('reconnect', () => waitingDialog.endWait());
             proxy.before('disconnect', () => {
                 // need to open dialog again if it is closed
-                const waitingDialogModal = $('.preview-modal-feedback');
-                if (!waitingDialogModal.hasClass('opened')){
-                    waitingDialogModal('open');
-                }
+                waitingDialog.dialog.show();
                 waitingDialog.beginWait();
             });
 

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -199,10 +199,7 @@ export default _.defaults(
                                 });
                             };
                         if (isOffline) {
-                            return new Promise(offlineSync)
-                                .catch(function() {
-                                    return resolve({ success: false });
-                                });
+                            return offlineSync();
                         } else {
                             return self
                                 .syncData()
@@ -210,10 +207,7 @@ export default _.defaults(
                                     if (self.isOffline()) {
                                         // in case last request was failed and connection lost
                                         // show offlineWaitingDialog
-                                        return new Promise(offlineSync)
-                                            .catch(function() {
-                                                return resolve({ success: false });
-                                            });
+                                        return offlineSync();
                                     }
                                     return resolve(result);
                                 })

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -178,30 +178,43 @@ export default _.defaults(
                         result.testContext = {
                             state: states.testSession.closed
                         };
-                        if (isOffline) {
-                            return new Promise(function() {
-                                offlineSyncModal(self)
-                                    .on('proceed', function() {
-                                        self.syncData()
-                                            .then(function() {
+                        const offlineSync = function() {
+                            offlineSyncModal(self)
+                                .on('proceed', function() {
+                                    self.syncData()
+                                        .then(function() {
+                                            // if is online resolve promise 
+                                            if (self.isOnline()) {
                                                 return resolve(result);
-                                            })
-                                            .catch(function() {
-                                                return resolve({ success: false });
-                                            });
-                                    })
-                                    .on('secondaryaction', function() {
-                                        self.initiateDownload().catch(function() {
+                                            }
+                                        })
+                                        .catch(function() {
                                             return resolve({ success: false });
                                         });
+                                    })
+                                .on('secondaryaction', function() {
+                                    self.initiateDownload().catch(function() {
+                                        return resolve({ success: false });
                                     });
-                            }).catch(function() {
-                                return resolve({ success: false });
-                            });
+                                });
+                            };
+                        if (isOffline) {
+                            return new Promise(offlineSync)
+                                .catch(function() {
+                                    return resolve({ success: false });
+                                });
                         } else {
                             return self
                                 .syncData()
                                 .then(function() {
+                                    if (self.isOffline()) {
+                                        // in case last request was failed and connection lost
+                                        // show offlineWaitingDialog
+                                        return new Promise(offlineSync)
+                                            .catch(function() {
+                                                return resolve({ success: false });
+                                            });
+                                    }
                                     return resolve(result);
                                 })
                                 .catch(function() {
@@ -319,7 +332,7 @@ export default _.defaults(
 
                             self.syncInProgress = false;
                             self.trigger('error', err);
-                            
+
                             throw err;
                         }).then(data => {
                             self.syncInProgress = false;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9666

In `offlineSyncMode` was added handler on `proxy.before('disconnect'`
On `offline/proxy `returned promise of `offlineAction` will be resolved only in online mode
@js how to open closed (by click Proceed&end essesment button) dialog again?

Steps to reproduce:
1) start taking a test;
2) move to offline test taking mode;
3) at the end of the test, come back online and see the message "You are encountering a prolonged connectivity loss. The connection seems to be back, please proceed." Don't click on it.
4) go offline and see the message in red. Don't interact with the message, the message disappears. 
5)while still offline, click on Proceed & End Assessment. -> browser returns standard offline (You're not connected) error message.
