### PR TITLE
TAO-9779 offlineSyncModal hide title message after reconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -73,7 +73,10 @@ function offlineSyncModalFactory(proxy) {
             $secondaryButton = getDialogEl('button[data-control="secondary"]');
             $countdown.insertAfter($secondaryButton);
 
-            proxy.after('reconnect.waiting', () => waitingDialog.endWait());
+            proxy.after('reconnect.waiting', () => {
+                waitingDialog.endWait();
+                hider.hide(getDialogEl('p.message'));
+            });
             proxy.before('disconnect.waiting', () => {
                 // need to open dialog again if it is closed
                 waitingDialog.dialog.show();
@@ -96,6 +99,7 @@ function offlineSyncModalFactory(proxy) {
         })
         .on('wait', () => {
             hider.show(getDialogEl(betweenButtonTextSelector));
+            hider.show(getDialogEl('p.message'));
             // if beginWait comes before render:
             if (waitingDialog.is('rendered')) {
                 waitingDialog.trigger('begincountdown');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9779

How to test:
- set offline mode for test runner 
`php index.php "oat\taoQtiTest\scripts\install\SetOfflineTestRunnerConfig"`
- run test
- go to the last item
- switch off an internet connection
- press End
- see popup
- switch on an internet connection
- see the message in popup (line "You are encountering a prolonged connectivity loss." will be removed)