### PR TITLE
Fix/tca 497/kb focus stays in the bottom bar menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -220,12 +220,11 @@ var menuComponentApi = {
         this.hoverOffAll();
 
         // component inner state
-        const wasOpen = this.is('opened');
         this.setState('opened', false);
         this.trigger('closemenu', this);
 
-        // Move focus if the menu was opened before the close action was launched.
-        if (wasOpen) {
+        // Move focus if the menu wasn't disabled before the close action was launched.
+        if (!this.is('disabled')) {
             this.$menuButton.parent().focus();  // It needs for screenreaders to correctly read menu button after submenu was closed
         }
     },


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-497

**Description**
KB focus stays in the Bottom bar menu when navigating from item to item

**How to test**

1. enable SR
2. start a test
3. Open menu on the bottom bar
4. press "Next" to navigate to the next item
5. Listen to the screen reader