### PR TITLE
Release 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4668,7 +4668,7 @@
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -74,6 +74,14 @@
     }
     .test-sidebar-left {
         border-right: 1px $uiGeneralContentBorder solid;
+
+        .landmark-title--hidden {
+            position: absolute;
+            overflow: hidden;
+            height: 1px;
+            width: 1px;
+            word-wrap: normal;
+        }
     }
 
     .test-sidebar-right {

--- a/src/provider/layout.tpl
+++ b/src/provider/layout.tpl
@@ -5,7 +5,9 @@
 
     <div class="test-runner-sections">
 
-        <aside class="test-sidebar test-sidebar-left"></aside>
+        <aside class="test-sidebar test-sidebar-left" aria-labelledby="test-sidebar-left-header">
+            <h2 id="test-sidebar-left-header" class="landmark-title--hidden">{{__ 'Test status and review structure'}}</h2>
+        </aside>
 
         <section class="content-wrapper">
             <div id="qti-content"></div>


### PR DESCRIPTION
**Jira ticket**
https://oat-sa.atlassian.net/browse/ACTP-303

**Description**
The test status and review structure landmark/region should have a heading as well as having further headings to describe the two sub-regions. Most often, screen reader users do not screen the page for regions/landmarks but for headings. Without headings, a blind person may miss crucial information.

“Test status” should be an h3 heading. We should introduce another invisible heading h3 with the label “review structure”.

**How to test**
1. Create a test.
2. Start a test as a testtacker.
3. Enable screenreader.
4. Test status and review structure heading should be reachable for screenreaders.

**Companion PR**
https://github.com/oat-sa/tao-test-runner-qti-fe/pull/148