### PR TITLE
fix/TAO-9730/build jumpTable in proxy init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/navigator/offlineNavigator.js
+++ b/src/navigator/offlineNavigator.js
@@ -65,7 +65,7 @@ export default function offlineNavigatorFactory(itemStore, responseStore) {
 
         /**
          * Initialization method for the offline navigator component
-         * It get called before every navigation action
+         * It get called in proxy init function 
          *
          * @returns {Promise}
          */

--- a/src/navigator/offlineNavigator.js
+++ b/src/navigator/offlineNavigator.js
@@ -67,12 +67,11 @@ export default function offlineNavigatorFactory(itemStore, responseStore) {
          * Initialization method for the offline navigator component
          * It get called before every navigation action
          *
-         * @returns {this}
+         * @returns {Promise}
          */
         init: function init() {
             offlineJumpTableHelper.setTestMap(testMap);
-            offlineJumpTableHelper.init(testContext);
-            return this;
+            return offlineJumpTableHelper.init(testContext);
         },
 
         /**

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -418,11 +418,7 @@ export default _.defaults(
                             .setTestMap(response.testMap)
                             .init()
                     })
-                    .then(function() {
-                        return new Promise(function(resolve) {
-                            resolve(response);
-                        });
-                    });
+                    .then(() => response);
             });
         },
 

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -134,6 +134,7 @@ export default _.defaults(
                      * performs navigation trough items of given test parameters according to action parameters
                      * doesent need active internet connection
                      * @param navigator - navigator helper used with this proxy
+                     * @param {Object} options - options to manage the navigation
                      * @param {Object} options.testContext - current test testContext dataset
                      * @param {Object} results - navigtion result output object
                      */

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -137,10 +137,12 @@ export default _.defaults(
                      * @param {Object} options.testContext - current test testContext dataset
                      * @param {Object} results - navigtion result output object
                      */
-                    var navigate = function(navigator, results) {
+                    var navigate = function(navigator, options, results) {
                         var newTestContext;
 
                         navigator
+                            .setTestContext(options.testContext)	
+                            .setTestMap(options.testMap)
                             .navigate(actionParams.direction, actionParams.scope, actionParams.ref, actionParams)
                             .then(function(res) {
                                 newTestContext = res;
@@ -216,6 +218,10 @@ export default _.defaults(
                         if (isOffline) {
                             navigate(
                                 self.offlineNavigator,
+                                {	
+                                    testContext: testContext,	
+                                    testMap: testMap	
+                                },
                                 result
                             );
                         } else {
@@ -224,6 +230,10 @@ export default _.defaults(
                                 .then(function() {
                                     navigate(
                                         self.offlineNavigator,
+                                        {	
+                                            testContext: testContext,	
+                                            testMap: testMap	
+                                        },
                                         result
                                     );
                                 })

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -134,17 +134,13 @@ export default _.defaults(
                      * performs navigation trough items of given test parameters according to action parameters
                      * doesent need active internet connection
                      * @param navigator - navigator helper used with this proxy
-                     * @param {Object} options - options to manage the navigation
                      * @param {Object} options.testContext - current test testContext dataset
                      * @param {Object} results - navigtion result output object
                      */
-                    var navigate = function(navigator, options, results) {
+                    var navigate = function(navigator, results) {
                         var newTestContext;
 
                         navigator
-                            .setTestContext(options.testContext)
-                            .setTestMap(options.testMap)
-                            .init()
                             .navigate(actionParams.direction, actionParams.scope, actionParams.ref, actionParams)
                             .then(function(res) {
                                 newTestContext = res;
@@ -220,10 +216,6 @@ export default _.defaults(
                         if (isOffline) {
                             navigate(
                                 self.offlineNavigator,
-                                {
-                                    testContext: testContext,
-                                    testMap: testMap
-                                },
                                 result
                             );
                         } else {
@@ -232,10 +224,6 @@ export default _.defaults(
                                 .then(function() {
                                     navigate(
                                         self.offlineNavigator,
-                                        {
-                                            testContext: testContext,
-                                            testMap: testMap
-                                        },
                                         result
                                     );
                                 })
@@ -423,11 +411,18 @@ export default _.defaults(
                     promises.push(self.itemStore.set(itemIdentifier, item));
                 });
 
-                return Promise.all(promises).then(function() {
-                    return new Promise(function(resolve) {
-                        resolve(response);
+                return Promise.all(promises)
+                    .then(() => {
+                        return self.offlineNavigator
+                            .setTestContext(response.testContext)
+                            .setTestMap(response.testMap)
+                            .init()
+                    })
+                    .then(function() {
+                        return new Promise(function(resolve) {
+                            resolve(response);
+                        });
                     });
-                });
             });
         },
 

--- a/src/services/offlineJumpTable.js
+++ b/src/services/offlineJumpTable.js
@@ -143,8 +143,10 @@ var offlineJumpTableFactory = function offlineJumpTableFactory(itemStore, respon
             const contextItemPosition = contextItemId ? testContext.itemPosition : null;
 
             const firstJumpItem = simplifiedTestMap[0];
-            this.addJump(firstJumpItem.part, firstJumpItem.section, firstJumpItem.item);
-
+            if (firstJumpItem) {
+                this.addJump(firstJumpItem.part, firstJumpItem.section, firstJumpItem.item);
+            }
+            
             if (!contextItemPosition) {
                 return Promise.resolve();
             }

--- a/src/services/offlineJumpTable.js
+++ b/src/services/offlineJumpTable.js
@@ -131,49 +131,52 @@ var offlineJumpTableFactory = function offlineJumpTableFactory(itemStore, respon
         },
 
         /**
-         * Initialization method for the offline jump table, which is responsible to add the first item as the first
-         * jump and collect the correct responses for the branching rules.
-         * @param {Object} [testContext] - current test context is needed in order to continue test after interruption
+         * Build jumpTable
+         *
+         * @param {Object} testContext
+         * @returns {Promise}
          */
-        init: function init(testContext) {
-            var firstItem;
-            var simplifiedTestMap = getSimplifiedTestMap(testMap);
-            var self = this;
-            var contextItemId = testContext ? testContext.itemIdentifier : null;
-            var contextItemPosition = contextItemId ? testContext.itemPosition : null;
-            var reducedTestMap = [];
-            var isTestMapResuced = false;
+        buildJumpTable: function buildJumpTable(testContext) {
+            const self = this;
+            const simplifiedTestMap = getSimplifiedTestMap(testMap);
+            const contextItemId = testContext ? testContext.itemIdentifier : null;
+            const contextItemPosition = contextItemId ? testContext.itemPosition : null;
 
-            // reducer to filter out all test items before current
-            var testMapReducer = function testMapReducer(accumulator, current) {
-                if (!isTestMapResuced) {
-                    accumulator.push(current);
-                    if (current.item === contextItemId) {
-                        isTestMapResuced = true;
-                    }
-                }
-                return accumulator;
-            };
+            const firstJumpItem = simplifiedTestMap[0];
+            this.addJump(firstJumpItem.part, firstJumpItem.section, firstJumpItem.item);
 
-            /**
-             * if the jump table is empty, it adds the first item as the first jump
-             * or put previous from current to jump table. Current item id is taken from test context
-             */
-            if (simplifiedTestMap.length > 0 && jumpTable.length === 0) {
-                if (contextItemId && contextItemPosition) {
-                    reducedTestMap = simplifiedTestMap.reduce(testMapReducer, []);
-                    _.forEach(reducedTestMap, function(item) {
-                        self.addJump(item.part, item.section, item.item);
-                    });
-                } else {
-                    firstItem = simplifiedTestMap[0];
-                    this.addJump(firstItem.part, firstItem.section, firstItem.item);
-                }
+            if (!contextItemPosition) {
+                return Promise.resolve();
             }
 
-            // Put all correct responses to the responseStore
+            function calculateNextJump() {
+                var lastJumpItem = self.getLastJump().item || null;
+                if (contextItemId !== lastJumpItem ) {
+                    return itemStore.get(lastJumpItem).then(function (item) {
+                        const itemResponse = {};
+                        _.forEach(item.itemState, function(state, itemStateIdentifier) {
+                            itemResponse[itemStateIdentifier] = state.response;
+                        });
+                        return self.jumpToNextItem(Object.assign({}, item, {itemResponse, itemDefinition: item.itemIdentifier }))
+                            .then(calculateNextJump);
+                    });
+                }
+                return Promise.resolve();
+            }
+            
+            return calculateNextJump();
+        },
+        /**
+         * Put all correct responses to the responseStore
+         *
+         * @param {Object} testContext
+         * @returns {Promise}
+         */
+        putCorrectResponsesInStore: function putCorrectResponsesInStore() {
+            const simplifiedTestMap = getSimplifiedTestMap(testMap);
+            const promises = [];
             simplifiedTestMap.forEach(function(row) {
-                itemStore
+                promises.push(itemStore
                     .get(row.item)
                     .then(function(item) {
                         if (item) {
@@ -186,8 +189,20 @@ var offlineJumpTableFactory = function offlineJumpTableFactory(itemStore, respon
                     })
                     .catch(function(err) {
                         return Promise.reject(err);
-                    });
+                    }));
             });
+            return Promise.all(promises);
+        },
+
+        /**
+         * Initialization method for the offline jump table, which is responsible to add the first item as the first
+         * jump and collect the correct responses for the branching rules.
+         * @param {Object} [testContext] - current test context is needed in order to continue test after interruption
+         * @returns {Promise}
+         */
+        init: function init(testContext) {
+            return this.putCorrectResponsesInStore()
+                .then(() => this.buildJumpTable(testContext));
         },
 
         /**

--- a/test/navigator/offlineNavigator/test.js
+++ b/test/navigator/offlineNavigator/test.js
@@ -69,12 +69,19 @@ define([
         assert.equal(typeof offlineNavigator['navigate'], 'function');
     });
 
-    QUnit.test('it returns itself after calling the setters or init method', function(assert) {
+    QUnit.test('it returns itself after calling the setters', function(assert) {
         var mockTestMap = { parts: {} };
 
         assert.equal(offlineNavigator['setTestContext'](), offlineNavigator);
         assert.equal(offlineNavigator['setTestMap'](mockTestMap), offlineNavigator);
-        assert.equal(offlineNavigator['init'](), offlineNavigator);
+    });
+
+    QUnit.test('it returns Promise after calling init method', function(assert) {
+        offlineNavigator
+            .setTestMap(mapHelper.createJumpTable(testMapJson))
+            .setTestContext(testContextJson)
+        var promise = offlineNavigator['init']();
+        assert.equal(typeof promise, 'object');
     });
 
     QUnit.cases
@@ -90,17 +97,18 @@ define([
                 .setTestMap(mapHelper.createJumpTable(testMapJson))
                 .setTestContext(testContextJson)
                 .clearJumpTable()
-                .init();
-
-            offlineNavigator.navigate(data.direction, data.scope, null, { itemResponse: {} }).then(function(result) {
-                assert.expect(4);
-
-                assert.equal(typeof result, 'object');
-                assert.equal(result.itemIdentifier, data.expectedItem);
-                assert.equal(result.sectionId, data.expectedSection);
-                assert.equal(result.testPartId, data.expectedPart);
-                done();
-            });
+                .init()
+                .then(() => {
+                    offlineNavigator.navigate(data.direction, data.scope, null, { itemResponse: {} }).then(function(result) {
+                        assert.expect(4);
+        
+                        assert.equal(typeof result, 'object');
+                        assert.equal(result.itemIdentifier, data.expectedItem);
+                        assert.equal(result.sectionId, data.expectedSection);
+                        assert.equal(result.testPartId, data.expectedPart);
+                        done();
+                    });
+                })
         });
 
     QUnit.test('it supports previousItem navigation action', function(assert) {
@@ -110,22 +118,23 @@ define([
             .setTestMap(mapHelper.createJumpTable(testMapJson))
             .setTestContext(testContextJson)
             .clearJumpTable()
-            .init();
-
-        Promise.all([
-            offlineNavigator.navigate('next', 'item', null, { itemResponse: {} }),
-            offlineNavigator.navigate('next', 'item', null, { itemResponse: {} }),
-            offlineNavigator.navigate('previous', 'item', null, { itemResponse: {} })
-        ]).then(function(result) {
-            result = result[2];
-            assert.expect(4);
-
-            assert.equal(typeof result, 'object');
-            assert.equal(result.itemIdentifier, 'Q02');
-            assert.equal(result.sectionId, 'S01');
-            assert.equal(result.testPartId, 'P01');
-            done();
-        });
+            .init()
+            .then(() => {
+                Promise.all([
+                    offlineNavigator.navigate('next', 'item', null, { itemResponse: {} }),
+                    offlineNavigator.navigate('next', 'item', null, { itemResponse: {} }),
+                    offlineNavigator.navigate('previous', 'item', null, { itemResponse: {} })
+                ]).then(function(result) {
+                    result = result[2];
+                    assert.expect(4);
+        
+                    assert.equal(typeof result, 'object');
+                    assert.equal(result.itemIdentifier, 'Q02');
+                    assert.equal(result.sectionId, 'S01');
+                    assert.equal(result.testPartId, 'P01');
+                    done();
+                });
+            });
     });
 
     QUnit.cases


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9730

Previously ` offlineNavigation.init() -> offlineJumpTableHelper.init() ` were called every navigation action
Now only in `offline/proxy init ` function. Then only `navigate` function that added new jumps in table.

For correct jumpTuble in `buildJumpTable` function were done (**have doubts about these steps**):
1.  `itemResponse` made from `itemState`
2.  `itemDefinition: item.itemIdentifier` for correct work `addResponsesToResponseStore`
