### PR TITLE
BOSA 72 - The modal feedback window can't be closed by clicking on the exit button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4668,7 +4668,7 @@
             "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -120,6 +120,8 @@
         max-width: map-get($widths, item-max-width) * 1px;
         width: 100%;
         margin: auto;
+        position: absolute;
+        z-index: 1;
     }
 
     #qti-item {


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/BOSA-72

**Description**

While passing the delivery, the TT can't close the modal feedback window by a simple click on the exit button due to the button's inactivity. It's possible only with pressing the ESC button.

Preconditions:
Delivery with the modal feedback function activated inside the item;

STR:
1. Log in as a guest and choose the proper delivery;
2. Answer the item which has modal feedback activated inside;
3. Press the Next button

Actual result: 
1. The guest can choose the necessary delivery for the list;
2. The answer is given;
3. After clicking the button, the TT is shown the modal window which is impossible to close by the exit button. He can do it only by pressing the Esc button and move further.

Expected result: The modal feedback window can be closed both ways (Esc button on th keyboard and the Exit button on the window itself)

**Environment**

Env- demo
Platform - Windows 10
Browsers- All