### PR TITLE
Fix/NFER-3/navigation in menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.4",
+    "version": "0.16.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.2",
+    "version": "0.16.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.6",
+    "version": "0.16.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.6",
+    "version": "0.16.7",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.4",
+    "version": "0.16.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.2",
+    "version": "0.16.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -150,7 +150,8 @@ export default pluginFactory({
                 control: 'color-contrast',
                 title: __('Change the current color preset'),
                 icon: 'contrast',
-                text: __('Contrast')
+                text: __('Contrast'),
+                navType: pluginConfig.navType
             })
             .on('click', function(e) {
                 e.preventDefault();

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -150,8 +150,7 @@ export default pluginFactory({
                 control: 'color-contrast',
                 title: __('Change the current color preset'),
                 icon: 'contrast',
-                text: __('Contrast'),
-                navType: pluginConfig.navType
+                text: __('Contrast')
             })
             .on('click', function(e) {
                 e.preventDefault();
@@ -240,7 +239,10 @@ export default pluginFactory({
                 if (self.getState('enabled') !== false) {
                     self.menuButton.toggleMenu();
                 }
-            });
+            })
+            .on('set-themeswitcher-navtype', function(type) {
+                self.menuButton.setNavigationType(type);
+            })
 
         return testRunner.getPluginStore(this.getName()).then(function(itemThemesStore) {
             self.storage = itemThemesStore;

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -240,7 +240,7 @@ export default pluginFactory({
                     self.menuButton.toggleMenu();
                 }
             })
-            .on('set-themeswitcher-navtype', function(type) {
+            .on('tool-themeswitcher-setnavtype', function(type) {
                 self.menuButton.setNavigationType(type);
             })
 

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -55,6 +55,7 @@ var menuComponentApi = {
      */
     initMenu: function initMenu() {
         this.id = this.config.control;
+        this.type = this.config.navType ? this.config.navType : 'fromLast';
         this.menuItems = [];
     },
 
@@ -124,8 +125,17 @@ var menuComponentApi = {
         // setup keyboard navigation & highlighting
         this.enableShortcuts();
         this.hoverOffAll();
-        this.hoverIndex = this.menuItems.length; // we start on the button, not at the max array index
-        // which would be menuItems.length-1
+        if (this.type === 'fromLast') {
+            // fromLast (default) navigation: focus on button and then using UP go to last item
+            this.hoverIndex = this.menuItems.length; // we start on the button, not at the max array index
+            // which would be menuItems.length-1
+        }
+        if (this.type === 'fromFirst') {
+            // fromFirst navigation: focus on button and then using DOWN go to first item
+            this.hoverIndex = -1; // we start on the button, not the first element
+            // which would be 0
+        }
+       
 
         // focus the button, for keyboard navigation
         if (document.activeElement) {
@@ -282,11 +292,20 @@ var menuComponentApi = {
         this.$menuButton.on('keydown.menuNavigation', function(e) {
             var currentKeyCode = e.keyCode ? e.keyCode : e.charCode;
 
-            if (currentKeyCode === keyCodes.UP) {
-                e.stopPropagation();
-                self.hoverIndex = self.menuItems.length - 1;
+            function setFocusToItem(index) {
+                self.hoverIndex = index;
                 self.$menuContainer.focus();
                 self.hoverItem(self.menuItems[self.hoverIndex].id);
+            }
+
+            if (currentKeyCode === keyCodes.UP && this.type === 'fromLast') {
+                e.stopPropagation();
+                setFocusToItem(self.menuItems.length - 1);
+            }
+
+            if (currentKeyCode === keyCodes.DOWN && this.type === 'fromFirst') {
+                e.stopPropagation();
+                setFocusToItem(0);
             }
         });
     },
@@ -306,6 +325,12 @@ var menuComponentApi = {
         if (this.hoverIndex > 0) {
             this.hoverIndex--;
             this.hoverItem(this.menuItems[this.hoverIndex].id);
+            // move to the menu button
+        } else if (this.hoverIndex === 0  && this.type === 'fromFirst') {
+            this.hoverIndex--;
+            this.hoverOffAll();
+            this.$menuButton.closest('.action').focus();
+            this.closeMenu();
         }
     },
 
@@ -319,7 +344,7 @@ var menuComponentApi = {
             this.hoverItem(this.menuItems[this.hoverIndex].id);
 
             // move to the menu button
-        } else if (this.hoverIndex === this.menuItems.length - 1) {
+        } else if (this.hoverIndex === this.menuItems.length - 1 && this.type === 'fromLast') {
             this.hoverIndex++;
             this.hoverOffAll();
             this.$menuButton.closest('.action').focus();

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -27,6 +27,16 @@
  *      icon: 'icon',
  *      text: __('Displayed label')
  * });
+ * Optional config navType - navigation type 
+ * navType: 'fromLast' (default behavior) - focus on button (if no active item) and then using UP go to last item, when press DOWN at last item menu will be closed,
+ * navType: 'fromFirst' - focus on button (if no active item) and then using DOWN go to first item, when press UP at first item menu will be closed
+ * toolbox.createMenu({
+ *      control: 'menu-id',
+ *      title: __('Html title'),
+ *      icon: 'icon',
+ *      text: __('Displayed label'),
+ *      navType: 'fromFirst'
+ * });
  *
  * @author Christophe Noël <christophe@taotesting.com>
  */
@@ -55,7 +65,7 @@ var menuComponentApi = {
      */
     initMenu: function initMenu() {
         this.id = this.config.control;
-        this.typeNav = this.config.navType ? this.config.navType : 'fromLast';
+        this.navType = this.config.navType ? this.config.navType : 'fromLast';
         this.menuItems = [];
     },
 
@@ -134,13 +144,13 @@ var menuComponentApi = {
             this.$menuContainer.focus();
             this.hoverItem(this.menuItems[activeItemIndex].id);
         }
-        else if (this.typeNav === 'fromLast') {
+        else if (this.navType === 'fromLast') {
             // fromLast (default) navigation: focus on button and then using UP go to last item
             this.hoverIndex = this.menuItems.length; // we start on the button, not at the max array index
             // which would be menuItems.length-1
             this.$menuButton.focus();
         }
-        else if (this.typeNav === 'fromFirst') {
+        else if (this.navType === 'fromFirst') {
             // fromFirst navigation: focus on button and then using DOWN go to first item
             this.hoverIndex = -1; // we start on the button, not the first element
             // which would be 0
@@ -306,12 +316,12 @@ var menuComponentApi = {
                 self.hoverItem(self.menuItems[self.hoverIndex].id);
             }
 
-            if (currentKeyCode === keyCodes.UP && self.typeNav === 'fromLast') {
+            if (currentKeyCode === keyCodes.UP && self.navType === 'fromLast') {
                 e.stopPropagation();
                 setFocusToItem(self.menuItems.length - 1);
             }
 
-            if (currentKeyCode === keyCodes.DOWN && self.typeNav === 'fromFirst') {
+            if (currentKeyCode === keyCodes.DOWN && self.navType === 'fromFirst') {
                 e.stopPropagation();
                 setFocusToItem(0);
             }
@@ -334,7 +344,7 @@ var menuComponentApi = {
             this.hoverIndex--;
             this.hoverItem(this.menuItems[this.hoverIndex].id);
             // move to the menu button
-        } else if (this.hoverIndex === 0  && this.typeNav === 'fromFirst') {
+        } else if (this.hoverIndex === 0  && this.navType === 'fromFirst') {
             this.hoverIndex--;
             this.hoverOffAll();
             this.$menuButton.closest('.action').focus();
@@ -352,7 +362,7 @@ var menuComponentApi = {
             this.hoverItem(this.menuItems[this.hoverIndex].id);
 
             // move to the menu button
-        } else if (this.hoverIndex === this.menuItems.length - 1 && this.typeNav === 'fromLast') {
+        } else if (this.hoverIndex === this.menuItems.length - 1 && this.navType === 'fromLast') {
             this.hoverIndex++;
             this.hoverOffAll();
             this.$menuButton.closest('.action').focus();
@@ -405,9 +415,9 @@ var menuComponentApi = {
      * Set navigation type
      * @param {String} type - 'fromLast', 'fromFirst'
      */
-    setNavigationType: function setItemNavigation(type) {
+    setNavigationType: function setNavigationType(type) {
         if (_.contains(['fromLast', 'fromFirst'], type)) {
-            this.typeNav = type;
+            this.navType = type;
         }
     }
 };

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -126,7 +126,7 @@ var menuComponentApi = {
         this.enableShortcuts();
         this.hoverOffAll();
         const activeItemIndex = _.findIndex(this.menuItems, item => item.is('active'));
-        if (activeItemIndex !== undefined) {
+        if (activeItemIndex >= 0) {
             this.hoverIndex = activeItemIndex;
             this.hoverItem(this.menuItems[activeItemIndex].id);
         }

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -27,7 +27,7 @@
  *      icon: 'icon',
  *      text: __('Displayed label')
  * });
- * Optional config navType - navigation type 
+ * Optional setting: navType - navigation type 
  * navType: 'fromLast' (default behavior) - focus on button (if no active item) and then using UP go to last item, when press DOWN at last item menu will be closed,
  * navType: 'fromFirst' - focus on button (if no active item) and then using DOWN go to first item, when press UP at first item menu will be closed
  * toolbox.createMenu({
@@ -416,7 +416,7 @@ var menuComponentApi = {
      * @param {String} type - 'fromLast', 'fromFirst'
      */
     setNavigationType: function setNavigationType(type) {
-        if (_.contains(['fromLast', 'fromFirst'], type)) {
+        if (['fromLast', 'fromFirst'].includes(type)) {
             this.navType = type;
         }
     }

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -125,28 +125,31 @@ var menuComponentApi = {
         // setup keyboard navigation & highlighting
         this.enableShortcuts();
         this.hoverOffAll();
+        if (document.activeElement) {
+            document.activeElement.blur();
+        }
         const activeItemIndex = _.findIndex(this.menuItems, item => item.is('active'));
         if (activeItemIndex >= 0) {
             this.hoverIndex = activeItemIndex;
+            this.$menuContainer.focus();
             this.hoverItem(this.menuItems[activeItemIndex].id);
         }
         else if (this.typeNav === 'fromLast') {
             // fromLast (default) navigation: focus on button and then using UP go to last item
             this.hoverIndex = this.menuItems.length; // we start on the button, not at the max array index
             // which would be menuItems.length-1
+            this.$menuButton.focus();
         }
         else if (this.typeNav === 'fromFirst') {
             // fromFirst navigation: focus on button and then using DOWN go to first item
             this.hoverIndex = -1; // we start on the button, not the first element
             // which would be 0
+            this.$menuButton.focus();
         }
        
 
-        // focus the button, for keyboard navigation
-        if (document.activeElement) {
-            document.activeElement.blur();
-        }
-        this.$menuContainer.focus();
+
+        
 
         // component inner state
         this.setState('opened', true);
@@ -303,12 +306,12 @@ var menuComponentApi = {
                 self.hoverItem(self.menuItems[self.hoverIndex].id);
             }
 
-            if (currentKeyCode === keyCodes.UP && this.typeNav === 'fromLast') {
+            if (currentKeyCode === keyCodes.UP && self.typeNav === 'fromLast') {
                 e.stopPropagation();
                 setFocusToItem(self.menuItems.length - 1);
             }
 
-            if (currentKeyCode === keyCodes.DOWN && this.typeNav === 'fromFirst') {
+            if (currentKeyCode === keyCodes.DOWN && self.typeNav === 'fromFirst') {
                 e.stopPropagation();
                 setFocusToItem(0);
             }

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -55,7 +55,7 @@ var menuComponentApi = {
      */
     initMenu: function initMenu() {
         this.id = this.config.control;
-        this.type = this.config.navType ? this.config.navType : 'fromLast';
+        this.typeNav = this.config.navType ? this.config.navType : 'fromLast';
         this.menuItems = [];
     },
 
@@ -126,15 +126,16 @@ var menuComponentApi = {
         this.enableShortcuts();
         this.hoverOffAll();
         const activeItemIndex = _.findIndex(this.menuItems, item => item.is('active'));
-        if (activeItemIndex) {
+        if (activeItemIndex !== undefined) {
             this.hoverIndex = activeItemIndex;
+            this.hoverItem(this.menuItems[activeItemIndex].id);
         }
-        else if (this.type === 'fromLast') {
+        else if (this.typeNav === 'fromLast') {
             // fromLast (default) navigation: focus on button and then using UP go to last item
             this.hoverIndex = this.menuItems.length; // we start on the button, not at the max array index
             // which would be menuItems.length-1
         }
-        else if (this.type === 'fromFirst') {
+        else if (this.typeNav === 'fromFirst') {
             // fromFirst navigation: focus on button and then using DOWN go to first item
             this.hoverIndex = -1; // we start on the button, not the first element
             // which would be 0
@@ -302,12 +303,12 @@ var menuComponentApi = {
                 self.hoverItem(self.menuItems[self.hoverIndex].id);
             }
 
-            if (currentKeyCode === keyCodes.UP && this.type === 'fromLast') {
+            if (currentKeyCode === keyCodes.UP && this.typeNav === 'fromLast') {
                 e.stopPropagation();
                 setFocusToItem(self.menuItems.length - 1);
             }
 
-            if (currentKeyCode === keyCodes.DOWN && this.type === 'fromFirst') {
+            if (currentKeyCode === keyCodes.DOWN && this.typeNav === 'fromFirst') {
                 e.stopPropagation();
                 setFocusToItem(0);
             }
@@ -330,7 +331,7 @@ var menuComponentApi = {
             this.hoverIndex--;
             this.hoverItem(this.menuItems[this.hoverIndex].id);
             // move to the menu button
-        } else if (this.hoverIndex === 0  && this.type === 'fromFirst') {
+        } else if (this.hoverIndex === 0  && this.typeNav === 'fromFirst') {
             this.hoverIndex--;
             this.hoverOffAll();
             this.$menuButton.closest('.action').focus();
@@ -348,7 +349,7 @@ var menuComponentApi = {
             this.hoverItem(this.menuItems[this.hoverIndex].id);
 
             // move to the menu button
-        } else if (this.hoverIndex === this.menuItems.length - 1 && this.type === 'fromLast') {
+        } else if (this.hoverIndex === this.menuItems.length - 1 && this.typeNav === 'fromLast') {
             this.hoverIndex++;
             this.hoverOffAll();
             this.$menuButton.closest('.action').focus();
@@ -394,6 +395,16 @@ var menuComponentApi = {
             if (document.activeElement) {
                 document.activeElement.blur();
             }
+        }
+    },
+
+    /**
+     * Set navigation type
+     * @param {String} type - 'fromLast', 'fromFirst'
+     */
+    setNavigationType: function setItemNavigation(type) {
+        if (_.contains(['fromLast', 'fromFirst'], type)) {
+            this.typeNav = type;
         }
     }
 };

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -125,12 +125,16 @@ var menuComponentApi = {
         // setup keyboard navigation & highlighting
         this.enableShortcuts();
         this.hoverOffAll();
-        if (this.type === 'fromLast') {
+        const activeItemIndex = _.findIndex(this.menuItems, item => item.is('active'));
+        if (activeItemIndex) {
+            this.hoverIndex = activeItemIndex;
+        }
+        else if (this.type === 'fromLast') {
             // fromLast (default) navigation: focus on button and then using UP go to last item
             this.hoverIndex = this.menuItems.length; // we start on the button, not at the max array index
             // which would be menuItems.length-1
         }
-        if (this.type === 'fromFirst') {
+        else if (this.type === 'fromFirst') {
             // fromFirst navigation: focus on button and then using DOWN go to first item
             this.hoverIndex = -1; // we start on the button, not the first element
             // which would be 0


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NFER-3

Added option in menu config `navType` : by default `'fromLast'`, also `'fromFirst'`
In case of the menu have `active` item - hoverIndex will be set on it
In case of the menu doesn't have`active` item:
for `navType: 'fromLast'` - focus on button and then using UP go to last item, when press DOWN on last item menu will be closed,
for `navType: 'fromFirst'` - focus on button and then using DOWN go to first item, when press UP on first item menu will be closed

Related PR: https://github.com/oat-sa/extension-tao-nfer/pull/169