### PR TITLE
Fix/nec 52/fix allow partial warning message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.3",
+    "version": "0.16.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/allowSkipping.js
+++ b/src/plugins/navigation/allowSkipping.js
@@ -70,8 +70,8 @@ export default pluginFactory({
             const testContext = testRunner.getTestContext();
             const isInteracting = !testRunner.getItemState(testContext.itemIdentifier, 'disabled');
             const warning = pluginConfig.allowPartial
-                ? __('A response to every question in this item is required.')
-                : __('A response to this item is required.');
+                ? __('A response to this item is required.')
+                : __('A response to every question in this item is required.');
 
 
             if (isInteracting && testRunnerOptions.enableAllowSkipping) {

--- a/test/plugins/navigation/allowSkipping/test.js
+++ b/test/plugins/navigation/allowSkipping/test.js
@@ -257,7 +257,7 @@ define([
                     runner.off('alert.notallowed').on('alert.notallowed', function(message, cb) {
                         assert.equal(
                             message,
-                            'A response to every question in this item is required.',
+                            'A response to this item is required.',
                             'The user receive the correct message'
                         );
                         cb();


### PR DESCRIPTION
**Related to task:** 
https://oat-sa.atlassian.net/browse/NEC-52

**Description:**
Wrong message when presenting warning message about skipping an item with partial responses.

**How to test:**
Use 1 of the tests from NASA (3-4 grade, 5-7 grade or 8-10 grade) 
Take a test and go to the last 2 items

**Unit tests cli:**
`npm run test`