### PR TITLE
Release 2.0.2

### DIFF
--- a/src/plugins/controls/timer/component/timerbox.js
+++ b/src/plugins/controls/timer/component/timerbox.js
@@ -213,6 +213,8 @@ export default function timerboxFactory(config) {
                             })
                             .on('change', function(value) {
                                 if (self.timers[id]) {
+                                    self.trigger('timertick', this.remainingTime); // propogate current timer data
+
                                     //keep the current timer data in sync
                                     self.timers[id].remainingTime = value;
                                 }

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -218,6 +218,9 @@ export default pluginFactory({
                             .on('init', resolve)
                             .on('error', handleError);
 
+                        // share this timer values to use in other components
+                        self.timerbox.spread(testRunner, 'timertick');
+
                         if (!config.contextualWarnings) {
                             self.timerbox.on('warn', function(message, level) {
                                 if (level && message) {


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-305

Allow a screen readers to access a timers of time-limited tests

**How to test:**
- switch taoAct in TAO instance to `feature/ACTP-305/timer-review-panel-aria` branch
- disable current key navigation plugin to acces native key navigation flow
- switch `oat-sa/tao-test-runner-qti-fe` in `taoQtiTest` extension to `feature/ACTP-305/timer-review-panel-aria` branch
- prepare a test with enabled timers
- login to ACT as a Guest or as user and run this test
- try to acces review panel from test using `TAB` key
- check a review panel is readed by your accessibility software, including timers value

**Related pull request**
https://github.com/oat-sa/extension-tao-act/pull/1340