### PR TITLE
NFER-31 Connectivity plugin add message near icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.7",
+    "version": "0.17.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.16.7",
+    "version": "0.17.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_connectivity.scss
+++ b/scss/inc/_connectivity.scss
@@ -2,6 +2,9 @@
     display: none;
     width: 40px;
     margin-left: 40px;
+    &.with-message {
+        width: 60px; 
+    }
     .icon-connect, .icon-disconnect {
         display: none;
         line-height: 2;
@@ -10,8 +13,9 @@
     }
     .message-connect, .message-disconnected {
         display: none;
-        @include font-size(16);
+        @include font-size(14);
         text-shadow: none;
+        margin-right: 3px;
     }
     &.connected, &.disconnected {
         display: inline-block;

--- a/scss/inc/_connectivity.scss
+++ b/scss/inc/_connectivity.scss
@@ -8,16 +8,22 @@
         @include font-size(16);
         text-shadow: 0 1px 0 black(.9);
     }
+    .message-connect, .message-disconnected {
+        display: none;
+        @include font-size(16);
+        text-shadow: none;
+    }
     &.connected, &.disconnected {
         display: inline-block;
     }
     &.connected {
-        .icon-connect {
+        .icon-connect, .message-connect {
             display: inline-block;
         }
+        
     }
     &.disconnected {
-        .icon-disconnect {
+        .icon-disconnect, .message-disconnected  {
             display: inline-block;
         }
     }

--- a/src/plugins/controls/connectivity/connectivity.js
+++ b/src/plugins/controls/connectivity/connectivity.js
@@ -35,7 +35,8 @@ import connectivityTpl from 'taoQtiTest/runner/plugins/controls/connectivity/con
  */
 var defaultConfig = {
     checkInterval: 30 * 1000,
-    indicator: true
+    indicator: true,
+    message: false
 };
 
 /**
@@ -59,7 +60,8 @@ export default pluginFactory({
             //create the indicator
             this.$element = $(
                 connectivityTpl({
-                    state: proxy.isOnline() ? 'connected' : 'disconnected'
+                    state: proxy.isOnline() ? 'connected' : 'disconnected',
+                    message: config.message
                 })
             );
 

--- a/src/plugins/controls/connectivity/connectivity.js
+++ b/src/plugins/controls/connectivity/connectivity.js
@@ -32,6 +32,7 @@ import connectivityTpl from 'taoQtiTest/runner/plugins/controls/connectivity/con
  * @type {Object}
  * @property {Number} checkInterval - when offline, interval to check if we're back online
  * @property {Boolean} indicator - do we display the indicator in the test UI
+ * @property {Boolean} message - do we display the message in the test UI
  */
 var defaultConfig = {
     checkInterval: 30 * 1000,

--- a/src/plugins/controls/connectivity/connectivity.tpl
+++ b/src/plugins/controls/connectivity/connectivity.tpl
@@ -1,4 +1,4 @@
 <div class="connectivity-box {{state}}">
-    <span data-control="connectivity-connected" class="qti-controls icon-connect" title="{{__ 'Connected to server'}}"></span>
-    <span data-control="connectivity-disconnected" class="qti-controls icon-disconnect" title="{{__ 'Disconnected from server'}}"></span>
+    <span class="message-connect">{{#if message}}{{__ 'Online'}}{{/if}}</span><span data-control="connectivity-connected" class="qti-controls icon-connect" title="{{__ 'Connected to server'}}"></span>
+    <span class="message-disconnected">{{#if message}}{{__ 'Offline'}}{{/if}}</span><span data-control="connectivity-disconnected" class="qti-controls icon-disconnect" title="{{__ 'Disconnected from server'}}"></span>
 </div>

--- a/src/plugins/controls/connectivity/connectivity.tpl
+++ b/src/plugins/controls/connectivity/connectivity.tpl
@@ -1,4 +1,4 @@
-<div class="connectivity-box {{state}}">
+<div class="connectivity-box {{state}}{{#if message}} with-message{{/if}}">
     <span class="message-connect">{{#if message}}{{__ 'Online'}}{{/if}}</span><span data-control="connectivity-connected" class="qti-controls icon-connect" title="{{__ 'Connected to server'}}"></span>
     <span class="message-disconnected">{{#if message}}{{__ 'Offline'}}{{/if}}</span><span data-control="connectivity-disconnected" class="qti-controls icon-disconnect" title="{{__ 'Disconnected from server'}}"></span>
 </div>

--- a/src/plugins/controls/connectivity/connectivity.tpl
+++ b/src/plugins/controls/connectivity/connectivity.tpl
@@ -1,4 +1,4 @@
 <div class="connectivity-box {{state}}{{#if message}} with-message{{/if}}">
-    <span class="message-connect">{{#if message}}{{__ 'Online'}}{{/if}}</span><span data-control="connectivity-connected" class="qti-controls icon-connect" title="{{__ 'Connected to server'}}"></span>
-    <span class="message-disconnected">{{#if message}}{{__ 'Offline'}}{{/if}}</span><span data-control="connectivity-disconnected" class="qti-controls icon-disconnect" title="{{__ 'Disconnected from server'}}"></span>
+    {{#if message}}<span class="message-connect">{{__ 'Online'}}</span>{{/if}}<span data-control="connectivity-connected" class="qti-controls icon-connect" title="{{__ 'Connected to server'}}"></span>
+    {{#if message}}<span class="message-disconnected">{{__ 'Offline'}}</span>{{/if}}<span data-control="connectivity-disconnected" class="qti-controls icon-disconnect" title="{{__ 'Disconnected from server'}}"></span>
 </div>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NFER-31

Message (Online, Offline) was added near icon in the connectivity plugin
Can be set by configs, by default `message: false`
![image](https://user-images.githubusercontent.com/25976342/73837643-f08bc080-4822-11ea-84d4-27abdf4ee6ef.png)
![image](https://user-images.githubusercontent.com/25976342/73837716-13b67000-4823-11ea-85fa-4a5de3044d9a.png)

How to test: 

- enable the connectivity plugin `config/taoTests/test_runner_plugin_registry.conf.php`
- set in `config/taoQtiTest/testRunner.conf.php` in section `plugins` 
`            'connectivity' => array(
                'message' => true
            )`
