### PR TITLE
tts plugin keep across items TCA-381

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.0",
+    "version": "2.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -204,6 +204,7 @@ export default pluginFactory({
             if (this.getState('enabled')) {
                 if (this.getState('active')) {
                     disablePlugin();
+                    this.setState('sleep', true);
                 } else {
                     enablePlugin();
                 }
@@ -224,6 +225,7 @@ export default pluginFactory({
         // Handle plugin button click
         this.button.on('click', (e) => {
             e.preventDefault();
+            this.setState('sleep', false);
             testRunner.trigger(`${actionPrefix}toggle`);
         });
 
@@ -252,10 +254,10 @@ export default pluginFactory({
             });
         }
 
-        // Hide plugin by default
+        // Show plugin by default
         togglePlugin();
-        this.disable();
-        this.hide();
+        this.enable();
+        this.show();
 
         //update plugin state based on changes
         testRunner
@@ -316,6 +318,10 @@ export default pluginFactory({
 
                 getTTSComponent().setMediaContentData(ttsApipData);
                 this.show();
+                if (!this.getState('sleep')) {
+                    this.setState('enabled', true);
+                    toggleTool();
+                }
             });
     },
     /**

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -207,6 +207,7 @@ export default pluginFactory({
                     this.setState('sleep', true);
                 } else {
                     enablePlugin();
+                    this.setState('sleep', false);
                 }
             }
         };
@@ -253,6 +254,11 @@ export default pluginFactory({
             });
         }
 
+        // Hide plugin by default
+        togglePlugin();
+        this.disable();
+        this.hide();
+
         //update plugin state based on changes
         testRunner
             .on('loaditem', () => {
@@ -267,7 +273,6 @@ export default pluginFactory({
                 this.disable();
             })
             .on(`${actionPrefix}toggle`, () => {
-                this.setState('sleep', false);
                 if (isConfigured()) {
                     toggleTool();
                 }

--- a/src/plugins/tools/apipTextToSpeech/plugin.js
+++ b/src/plugins/tools/apipTextToSpeech/plugin.js
@@ -225,7 +225,6 @@ export default pluginFactory({
         // Handle plugin button click
         this.button.on('click', (e) => {
             e.preventDefault();
-            this.setState('sleep', false);
             testRunner.trigger(`${actionPrefix}toggle`);
         });
 
@@ -254,11 +253,6 @@ export default pluginFactory({
             });
         }
 
-        // Show plugin by default
-        togglePlugin();
-        this.enable();
-        this.show();
-
         //update plugin state based on changes
         testRunner
             .on('loaditem', () => {
@@ -273,6 +267,7 @@ export default pluginFactory({
                 this.disable();
             })
             .on(`${actionPrefix}toggle`, () => {
+                this.setState('sleep', false);
                 if (isConfigured()) {
                     toggleTool();
                 }

--- a/src/plugins/tools/apipTextToSpeech/textToSpeech.js
+++ b/src/plugins/tools/apipTextToSpeech/textToSpeech.js
@@ -34,7 +34,7 @@ import 'nouislider';
 const defaultConfig = {
     activeElementClass: 'tts-active-content-node',
     elementClass: 'tts-content-node',
-    left: 50,
+    left: -10,
     maxPlaybackRate: 2,
     minPlaybackRate: 0.5,
     playbackRate: 1,
@@ -328,13 +328,16 @@ function maskingComponentFactory(container, config) {
             this.render(container);
         })
         .on('render', function () {
-            const {
+            let {
                 left,
                 maxPlaybackRate,
                 minPlaybackRate,
                 playbackRate: defaultPlaybackRate,
                 top
             } = this.getConfig();
+            if (left < 0) {
+                left = window.innerWidth - this.getElement().width() + left;
+            }
             const $element = this.getElement();
             const $closeElement = $('.tts-control-close', $element);
             const $dragElement = $('.tts-control-drag', $element);

--- a/test/plugins/tools/apipTextToSpeech/plugin/test.js
+++ b/test/plugins/tools/apipTextToSpeech/plugin/test.js
@@ -411,15 +411,15 @@ define([
             .then(() => {
                 const $button = $container.find('[data-control="apiptts"]');
 
-                assert.equal(plugin.getState('active'), false, 'The plugin should not be active by default');
-
-                $button.click();
-
-                assert.equal(plugin.getState('active'), true, 'The button should toggle the plugin to active state');
+                assert.equal(plugin.getState('active'), true, 'The plugin should be active by default');
 
                 $button.click();
 
                 assert.equal(plugin.getState('active'), false, 'If the plugin is active, the button should toggle the plugin to non active state');
+
+                $button.click();
+
+                assert.equal(plugin.getState('active'), true, 'The button should toggle the plugin to active state');
             })
             .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);

--- a/test/plugins/tools/apipTextToSpeech/plugin/test.js
+++ b/test/plugins/tools/apipTextToSpeech/plugin/test.js
@@ -449,6 +449,7 @@ define([
                 areaBroker.getToolbox().render($container);
 
                 runner.trigger('renderitem');
+                runner.trigger(`${actionPrefix}toggle`);
 
                 return plugin.enable();
             })


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-381

**Description**
test taker wants to have the TTS tool defaulted to on when I begin the test and stay on (unless turn it off) across all items of the test.

**How to test**
1. prepare ACT instance
2. link or replace package with this branch
3. navigate to test with some APIP items
4. check APIP plugin state and position across items

**Related PR's**
https://github.com/oat-sa/extension-tao-testqti/pull/1767