### PR TITLE
End test warning msg displays incorrect no. of questions flagged for …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.17.1",
+    "version": "0.17.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "0.17.1",
+    "version": "0.17.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -304,10 +304,10 @@ export default {
                 }
 
                 // Calculate all unanswered and flagged questions in inaccessible parts
-                const actualParts = parts.slice(linearPartIndex);
-                const countOfInaccessibleUnasweredQestions = actualParts
+                const inaccessibleParts = parts.slice(linearPartIndex);
+                const countOfInaccessibleUnasweredQestions = inaccessibleParts
                     .reduce((acc, {stats: { questions, answered }}) => acc + (questions - answered), 0);
-                const countOfInaccessibleFlaggedQestions = actualParts
+                const countOfInaccessibleFlaggedQestions = inaccessibleParts
                     .reduce((acc, {stats: { flagged }}) => acc + flagged, 0);
                 return Object.assign(
                     {},

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -303,15 +303,19 @@ export default {
                     return testStats;
                 }
 
-                // Calculate all unanswered questions in inaccessible parts
-                const countOfInaccessibleUnasweredQestions = parts
-                    .slice(linearPartIndex)
+                // Calculate all unanswered and flagged questions in inaccessible parts
+                const actualParts = parts.slice(linearPartIndex);
+                const countOfInaccessibleUnasweredQestions = actualParts
                     .reduce((acc, {stats: { questions, answered }}) => acc + (questions - answered), 0);
-
+                const countOfInaccessibleFlaggedQestions = actualParts
+                    .reduce((acc, {stats: { flagged }}) => acc + flagged, 0);
                 return Object.assign(
                     {},
                     testStats,
-                    { answered: testStats.answered + countOfInaccessibleUnasweredQestions }
+                    {
+                        answered: testStats.answered + countOfInaccessibleUnasweredQestions,
+                        flagged: testStats.flagged - countOfInaccessibleFlaggedQestions
+                    }
                 );
             }
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/ACTP-219

Fix a number of flagged items when the test-taker leaves the test with items that flagged in inaccessible (previous sections) flagged items.

#### How to test:
- import the test attached to the task
- flag the item in any section
- switch to another section
- flag yet another item
- try to leave the test
- check the number of flagged items in the warning pop-up
