### PR TITLE
Hotfix/tao 9666/disconnect reconnect at the end

### DIFF
--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -68,9 +68,12 @@ var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
 
             proxy.after('reconnect', () => waitingDialog.endWait());
             proxy.before('disconnect', () => {
-                // need to open dialog again!!!
-                // waitingDialog.getElement().modal('open'); - not working 
-                waitingDialog.beginWait()
+                // need to open dialog again if it is closed
+                const waitingDialogModal = $('.preview-modal-feedback');
+                if (!waitingDialogModal.hasClass('opened')){
+                    waitingDialogModal('open');
+                }
+                waitingDialog.beginWait();
             });
 
             // if render comes before beginWait:

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -27,14 +27,16 @@ import hider from 'ui/hider';
 import waitingDialogFactory from 'ui/waitingDialog/waitingDialog';
 import offlineSyncModalCountdownTpl from 'taoQtiTest/runner/helpers/templates/offlineSyncModalCountdown';
 import offlineSyncModalWaitContentTpl from 'taoQtiTest/runner/helpers/templates/offlineSyncModalWaitContent';
+import shortcutRegistry from 'util/shortcut/registry';
+import globalShortcut from 'util/shortcut';
 
 /**
  * Display the waiting dialog, while waiting the connection to be back
  * @param {Object} [proxy] - test runner proxy
  * @returns {waitingDialog} resolves once the wait is over and the user click on 'proceed'
  */
-var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
-    var waitingConfig = {
+function offlineSyncModalFactory(proxy) {
+    const waitingConfig = {
         message: __('You are encountering a prolonged connectivity loss.'),
         waitContent: offlineSyncModalWaitContentTpl(),
         proceedContent: __('The connection seems to be back, please proceed.'),
@@ -77,8 +79,17 @@ var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
             if (waitingDialog.is('waiting')) {
                 waitingDialog.trigger('begincountdown');
             }
+
+            globalShortcut.disable();
+            dialogShortcut.enable();
+        })
+        .on('destroy', () => {
+            globalShortcut.enable();
+            dialogShortcut.disable();
+            dialogShortcut.clear();
         })
         .on('wait', () => {
+
             hider.show('.between-buttons-text');
             // if beginWait comes before render:
             if (waitingDialog.is('rendered')) {
@@ -91,7 +102,7 @@ var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
             // if disconnect-reconnect delay will be left seconds
             $secondaryButton.prop('disabled', true);
             countdownPolling = polling({
-                action: function() {
+                action: function countdownAction() {
                     delaySec--;
                     $countdown.html(__('The download will be available in <strong>%d</strong> seconds', delaySec));
                     if (delaySec < 1) {
@@ -104,7 +115,7 @@ var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
                 autoStart: true
             });
         })
-        .on('unwait', function() {
+        .on('unwait', () => {
             countdownPolling.stop();
             $secondaryButton.prop('disabled', true);
             $countdown.html('');

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -69,10 +69,7 @@ var offlineSyncModalFactory = function offlineSyncModalFactory(proxy) {
             proxy.after('reconnect', () => waitingDialog.endWait());
             proxy.before('disconnect', () => {
                 // need to open dialog again if it is closed
-                const waitingDialogModal = $('.preview-modal-feedback');
-                if (!waitingDialogModal.hasClass('opened')){
-                    waitingDialogModal('open');
-                }
+                waitingDialog.dialog.show();
                 waitingDialog.beginWait();
             });
 

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -178,30 +178,43 @@ export default _.defaults(
                         result.testContext = {
                             state: states.testSession.closed
                         };
-                        if (isOffline) {
-                            return new Promise(function() {
-                                offlineSyncModal(self)
-                                    .on('proceed', function() {
-                                        self.syncData()
-                                            .then(function() {
+                        const offlineSync = function() {
+                            offlineSyncModal(self)
+                                .on('proceed', function() {
+                                    self.syncData()
+                                        .then(function() {
+                                            // if is online resolve promise 
+                                            if (self.isOnline()) {
                                                 return resolve(result);
-                                            })
-                                            .catch(function() {
-                                                return resolve({ success: false });
-                                            });
-                                    })
-                                    .on('secondaryaction', function() {
-                                        self.initiateDownload().catch(function() {
+                                            }
+                                        })
+                                        .catch(function() {
                                             return resolve({ success: false });
                                         });
+                                    })
+                                .on('secondaryaction', function() {
+                                    self.initiateDownload().catch(function() {
+                                        return resolve({ success: false });
                                     });
-                            }).catch(function() {
-                                return resolve({ success: false });
-                            });
+                                });
+                            };
+                        if (isOffline) {
+                            return new Promise(offlineSync)
+                                .catch(function() {
+                                    return resolve({ success: false });
+                                });
                         } else {
                             return self
                                 .syncData()
                                 .then(function() {
+                                    if (self.isOffline()) {
+                                        // in case last request was failed and connection lost
+                                        // show offlineWaitingDialog
+                                        return new Promise(offlineSync)
+                                            .catch(function() {
+                                                return resolve({ success: false });
+                                            });
+                                    }
                                     return resolve(result);
                                 })
                                 .catch(function() {
@@ -319,7 +332,7 @@ export default _.defaults(
 
                             self.syncInProgress = false;
                             self.trigger('error', err);
-                            
+
                             throw err;
                         }).then(data => {
                             self.syncInProgress = false;


### PR DESCRIPTION
Backport https://github.com/oat-sa/tao-test-runner-qti-fe/pull/78
Version 0.10.2-4

**Release notes :**
- [fix] [TAO-9666](https://oat-sa.atlassian.net/browse/TAO-9666) check is online before resolve offlineAction [#78](https://github.com/oat-sa/tao-test-runner-qti-fe/pull/78)

**Due to incorrect release of 0.10.2-3 don't have changes from Hotfix/tao 9603 https://github.com/oat-sa/tao-test-runner-qti-fe/pull/76 these changes were added**
see diff between
https://github.com/oat-sa/tao-test-runner-qti-fe/blob/0.10.2-3/src/helpers/offlineSyncModal.js
and https://github.com/oat-sa/tao-test-runner-qti-fe/blob/release-0.10.2-3/src/helpers/offlineSyncModal.js