### PR TITLE
Release 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ACTP-305

Allow a screen readers to access a timers of time-limited tests

**How to test:**
- switch taoAct in TAO instance to `feature/ACTP-305/timer-review-panel-aria` branch
- disable current key navigation plugin to acces native key navigation flow
- switch `oat-sa/tao-test-runner-qti-fe` in `taoQtiTest` extension to `feature/ACTP-305/timer-review-panel-aria` branch
- prepare a test with enabled timers
- login to ACT as a Guest or as user and run this test
- try to acces review panel from test using `TAB` key
- check a review panel is readed by your accessibility software, including timers value

**Related pull request**
https://github.com/oat-sa/extension-tao-act/pull/1340