### PR TITLE
[TAO-9576] WTP-1353 - No. of occurances of highlighter tool is incorrect.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.16",
+    "version": "0.10.17",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.10.16",
+    "version": "0.10.17",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/highlighter/plugin.js
+++ b/src/plugins/tools/highlighter/plugin.js
@@ -306,21 +306,21 @@ export default pluginFactory({
                     }
                 })
                 .after('renderitem', function() {
-                    // Attach start/end listeners to all highlighter instances:
-                    _.forEach(highlighters.getAllHighlighters(), function(instance) {
-                        if (instance.isEnabled()) {
-                            instance
-                                .on('start', function() {
-                                    self.buttonMain.turnOn();
-                                    self.trigger('start');
-                                    hasHighlights = true;
-                                })
-                                .on('end', function() {
-                                    self.buttonMain.turnOff();
-                                    self.trigger('end');
-                                });
-                        }
-                    });
+                    // Attach start/end listeners only to item level highlighter
+                    const instance = highlighters.getItemHighlighter();
+
+                    if (instance.isEnabled()) {
+                        instance
+                            .on('start', function() {
+                                self.buttonMain.turnOn();
+                                self.trigger('start');
+                                hasHighlights = true;
+                            })
+                            .on('end', function() {
+                                self.buttonMain.turnOff();
+                                self.trigger('end');
+                            });
+                    }
                 })
                 .after('clear.highlighter', function() {
                     saveAll();
@@ -334,7 +334,7 @@ export default pluginFactory({
                         _.forEach(highlighters.getAllHighlighters(), function(instance) {
                             if (instance.isEnabled()) {
                                 instance
-                                    .off('end.save')
+                                    .off('end.save end start')
                                     .toggleHighlighting(false)
                                     .disable();
                             }


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-9576
 
Remove `end` and `start` event handlers from highlighters after item unload. Handle `end` and `start` events only on item level highlighter
  
#### How to test
- Prepare an instance of tao with `taoAct` extension
- Prepare an item with shared stimulus
- Create a test with multiple accuracies of the item and create a delivery
- Execute test as a test taker
- Make sure that after navigation between test items, when you start to use highlighter tool start and end events triggered only once
- Make sure that `start` and `end` events of shared stimulus level highlighters does not handled
 
