### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.3.3",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "1.3.3",
+    "version": "2.0.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",
@@ -50,7 +50,7 @@
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.3.0",
         "@oat-sa/tao-core-sdk": "^0.8.1",
-        "@oat-sa/tao-core-ui": "^0.26.0",
+        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#breaking/ACTP-429/keynavigation-issue-in-native-mode",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-item-runner-qti": "^0.3.2",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/src/plugins/content/accessibility/keyNavigation/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/keyNavigation.js
@@ -21,7 +21,6 @@
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 import keyNavigator from 'ui/keyNavigation/navigator';
-import navigableGroupElement from 'ui/keyNavigation/navigableGroupElement';
 import {
     allowedToNavigateFrom,
     setupItemsNavigator,
@@ -70,11 +69,8 @@ export default function keyNavigationFactory(testRunner, config = {}) {
 
             groupNavigator = keyNavigator({
                 id: 'test-runner',
-                replace: true,
                 loop: true,
-                elements: navigableGroupElement.createFromNavigators(navigators),
-                // we don't need to propagate tabs for the main navigation, because we've rewritten them and this is not an element
-                // there is an issue with nested navigators
+                elements: navigators,
                 propagateTab: navigationConfig.propagateTab
             });
 
@@ -89,7 +85,7 @@ export default function keyNavigationFactory(testRunner, config = {}) {
                         .on('lowerbound', () => {
                             if (allowedToNavigateFrom(navigator)) {
                                 groupNavigator.previous();
-                                groupNavigator.getCursor().navigable.getKeyNavigator().last();
+                                groupNavigator.getCursor().navigable.last();
                             }
                         });
                 });

--- a/src/plugins/content/accessibility/keyNavigation/modes/nativeMode.js
+++ b/src/plugins/content/accessibility/keyNavigation/modes/nativeMode.js
@@ -30,7 +30,7 @@ export default {
     init(config = {}) {
         return {
             // todo: add access to the page and the rubric blocks
-            strategies: ['header', 'top-toolbar', 'navigator', 'item', 'toolbar'],
+            strategies: ['header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'item', 'toolbar'],
             config: Object.assign({
                 autoFocus: false,
                 keepState: false,

--- a/src/plugins/content/accessibility/keyNavigation/strategies/headerNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/headerNavigation.js
@@ -20,8 +20,8 @@ import $ from 'jquery';
 import keyNavigator from 'ui/keyNavigation/navigator';
 import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
 import {
-    setupItemsNavigator,
-    setupClickableNavigator
+    setupClickableNavigator,
+    setupItemsNavigator
 } from 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/helpers';
 
 /**
@@ -44,7 +44,7 @@ export default {
      */
     init() {
         const config = this.getConfig();
-        //need global selector as currently no way to access delivery frame from test runner
+        // we need a global selector as there is currently no way to access the delivery frame from the test runner
         const $headerBar = $('header');
         const $headerElements = $headerBar.find('a:visible');
 
@@ -55,7 +55,7 @@ export default {
                     id,
                     group,
                     elements,
-                    replace: true
+                    propagateTab: false
                 });
 
                 setupItemsNavigator(navigator, config);
@@ -65,7 +65,12 @@ export default {
         };
 
         this.keyNavigators = [];
-        registerHeaderNavigator(groupId, $headerBar, $headerElements);
+
+        if (config.flatNavigation) {
+            $headerElements.each((index, element) => registerHeaderNavigator(`${groupId}-${index}`, $headerBar, $(element)));
+        } else {
+            registerHeaderNavigator(groupId, $headerBar, $headerElements);
+        }
 
         return this;
     },

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -76,13 +76,14 @@ export default {
 
                     //search for inputs that represent the interaction focusable choices
                     const $inputs = $itemElement.is(':input') ? $itemElement : $itemElement.find(':input');
-                    const interactionNavigables = navigableDomElement.createFromDoms($inputs);
+                    const navigableElements = navigableDomElement.createFromDoms($inputs);
 
-                    if (interactionNavigables.length) {
+                    if (navigableElements.length) {
                         const navigator = keyNavigator({
-                            elements: interactionNavigables,
+                            elements: navigableElements,
                             group: $itemElement,
-                            loop: false
+                            loop: false,
+                            propagateTab: false
                         })
                             .on('focus', cursor => {
                                 const $qtiChoice = cursor.navigable.getElement().closest('.qti-choice');

--- a/src/plugins/content/accessibility/keyNavigation/strategies/linearItemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/linearItemNavigation.js
@@ -19,7 +19,6 @@
 import $ from 'jquery';
 import keyNavigator from 'ui/keyNavigation/navigator';
 import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
-import navigableGroupElement from 'ui/keyNavigation/navigableGroupElement';
 import {
     setupItemsNavigator,
     setupClickableNavigator
@@ -53,7 +52,7 @@ export default {
         let list = [];
         const setupListNavigator = () => {
             const navigator = keyNavigator({
-                elements: navigableGroupElement.createFromNavigators(list),
+                elements: list,
                 propagateTab: false
             });
 

--- a/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
@@ -48,7 +48,7 @@ export default {
         //the tag to identify if the item listing has been browsed, to only "smart jump" to active item only on the first visit
         let itemListingVisited = false;
         //the position of the filter in memory, to only "smart jump" to active item only on the first visit
-        let filterCursor;
+        let currentFilter;
 
         this.managedNavigators = [];
         this.keyNavigators = [];
@@ -60,7 +60,7 @@ export default {
                 filtersNavigator = keyNavigator({
                     keepState: config.keepState,
                     id: 'navigator-filters',
-                    replace: true,
+                    propagateTab: false,
                     elements: navigableFilters,
                     group: $navigator.find('.qti-navigator-filters')
                 });
@@ -72,17 +72,17 @@ export default {
                 setupClickableNavigator(filtersNavigator);
 
                 if (config.keepState) {
-                    filtersNavigator.on('focus', (cursor, origin) => {
+                    filtersNavigator.on('focus', cursor => {
                         if (config.keepState) {
-                            //activate the tab in the navigators
-                            cursor.navigable.getElement().click();
+                            const $element = cursor.navigable.getElement();
+                            const filter = $element.data('mode');
+                            $element.click();
 
-                            //reset the item listing browsed tag whenever the focus on the filter happens after a focus on another element
-                            if ((filterCursor && filterCursor.position !== cursor.position) || origin) {
+                            if (currentFilter !== filter) {
                                 itemListingVisited = false;
                             }
-                            //set the filter cursor in memory
-                            filterCursor = cursor;
+
+                            currentFilter = filter;
                         }
                     });
                 }
@@ -92,7 +92,7 @@ export default {
                         if (allowedToNavigateFrom(elem) && itemsNavigator) {
                             _.defer(() => {
                                 if (itemListingVisited) {
-                                    itemsNavigator.focus().first();
+                                    itemsNavigator.first();
                                 } else {
                                     itemsNavigator.focus();
                                 }
@@ -121,18 +121,15 @@ export default {
                 //instantiate a key navigator but do not add it to the returned list of navigators as this is not supposed to be reached with tab key
                 itemsNavigator = keyNavigator({
                     id: 'navigator-items',
-                    replace: true,
                     elements: navigableTrees,
                     group: $navigatorTree,
-                    defaultPosition(navigables) {
+                    defaultPosition(navigableElements) {
                         let pos = 0;
-                        if (filterCursor && filterCursor.navigable.getElement().data('mode') !== 'flagged') {
-                            _.forEach(navigables, function (navigable, i) {
+                        if (config.flatNavigation || currentFilter !== 'flagged') {
+                            pos = _.findIndex(navigableElements, navigable => {
                                 const $parent = navigable.getElement().parent('.qti-navigator-item');
-                                //find the first active and visible item
                                 if ($parent.hasClass('active') && $parent.is(':visible')) {
-                                    pos = i;
-                                    return false;
+                                    return true;
                                 }
                             });
                         }

--- a/src/plugins/content/accessibility/keyNavigation/strategies/pageNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/pageNavigation.js
@@ -19,6 +19,9 @@
 import $ from 'jquery';
 import keyNavigator from 'ui/keyNavigation/navigator';
 import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
+import {
+    setupItemsNavigator
+} from 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/helpers';
 
 /**
  * The identifier the keyNavigator group
@@ -39,6 +42,7 @@ export default {
      * @returns {keyNavigationStrategy}
      */
     init() {
+        const config = this.getConfig();
         this.keyNavigators = [];
 
         this.getTestRunner().getAreaBroker().getContainer()
@@ -46,15 +50,15 @@ export default {
             .addClass('key-navigation-scrollable')
             .each((i, el) => {
                 const $element = $(el);
-                this.keyNavigators.push(
-                    keyNavigator({
-                        id: `${groupId}-${this.keyNavigators.length}`,
-                        elements: navigableDomElement.createFromDoms($element),
-                        group: $element,
-                        propagateTab: false, // inner item navigators will send tab to this element
-                        replace: true
-                    })
-                );
+                const navigator = keyNavigator({
+                    id: `${groupId}-${this.keyNavigators.length}`,
+                    elements: navigableDomElement.createFromDoms($element),
+                    group: $element,
+                    propagateTab: false
+                });
+
+                setupItemsNavigator(navigator, config);
+                this.keyNavigators.push(navigator);
             });
 
         return this;

--- a/src/plugins/content/accessibility/keyNavigation/strategies/rubricsNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/rubricsNavigation.js
@@ -19,6 +19,9 @@
 import $ from 'jquery';
 import keyNavigator from 'ui/keyNavigation/navigator';
 import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
+import {
+    setupItemsNavigator
+} from 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/helpers';
 
 /**
  * The identifier the keyNavigator group
@@ -39,6 +42,7 @@ export default {
      * @returns {keyNavigationStrategy}
      */
     init() {
+        const config = this.getConfig();
         this.keyNavigators = [];
 
         this.getTestRunner().getAreaBroker().getContainer()
@@ -46,14 +50,15 @@ export default {
             .addClass('key-navigation-scrollable')
             .each((i, el) => {
                 const $element = $(el);
-                this.keyNavigators.push(
-                    keyNavigator({
-                        id: `${groupId}-${this.keyNavigators.length}`,
-                        elements: navigableDomElement.createFromDoms($element),
-                        group: $element,
-                        replace: true
-                    })
-                );
+                const navigator = keyNavigator({
+                    id: `${groupId}-${this.keyNavigators.length}`,
+                    elements: navigableDomElement.createFromDoms($element),
+                    group: $element,
+                    propagateTab: false
+                });
+
+                setupItemsNavigator(navigator, config);
+                this.keyNavigators.push(navigator);
             });
 
         return this;

--- a/src/plugins/content/accessibility/keyNavigation/strategies/toolbarNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/toolbarNavigation.js
@@ -21,8 +21,8 @@ import $ from 'jquery';
 import keyNavigator from 'ui/keyNavigation/navigator';
 import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
 import {
-    setupItemsNavigator,
-    setupClickableNavigator
+    setupClickableNavigator,
+    setupItemsNavigator
 } from 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/helpers';
 
 /**
@@ -55,15 +55,15 @@ export default {
                     id,
                     group,
                     elements,
-                    replace: true,
-                    defaultPosition(navigables) {
+                    propagateTab: false,
+                    defaultPosition(navigableElements) {
                         let pos = 0;
 
                         // search for the position of the "Next" button if any,
                         // otherwise take the position of the last element
                         if (config.autoFocus) {
-                            pos = navigables.length - 1;
-                            _.forEach(navigables, (navigable, i) => {
+                            pos = navigableElements.length - 1;
+                            _.forEach(navigableElements, (navigable, i) => {
                                 const $element = navigable.getElement();
                                 if ($element.data('control') === 'move-forward' || $element.data('control') === 'move-end') {
                                     pos = i;
@@ -82,7 +82,12 @@ export default {
         };
 
         this.keyNavigators = [];
-        registerToolbarNavigator(groupId, $navigationBar, $toolbarElements);
+
+        if (config.flatNavigation) {
+            $toolbarElements.each((index, element) => registerToolbarNavigator(`${groupId}-${index}`, $navigationBar, $(element)));
+        } else {
+            registerToolbarNavigator(groupId, $navigationBar, $toolbarElements);
+        }
 
         return this;
     },

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -66,7 +66,6 @@ export default pluginFactory({
                 id: groupNavigationId,
                 group: $navigationGroupElement,
                 elements: navigableDomElement.createFromDoms($navigationElements.add($navigationGroupElement)),
-                replace: true,
                 propagateTab: false,
                 loop: true,
                 keepState: true,
@@ -100,7 +99,7 @@ export default pluginFactory({
                         0
                     );
                 })
-                .focusPosition($navigationElements.length);
+                .setCursorAt($navigationElements.length);
 
             ttsComponent.on('next finish', () => {
                 if (ttsComponent.is('sfhMode')) {

--- a/test/plugins/content/keyNavigation/assets/layout.tpl
+++ b/test/plugins/content/keyNavigation/assets/layout.tpl
@@ -2,7 +2,7 @@
     <!-- added the role div -->
     <header role="menubar" class="dark-bar clearfix key-navigation-group" data-navigation-id="header-toolbar">
             <span class="lft">
-                <img src="assets/tao-logo.png" alt="TAO Logo" id="tao-main-logo">
+                <img src="../assets/tao-logo.png" alt="TAO Logo" id="tao-main-logo">
             </span>
         <div class="lft title-box"></div>
         <nav role="menu" class="rgt">

--- a/test/plugins/content/keyNavigation/data/navigation.json
+++ b/test/plugins/content/keyNavigation/data/navigation.json
@@ -54,10 +54,31 @@
                 }
             },
             {
+                "label": "Previous button",
+                "selector": "[data-control=\"move-backward\"]",
+                "key": {
+                    "keyCode": "LEFT"
+                }
+            },
+            {
                 "label": "Hide review button",
                 "selector": "[data-control=\"hide-review\"]",
                 "key": {
                     "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Previous button",
+                "selector": "[data-control=\"move-backward\"]",
+                "key": {
+                    "keyCode": "RIGHT"
+                }
+            },
+            {
+                "label": "Next button",
+                "selector": "[data-control=\"move-forward\"]",
+                "key": {
+                    "keyCode": "RIGHT"
                 }
             },
             {
@@ -79,6 +100,20 @@
                 "selector": "#exit",
                 "key": {
                     "keyCode": "RIGHT"
+                }
+            },
+            {
+                "label": "Logout link",
+                "selector": "#logout",
+                "key": {
+                    "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Home link",
+                "selector": "#home",
+                "key": {
+                    "keyCode": "LEFT"
                 }
             },
             {
@@ -107,6 +142,34 @@
                 "selector": ".qti-navigator-filter[data-mode=\"unanswered\"]",
                 "key": {
                     "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Navigation panel All tab",
+                "selector": ".qti-navigator-filter[data-mode=\"all\"]",
+                "key": {
+                    "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Navigation panel Unanswered tab",
+                "selector": ".qti-navigator-filter[data-mode=\"unanswered\"]",
+                "key": {
+                    "keyCode": "RIGHT"
+                }
+            },
+            {
+                "label": "Navigation panel current item",
+                "selector": ".qti-navigator-item[data-id=\"item-3\"] .qti-navigator-label",
+                "key": {
+                    "keyCode": "DOWN"
+                }
+            },
+            {
+                "label": "Navigation panel previous item",
+                "selector": ".qti-navigator-item[data-id=\"item-2\"] .qti-navigator-label",
+                "key": {
+                    "keyCode": "UP"
                 }
             },
             {
@@ -227,10 +290,31 @@
                 }
             },
             {
+                "label": "Previous button",
+                "selector": "[data-control=\"move-backward\"]",
+                "key": {
+                    "keyCode": "LEFT"
+                }
+            },
+            {
                 "label": "Hide review button",
                 "selector": "[data-control=\"hide-review\"]",
                 "key": {
                     "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Previous button",
+                "selector": "[data-control=\"move-backward\"]",
+                "key": {
+                    "keyCode": "RIGHT"
+                }
+            },
+            {
+                "label": "Next button",
+                "selector": "[data-control=\"move-forward\"]",
+                "key": {
+                    "keyCode": "RIGHT"
                 }
             },
             {
@@ -252,6 +336,20 @@
                 "selector": "#exit",
                 "key": {
                     "keyCode": "RIGHT"
+                }
+            },
+            {
+                "label": "Logout link",
+                "selector": "#logout",
+                "key": {
+                    "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Home link",
+                "selector": "#home",
+                "key": {
+                    "keyCode": "LEFT"
                 }
             },
             {
@@ -280,6 +378,34 @@
                 "selector": ".qti-navigator-filter[data-mode=\"unanswered\"]",
                 "key": {
                     "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Navigation panel All tab",
+                "selector": ".qti-navigator-filter[data-mode=\"all\"]",
+                "key": {
+                    "keyCode": "LEFT"
+                }
+            },
+            {
+                "label": "Navigation panel Unanswered tab",
+                "selector": ".qti-navigator-filter[data-mode=\"unanswered\"]",
+                "key": {
+                    "keyCode": "RIGHT"
+                }
+            },
+            {
+                "label": "Navigation panel current item",
+                "selector": ".qti-navigator-item[data-id=\"item-3\"] .qti-navigator-label",
+                "key": {
+                    "keyCode": "DOWN"
+                }
+            },
+            {
+                "label": "Navigation panel previous item",
+                "selector": ".qti-navigator-item[data-id=\"item-2\"] .qti-navigator-label",
+                "key": {
+                    "keyCode": "UP"
                 }
             },
             {
@@ -333,7 +459,7 @@
     {
         "title": "Native",
         "mode": "native",
-        "rubrics": false,
+        "rubrics": true,
         "steps": [
             {
                 "label": "Home link",
@@ -386,6 +512,21 @@
                 }
             },
             {
+                "label": "Navigation panel All tab",
+                "selector": ".qti-navigator-filter[data-mode=\"all\"]",
+                "key": {
+                    "keyCode": "TAB",
+                    "shiftKey": true
+                }
+            },
+            {
+                "label": "Navigation panel Unanswered tab",
+                "selector": ".qti-navigator-filter[data-mode=\"unanswered\"]",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
                 "label": "Navigation panel Flagged tab",
                 "selector": ".qti-navigator-filter[data-mode=\"flagged\"]",
                 "key": {
@@ -395,6 +536,35 @@
             {
                 "label": "Navigation panel current item",
                 "selector": ".qti-navigator-item[data-id=\"item-3\"] .qti-navigator-label",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
+                "label": "Navigation panel previous item",
+                "selector": ".qti-navigator-item[data-id=\"item-2\"] .qti-navigator-label",
+                "key": {
+                    "keyCode": "TAB",
+                    "shiftKey": true
+                }
+            },
+            {
+                "label": "Navigation panel current item",
+                "selector": ".qti-navigator-item[data-id=\"item-3\"] .qti-navigator-label",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
+                "label": "Item wrapper",
+                "selector": "section.content-wrapper",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
+                "label": "Rubrics block",
+                "selector": ".qti-rubricBlock",
                 "key": {
                     "keyCode": "TAB"
                 }
@@ -458,6 +628,13 @@
                 }
             },
             {
+                "label": "Previous button",
+                "selector": "[data-control=\"move-backward\"]",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
                 "label": "Next button",
                 "selector": "[data-control=\"move-forward\"]",
                 "key": {
@@ -474,6 +651,14 @@
             {
                 "label": "Next button",
                 "selector": "[data-control=\"move-forward\"]",
+                "key": {
+                    "keyCode": "TAB",
+                    "shiftKey": true
+                }
+            },
+            {
+                "label": "Previous button",
+                "selector": "[data-control=\"move-backward\"]",
                 "key": {
                     "keyCode": "TAB",
                     "shiftKey": true

--- a/test/plugins/content/keyNavigation/data/test.json
+++ b/test/plugins/content/keyNavigation/data/test.json
@@ -222,8 +222,8 @@
                         "position": 1,
                         "timeConstraint": null,
                         "items": {
-                            "item-3": {
-                                "id": "item-3",
+                            "item-2": {
+                                "id": "item-2",
                                 "label": "mock 2",
                                 "position": 1,
                                 "occurrence": 0,
@@ -236,8 +236,8 @@
                                 ],
                                 "informational": false
                             },
-                            "item-2": {
-                                "id": "item-2",
+                            "item-3": {
+                                "id": "item-3",
                                 "label": "mock 3",
                                 "position": 2,
                                 "occurrence": 0,

--- a/test/plugins/content/keyNavigation/keyNavigation/test.js
+++ b/test/plugins/content/keyNavigation/keyNavigation/test.js
@@ -154,7 +154,7 @@ define([
                         assert.equal($container.find('.runner').children().length, 1, 'The test runner is rendered');
 
                         runner.after('renderitem.runnerComponent', itemRef => {
-                            if (itemRef === 'item-1') {
+                            if (itemRef !== 'item-3') {
                                 runner.next();
                             } else {
                                 runner.off('renderitem.runnerComponent');

--- a/test/plugins/content/keyNavigation/modesManager/test.js
+++ b/test/plugins/content/keyNavigation/modesManager/test.js
@@ -90,7 +90,7 @@ define([
             additional: 'foo'
         },
         expected: {
-            strategies: ['header', 'top-toolbar', 'navigator', 'item', 'toolbar'],
+            strategies: ['header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'item', 'toolbar'],
             config: {
                 autoFocus: false,
                 keepState: false,

--- a/test/plugins/content/keyNavigation/plugin/demo.html
+++ b/test/plugins/content/keyNavigation/plugin/demo.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <title>Key Navigation - Test Runner Plugin test</title>
+        <title>Key Navigation - Visual Playground</title>
         <link rel="stylesheet" href="../assets/tao-3.css"/>
         <link rel="stylesheet" href="../assets/qti-runner.css"/>
         <script type="text/javascript" src="/environment/require.js"></script>
@@ -17,7 +17,7 @@
                             }
                         }
                     });
-                    require(['taoQtiTest/test/runner/plugins/content/keyNavigation/plugin/test'], function() {
+                    require(['taoQtiTest/test/runner/plugins/content/keyNavigation/plugin/demo'], function() {
                         QUnit.start();
                     });
                 });
@@ -27,6 +27,7 @@
             #visual-playground {
                 position: relative;
                 width: 100%;
+                height: 100vh;
                 display: flex;
                 flex-direction: column;
             }

--- a/test/plugins/content/keyNavigation/plugin/demo.js
+++ b/test/plugins/content/keyNavigation/plugin/demo.js
@@ -1,0 +1,58 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+define([
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/test/runner/plugins/content/keyNavigation/mock/backend',
+    'taoQtiTest/test/runner/plugins/content/keyNavigation/plugin/playground',
+    'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/test.json',
+    'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/item.json'
+], function (
+    runnerFactory,
+    providerMock,
+    backendMockFactory,
+    visualPlayground,
+    testDefinition,
+    itemsBank
+) {
+    'use strict';
+
+    const providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    const backendMock = backendMockFactory(testDefinition, itemsBank);
+
+    QUnit.module('Visual');
+
+    QUnit.test('Visual test', assert => {
+        const ready = assert.async();
+        assert.expect(1);
+        visualPlayground('#visual-playground', backendMock)
+            .then(() => {
+                assert.ok(true, 'The playground is ready');
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+});

--- a/test/plugins/content/keyNavigation/plugin/playground.js
+++ b/test/plugins/content/keyNavigation/plugin/playground.js
@@ -1,0 +1,103 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+define([
+    'jquery',
+    'ui/dialog/alert',
+    'taoTests/runner/runnerComponent',
+    'tpl!taoQtiTest/test/runner/plugins/content/keyNavigation/assets/layout',
+    'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/config.json',
+    'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/test.json',
+    'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/item.json',
+    'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/rubrics.json',
+    'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/navigation.json'
+], function (
+    $,
+    dialogAlert,
+    runnerComponent,
+    layoutTpl,
+    configData,
+    testDefinition,
+    itemsBank,
+    rubricsBank,
+    navigationCases
+) {
+    'use strict';
+
+    /**
+     * Builds a visual playground to demo the modes of the keyNavigation plugin
+     * @param {String|HTMLElemennt} container
+     * @param {backendMock}backendMock
+     * @returns {Promise<unknown>}
+     */
+    return function visualPlayground(container, backendMock) {
+        const $container = $(container);
+        const $selector = $container.find('.playground-selector');
+        const $view = $container.find('.playground-view');
+        const modes = [];
+
+        return Promise.resolve()
+            .then(() => new Promise((resolve, reject) => {
+                $view.html(layoutTpl());
+                runnerComponent($view.find('.runner'), configData)
+                    .on('error', reject)
+                    .on('ready', runner => {
+                        runner
+                            .after('renderitem.runnerComponent', () => {
+                                runner.off('renderitem.runnerComponent');
+                                resolve(runner);
+                            })
+                            .after('setcontenttabtype', mode => {
+                                const modeData = navigationCases.find(navigation => navigation.mode === mode);
+                                const {rubrics} = modeData;
+                                if (rubrics) {
+                                    backendMock.setRubricsBank(rubricsBank);
+                                } else {
+                                    backendMock.setRubricsBank({});
+                                }
+                                runner.jump(runner.getTestContext().itemPosition);
+                            });
+                    });
+            }))
+            .then(runner => {
+                function activateMode(id) {
+                    modes.forEach(mode => mode.$button.toggleClass('btn-info', id === mode.id));
+                    $view.attr('data-mode', id);
+                    runner.trigger('setcontenttabtype', id);
+                }
+
+                $view.find('header').on('click', 'a', e => {
+                    dialogAlert(`You clicked on <b>${$(e.currentTarget).text()}</b>`);
+                    e.preventDefault();
+                });
+
+                $selector
+                    .on('click', 'button', e => {
+                        activateMode(e.target.dataset.mode);
+                    })
+                    .find('button').each(function () {
+                        modes.push({
+                            id: this.dataset.mode,
+                            $button: $(this)
+                        });
+                    });
+
+                activateMode('default');
+            });
+    };
+});

--- a/test/plugins/content/keyNavigation/plugin/test.js
+++ b/test/plugins/content/keyNavigation/plugin/test.js
@@ -19,12 +19,12 @@
 define([
     'jquery',
     'lodash',
-    'ui/dialog/alert',
     'taoTests/runner/runner',
     'taoTests/runner/runnerComponent',
     'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/plugin',
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/test/runner/plugins/content/keyNavigation/mock/backend',
+    'taoQtiTest/test/runner/plugins/content/keyNavigation/plugin/playground',
     'tpl!taoQtiTest/test/runner/plugins/content/keyNavigation/assets/layout',
     'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/config.json',
     'json!taoQtiTest/test/runner/plugins/content/keyNavigation/data/test.json',
@@ -35,12 +35,12 @@ define([
 ], function (
     $,
     _,
-    dialogAlert,
     runnerFactory,
     runnerComponent,
     pluginFactory,
     providerMock,
     backendMockFactory,
+    visualPlayground,
     layoutTpl,
     configData,
     testDefinition,
@@ -194,7 +194,7 @@ define([
                         runner
                             .after('setcontenttabtype', () => runner.next())
                             .after('renderitem.runnerComponent', itemRef => {
-                                if (itemRef === 'item-1') {
+                                if (itemRef !== 'item-3') {
                                     runner.trigger('setcontenttabtype', data.mode);
                                 } else {
                                     runner.off('renderitem.runnerComponent');
@@ -234,59 +234,9 @@ define([
 
     QUnit.test('Visual test', assert => {
         const ready = assert.async();
-        const $container = $('#visual-playground');
-        const $selector = $container.find('.playground-selector');
-        const $view = $container.find('.playground-view');
-        const modes = [];
         assert.expect(1);
-
-        Promise.resolve()
-            .then(() => new Promise((resolve, reject) => {
-                $view.html(layoutTpl());
-                runnerComponent($view.find('.runner'), configData)
-                    .on('error', reject)
-                    .on('ready', runner => {
-                        runner
-                            .after('renderitem.runnerComponent', () => {
-                                runner.off('renderitem.runnerComponent');
-                                resolve(runner);
-                            })
-                            .after('setcontenttabtype', mode => {
-                                const modeData = navigationCases.find(navigation => navigation.mode === mode);
-                                const {rubrics} = modeData;
-                                if (rubrics) {
-                                    backendMock.setRubricsBank(rubricsBank);
-                                } else {
-                                    backendMock.setRubricsBank({});
-                                }
-                                runner.jump(0);
-                            });
-                    });
-            }))
-            .then(runner => {
-                function activateMode(id) {
-                    modes.forEach(mode => mode.$button.toggleClass('btn-info', id === mode.id));
-                    $view.attr('data-mode', id);
-                    runner.trigger('setcontenttabtype', id);
-                }
-
-                $view.find('header').on('click', 'a', e => {
-                    dialogAlert(`You clicked on <b>${$(e.currentTarget).text()}</b>`);
-                    e.preventDefault();
-                });
-
-                $selector
-                    .on('click', 'button', e => {
-                        activateMode(e.target.dataset.mode);
-                    })
-                    .find('button').each(function () {
-                        modes.push({
-                            id: this.dataset.mode,
-                            $button: $(this)
-                        });
-                    });
-
-                activateMode('default');
+        visualPlayground('#visual-playground', backendMock)
+            .then(() => {
                 assert.ok(true, 'The playground is ready');
             })
             .catch(err => {

--- a/test/plugins/tools/apipTextToSpeech/plugin/test.js
+++ b/test/plugins/tools/apipTextToSpeech/plugin/test.js
@@ -24,9 +24,8 @@ define([
     'taoTests/runner/runner',
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/runner/plugins/tools/apipTextToSpeech/plugin',
-    'ui/keyNavigation/navigator',
     'lib/simulator/jquery.simulate'
-], function (_, hider, runnerFactory, providerMock, pluginFactory, keyNavigatorFactory) {
+], function (_, hider, runnerFactory, providerMock, pluginFactory) {
     'use strict';
 
     const providerName = 'mock';
@@ -148,13 +147,11 @@ define([
             .init()
             .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
-
-                ready();
             })
             .catch((err) => {
                 assert.ok(false, `The init failed: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     /**
@@ -166,14 +163,14 @@ define([
         const ready = assert.async();
         const runner = runnerFactory(providerName);
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
 
         assert.expect(3);
 
         plugin
             .init()
             .then(() => {
-                const $container = runner.getAreaBroker().getToolboxArea();
                 let $button;
 
                 areaBroker.getToolbox().render($container);
@@ -188,52 +185,53 @@ define([
                 $button = $container.find('[data-control="apiptts"]');
 
                 assert.equal($button.length, 0, 'The trigger button has been removed');
-                ready();
             })
             .catch((err) => {
                 assert.ok(false, `Error in init method: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     QUnit.test('enable/disable button', (assert) => {
         const ready = assert.async();
         const runner = runnerFactory(providerName);
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
 
         assert.expect(2);
 
         plugin
             .init()
             .then(() => {
-                const $container = runner.getAreaBroker().getToolboxArea();
-
                 areaBroker.getToolbox().render($container);
 
-                return plugin.enable().then(() => {
-                    const $button = $container.find('[data-control="apiptts"]');
+                return plugin.enable();
+            })
+            .then(() => {
+                const $button = $container.find('[data-control="apiptts"]');
 
-                    assert.equal($button.hasClass('disabled'), false, 'The trigger button has been enabled');
+                assert.equal($button.hasClass('disabled'), false, 'The trigger button has been enabled');
 
-                    return plugin.disable().then(() => {
-                        assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
+                return plugin.disable();
+            })
+            .then(() => {
+                const $button = $container.find('[data-control="apiptts"]');
 
-                        ready();
-                    });
-                });
+                assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
             })
             .catch((err) => {
                 assert.ok(false, `Unexpected error: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     QUnit.test('show/hide button', (assert) => {
         const ready = assert.async();
         const runner = runnerFactory(providerName);
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
 
         assert.expect(3);
 
@@ -244,37 +242,41 @@ define([
         plugin
             .init()
             .then(() => {
-                const $container = runner.getAreaBroker().getToolboxArea();
-
                 areaBroker.getToolbox().render($container);
 
-                return plugin.hide().then(() => {
-                    const $button = $container.find('[data-control="apiptts"]');
+                return plugin.hide();
+            })
+            .then(() => {
+                const $button = $container.find('[data-control="apiptts"]');
 
-                    assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden');
+                assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden');
 
-                    return plugin.show().then(() => {
-                        assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
+                return plugin.show();
+            })
+            .then(() => {
+                const $button = $container.find('[data-control="apiptts"]');
 
-                        return plugin.hide().then(() => {
-                            assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden again');
+                assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
 
-                            ready();
-                        });
-                    });
-                });
+                return plugin.hide();
+            })
+            .then(() => {
+                const $button = $container.find('[data-control="apiptts"]');
+
+                assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden again');
             })
             .catch((err) => {
                 assert.ok(false, `Unexpected error: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     QUnit.test('runner events: loaditem / unloaditem', (assert) => {
         const ready = assert.async();
         const runner = runnerFactory(providerName);
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
 
         assert.expect(3);
 
@@ -285,8 +287,6 @@ define([
         plugin
             .init()
             .then(() => {
-                const $container = runner.getAreaBroker().getToolboxArea();
-
                 areaBroker.getToolbox().render($container);
 
                 const $button = $container.find('[data-control="apiptts"]');
@@ -300,20 +300,19 @@ define([
                 assert.equal(hider.isHidden($button), false, 'The trigger button is still visible');
 
                 assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
-
-                ready();
             })
             .catch((err) => {
                 assert.ok(false, `Error in init method: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     QUnit.test('runner events: renderitem', (assert) => {
         const ready = assert.async();
         const runner = runnerFactory(providerName);
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
@@ -324,8 +323,6 @@ define([
         plugin
             .init()
             .then(() => {
-                const $container = runner.getAreaBroker().getToolboxArea();
-
                 areaBroker.getToolbox().render($container);
 
                 const $button = $container.find('[data-control="apiptts"]');
@@ -335,13 +332,11 @@ define([
                 assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
 
                 assert.equal($button.hasClass('disabled'), false, 'The trigger button is not disabled');
-
-                ready();
             })
             .catch((err) => {
                 assert.ok(false, `Error in init method: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     QUnit.test('runner events: renderitem with disabled plugin', (assert) => {
@@ -366,7 +361,8 @@ define([
         runner.setTestMap(Object.assign({}, sampleTestMap, testPartWithApipCategory));
 
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
 
         runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
 
@@ -375,8 +371,6 @@ define([
         plugin
             .init()
             .then(() => {
-                const $container = runner.getAreaBroker().getToolboxArea();
-
                 areaBroker.getToolbox().render($container);
 
                 const $button = $container.find('[data-control="apiptts"]');
@@ -385,20 +379,19 @@ define([
                 runner.trigger('renderitem');
 
                 assert.equal(hider.isHidden($button), true, 'the button is not visible');
-
-                ready();
             })
             .catch((err) => {
                 assert.ok(false, `Error in init method: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     QUnit.test('Toggle on click', (assert) => {
         const ready = assert.async();
         const runner = runnerFactory(providerName);
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
 
         assert.expect(3);
 
@@ -408,45 +401,43 @@ define([
 
         plugin
             .init()
-            .then(function () {
-                const $container = areaBroker.getToolboxArea();
-
+            .then(() => {
                 runner.trigger('renderitem');
 
                 areaBroker.getToolbox().render($container);
 
-                return plugin.enable().then(() => {
-                    const $button = $container.find('[data-control="apiptts"]');
-
-                    assert.equal(plugin.getState('active'), false, 'The plugin should not be active by default');
-
-                    $button.click();
-
-                    assert.equal(plugin.getState('active'), true, 'The button should toggle the plugin to active state');
-
-                    $button.click();
-
-                    assert.equal(plugin.getState('active'), false, 'If the plugin is active, the button should toggle the plugin to non active state');
-
-                    ready();
-                });
+                return plugin.enable();
             })
-            .catch(function (err) {
+            .then(() => {
+                const $button = $container.find('[data-control="apiptts"]');
+
+                assert.equal(plugin.getState('active'), false, 'The plugin should not be active by default');
+
+                $button.click();
+
+                assert.equal(plugin.getState('active'), true, 'The button should toggle the plugin to active state');
+
+                $button.click();
+
+                assert.equal(plugin.getState('active'), false, 'If the plugin is active, the button should toggle the plugin to non active state');
+            })
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 
     QUnit.test('Add navigation group', (assert) => {
         const ready = assert.async();
         const runner = runnerFactory(providerName);
         const areaBroker = runner.getAreaBroker();
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const $testContainer = areaBroker.getContainer();
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, areaBroker);
         const pluginName = plugin.getName();
-        const groupNavigationId = `${pluginName}_navigation_group`;
         const actionPrefix = `tool-${pluginName}-`;
 
-        assert.expect(7);
+        assert.expect(8);
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
@@ -454,55 +445,70 @@ define([
 
         plugin
             .init()
-            .then(function () {
-                const $container = areaBroker.getToolboxArea();
-                const $testContainer = areaBroker.getContainer();
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
                 runner.trigger('renderitem');
 
-                return plugin.enable().then(() => {
-                    const $button = $container.find('[data-control="apiptts"]');
-                    const $sfhButton = $testContainer.find('.tts-control-mode');
-
-                    assert.equal($button.is(document.activeElement), false, 'The focus group is not focused by default');
-
-                    $button.click();
-
-                    const navigationGroup = keyNavigatorFactory.get(groupNavigationId);
-
-                    assert.equal(typeof navigationGroup, 'object', 'The plugin create navigation group after render');
-
-                    assert.equal($button.is(document.activeElement), true, 'The focus group is not focused after plugin activation');
-
-                    $button.click();
-                    $sfhButton.click();
-
-                    assert.equal($button.is(document.activeElement), false, 'The focus group lose focus after plugin disabling');
-
-                    runner.on(`${actionPrefix}next`, () => {
-                        assert.ok(true, 'The next event triggered after tab navigation');
-
-                        runner.on(`${actionPrefix}previous`, () => {
-                            assert.ok(true, 'The previous event triggered after tab+shift navigation');
-
-                            ready();
-                        });
-
-                        navigationGroup.trigger('shift+tab');
-                    });
-
-                    runner.on(`${actionPrefix}togglePlayback`, () => {
-                        assert.ok(true, 'The togglePlayback event triggered on activate navigation event');
-                    });
-
-                    navigationGroup.trigger('tab');
-                    navigationGroup.trigger('activate');
-                });
+                return plugin.enable();
             })
-            .catch(function (err) {
+            .then(() => {
+                const $button = $container.find('[data-control="apiptts"]');
+                const $sfhButton = $testContainer.find('.tts-control-mode');
+
+                assert.equal($button.is(document.activeElement), false, 'The focus group is not focused by default');
+
+                $button.click();
+
+                assert.equal(typeof plugin.navigationGroup, 'object', 'The plugin create navigation group after render');
+
+                assert.equal($button.is(document.activeElement), true, 'The focus group is focused after plugin activation');
+
+                $button.click();
+                $sfhButton.click();
+
+                assert.equal($button.is(document.activeElement), false, 'The focus group lose focus after plugin disabling');
+
+                $button.click();
+
+                assert.equal($button.is(document.activeElement), true, 'The focus group is focused again');
+            })
+            .then(() => new Promise(resolve => {
+                const $button = $container.find('[data-control="apiptts"]');
+
+                runner.on(`${actionPrefix}next`, () => {
+                    assert.ok(true, 'The next event triggered after tab navigation');
+
+                    resolve();
+                });
+
+                $button.simulate('keydown', {keyCode: 9}); //Tab -> navigate next
+            }))
+            .then(() => new Promise(resolve => {
+                const $button = $container.find('[data-control="apiptts"]');
+
+                runner.on(`${actionPrefix}previous`, () => {
+                    assert.ok(true, 'The previous event triggered after tab+shift navigation');
+
+                    resolve();
+                });
+
+                $button.simulate('keydown', {keyCode: 9, shiftKey: true}); //Shift+Tab -> navigate back
+            }))
+            .then(() => new Promise(resolve => {
+                const $button = $container.find('[data-control="apiptts"]');
+
+                runner.on(`${actionPrefix}togglePlayback`, () => {
+                    assert.ok(true, 'The togglePlayback event triggered on activate navigation event');
+
+                    resolve();
+                });
+
+                $button.simulate('keydown', {keyCode: 13}); //Enter -> activate
+            }))
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
-                ready();
-            });
+            })
+            .then(ready);
     });
 });


### PR DESCRIPTION
Version 2.0.0

**Release notes :**
- [breaking] [TCA-429](https://oat-sa.atlassian.net/browse/TCA-429)

Fix a focus issue with the page and the rubrics blocks. Now all elements should be reachable without navigation trap or element skipping.
The unit tests have been improved too, the playground has been put in a dedicated demo page.

Breaking changes from tao-core-ui:

the navigableDomGroup module has been removed, the keyNavigator being now able to be managed as a navigable element as well no need to have an extraneous object to do so.
the getNavigables() method has been removed to getNavigableElements().
the instances of the keyNavigator are not persisted anymore inside a module variable
the replace config property has been removed since the module variable has been removed
the goto() API has been removed. It was relying on the bad design lead by the module variable. However, it was not used.
the get() API has been removed, but wasn't used. Still the same reason: removal of the module variable.

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/159
