### PR TITLE
Fix/tao 9435/wrong remaining time on proctor scr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/duration/duration.js
+++ b/src/plugins/controls/duration/duration.js
@@ -108,7 +108,7 @@ export default pluginFactory({
                     self.enable();
                 })
 
-                .before('move skip exit timeout', function() {
+                .before('move skip exit timeout pause', function() {
                     var context = testRunner.getTestContext();
                     var itemAttemptId = `${context.itemIdentifier}#${context.attempt}`;
 

--- a/src/plugins/controls/testState/testState.js
+++ b/src/plugins/controls/testState/testState.js
@@ -75,9 +75,12 @@ export default pluginFactory({
             ) {
                 isLeaving = true;
 
-                testRunner.setState('closedOrSuspended', true);
-
-                testRunner.trigger('leave', data);
+                if ('pause' === data.type) {
+                    testRunner.trigger('pause', data);
+                } else {
+                    testRunner.setState('closedOrSuspended', true);
+                    testRunner.trigger('leave', data);
+                }
             }
         });
     }


### PR DESCRIPTION
Necessary changes to send current item duration when assessment is paused. 
 
Related to : https://oat-sa.atlassian.net/browse/TAO-9435

On `pause` event adds the `itemDuration` parameters to the request payload.
When `teststate` change event with type `pause` is detected during regular sync, then `pause` event is triggered.
 
#### Steps to reproduce
 - Launch an assessment.
 - Go to timed section.
 - In the assessment that I used max time is 00:55:00
 - On item 1, let the timer run down for a few mins.
 - I paused the test when remaining time was 00:52:20
 - The proctor screen, click pause, select a category, sub-category and add description. Click on OK.
 - Notice that remaining time on proctor screen is now 00:55:00.
  
#### Scenarios to test
 
1) Configure a delivery that requires proctoring and has `Security plugins` enabled. Launch it with test taker, create out of focus event by f.e. navigating to another browser tab or another application. Refresh the delivery execution list on proctor screen, notice that test session remaining time matches the time on the client side.

2) Configure a delivery that requires proctoring. Launch it with test taker. Navigate to proctor screen and pause the test, wait for the client side to detect the pause. Refresh the delivery execution list on proctor screen, notice that test session remaining time is correctly reduced.
  
#### Dependencies
 
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1644