### PR TITLE
BSA-72: Fix qti-content alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -120,7 +120,7 @@
         max-width: map-get($widths, item-max-width) * 1px;
         width: 100%;
         margin: auto;
-        position: absolute;
+        position: relative;
         z-index: 1;
     }
 


### PR DESCRIPTION
BSA-72 fix: align `qti-content` by putting it back into the render flow, applying `position: relative`