### PR TITLE
BSA-84: Remove z-index from #qti-content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -120,8 +120,6 @@
         max-width: map-get($widths, item-max-width) * 1px;
         width: 100%;
         margin: auto;
-        position: relative;
-        z-index: 1;
     }
 
     #qti-item {

--- a/src/plugins/content/overlay/overlay.js
+++ b/src/plugins/content/overlay/overlay.js
@@ -51,7 +51,7 @@ export default pluginFactory({
         };
 
         //change plugin state
-        testRunner.on('disableitem', shield).on('enableitem unloaditem', unshield);
+        testRunner.on('disableitem', shield).on('enableitem unloaditem modalFeedbacks', unshield);
     },
 
     /**


### PR DESCRIPTION
- BSA-84 fix: hide test-runner's overlay upon rendering a modal feedback
- BSA-84 fix: remove `z-index: 1` from `#qti-content`

Fixes extra `z-index`, introduced in #160.