### PR TITLE
Fix/ACTP-297/Bundling issue after having renamed a module

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -19,6 +19,7 @@
 import path from 'path';
 import glob from 'glob-promise';
 import alias from 'rollup-plugin-alias';
+import clear from 'rollup-plugin-clear';
 import handlebarsPlugin from 'rollup-plugin-handlebars-plus';
 import cssResolve from './css-resolve';
 import wildcardExternal from '@oat-sa/rollup-plugin-wildcard-external';
@@ -87,6 +88,10 @@ export default inputs.map(input => {
             'layout/loading-bar'
         ],
         plugins: [
+            clear({
+                targets: [outputDir],
+                watch: false
+            }),
             cssResolve(),
             wildcardExternal(['core/**', 'ui/**', 'util/**', 'lib/**', 'taoTests/**', 'taoItems/**', 'taoQtiItem/**']),
             alias({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4945,6 +4945,15 @@
                 "rollup-pluginutils": "^2.8.1"
             }
         },
+        "rollup-plugin-clear": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-clear/-/rollup-plugin-clear-2.0.7.tgz",
+            "integrity": "sha512-Hg8NC3JcJBO1ofgyQC0IACpyKn/yhHPGZ3C7R3ubNGWUXy9JXHQrewk4J4hVcZznw6SOKayLsaNae596Rwt8Vg==",
+            "dev": true,
+            "requires": {
+                "rimraf": "^2.6.2"
+            }
+        },
         "rollup-plugin-handlebars-plus": {
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/rollup-plugin-handlebars-plus/-/rollup-plugin-handlebars-plus-0.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "rollup": "^1.16.7",
         "rollup-plugin-alias": "^1.5.2",
         "rollup-plugin-babel": "^4.3.3",
+        "rollup-plugin-clear": "^2.0.7",
         "rollup-plugin-handlebars-plus": "^0.2.4",
         "rollup-plugin-istanbul": "^2.0.1",
         "select2": "3.5.1",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/ACTP-297

The last published version (at least the `1.2.0`) contains a ghost module (`keyNavigation.js` has been moved).

This PR is adding a clean up of the dist folder before building the sources.

How to test:
- install the package: `npm i`
- add a dummy file into the dist folder: `touch dist/foo.js`
- build the sources: `npm run build`
- check if the dummy file is still there in the dist folder
