### PR TITLE
[TCA-525] Tools - Timer - Add Accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -150,6 +150,14 @@
             display: none;
         }
     }
+
+    .visible-hidden {
+      position: absolute;
+      overflow: hidden;
+      height: 1px;
+      width: 1px;
+      word-wrap: normal;
+  }
 }
 
 .no-controls .test-runner-scope {

--- a/src/plugins/controls/timer/component/countdown.js
+++ b/src/plugins/controls/timer/component/countdown.js
@@ -106,6 +106,7 @@ export default function countdownFactory($container, config) {
                 var encodedTime;
                 var warningId;
                 var warningMessage;
+                let screenreaderWarningId;
 
                 if (!this.is('completed')) {
                     if (remainingTime <= 0) {
@@ -147,6 +148,33 @@ export default function countdownFactory($container, config) {
                                  * @param {String} level
                                  */
                                 this.trigger('warn', warningMessage, this.warnings[warningId].level);
+                            }
+                        }
+
+                        if (this.warningsForScreenreader) {
+                            //the warnings have already be sorted
+                            screenreaderWarningId = _.findLastKey(this.warningsForScreenreader, (warning) => (
+                                warning &&
+                                !warning.shown &&
+                                warning.threshold > 0 &&
+                                warning.threshold >= self.remainingTime
+                            ));
+
+                            if (screenreaderWarningId) {
+                                this.warningsForScreenreader[screenreaderWarningId].shown = true;
+
+                                /**
+                                 * Warn user the timer reach a threshold
+                                 * @event countdown#warn
+                                 * @param {String} message
+                                 * @param {String} level
+                                 */
+                                this.trigger(
+                                    'warnscreenreader',
+                                    this.warningsForScreenreader[screenreaderWarningId].message,
+                                    self.remainingTime,
+                                    this.warningsForScreenreader[screenreaderWarningId].scope
+                                );
                             }
                         }
 
@@ -251,6 +279,10 @@ export default function countdownFactory($container, config) {
 
             if (this.config.warnings) {
                 this.warnings = _.sortBy(this.config.warnings, 'threshold');
+            }
+
+            if (this.config.warningsForScreenreader) {
+                this.warningsForScreenreader = _.sortBy(this.config.warningsForScreenreader, 'threshold');
             }
 
             //if configured, create a polling for the countdown

--- a/src/plugins/controls/timer/component/countdown.js
+++ b/src/plugins/controls/timer/component/countdown.js
@@ -106,7 +106,6 @@ export default function countdownFactory($container, config) {
                 var encodedTime;
                 var warningId;
                 var warningMessage;
-                let screenreaderWarningId;
 
                 if (!this.is('completed')) {
                     if (remainingTime <= 0) {
@@ -153,7 +152,7 @@ export default function countdownFactory($container, config) {
 
                         if (this.warningsForScreenreader) {
                             //the warnings have already be sorted
-                            screenreaderWarningId = _.findLastKey(this.warningsForScreenreader, (warning) => (
+                            const screenreaderWarningId = _.findLastKey(this.warningsForScreenreader, (warning) => (
                                 warning &&
                                 !warning.shown &&
                                 warning.threshold > 0 &&
@@ -165,9 +164,10 @@ export default function countdownFactory($container, config) {
 
                                 /**
                                  * Warn user the timer reach a threshold
-                                 * @event countdown#warn
-                                 * @param {String} message
-                                 * @param {String} level
+                                 * @event countdown#warnscreenreader
+                                 * @param {Function} message
+                                 * @param {Number} remainingTime
+                                 * @param {String} scope
                                  */
                                 this.trigger(
                                     'warnscreenreader',

--- a/src/plugins/controls/timer/component/timerbox.js
+++ b/src/plugins/controls/timer/component/timerbox.js
@@ -213,13 +213,13 @@ export default function timerboxFactory(config) {
                             })
                             .on('change', function(value) {
                                 if (self.timers[id]) {
-                                    self.trigger('timertick', this.remainingTime); // propogate current timer data
+                                    self.trigger('timertick', this.remainingTime, self.timers[id].scope); // propogate current timer data
 
                                     //keep the current timer data in sync
                                     self.timers[id].remainingTime = value;
                                 }
                             });
-                        countdown.spread(self, ['error', 'change', 'warn']);
+                        countdown.spread(self, ['error', 'change', 'warn', 'warnscreenreader']);
                     });
                 }
                 return Promise.resolve(false);

--- a/src/plugins/controls/timer/component/tpl/screenreaderNotification.tpl
+++ b/src/plugins/controls/timer/component/tpl/screenreaderNotification.tpl
@@ -1,0 +1,1 @@
+<div aria-live="polite" class="visible-hidden"></div>

--- a/src/plugins/controls/timer/component/tpl/timerbox.tpl
+++ b/src/plugins/controls/timer/component/tpl/timerbox.tpl
@@ -1,6 +1,6 @@
 <div class="timer-box" aria-hidden="{{ariaHidden}}">
     {{#if zenMode.enabled}}
-    <a href="#" class="timer-toggler hidden" title="{{__ 'Hide timers'}}"><span class="icon-clock"></span></a>
+    <a href="#" class="timer-toggler hidden" title="{{__ 'Hide timers'}}" role="button"><span class="icon-clock"></span></a>
     {{/if}}
     <div class="timer-wrapper">
 

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -235,14 +235,22 @@ export default pluginFactory({
                                 }
                             });
 
-                            self.timerbox.on('warnscreenreader', (message, remainingTime, scope) => {
-                                const stats = statsHelper.getInstantStats(scope, testRunner);
-                                const unansweredQuestions = stats && (stats.questions - stats.answered);
+                            // debounce used to prevent multiple invoking at the same time
+                            self.timerbox.on('warnscreenreader', _.debounce(
+                                (message, remainingTime, scope) => {
+                                    const stats = statsHelper.getInstantStats(scope, testRunner);
+                                    const unansweredQuestions = stats && (stats.questions - stats.answered);
 
-                                self.$screenreaderWarningContainer.text(
-                                    message(remainingTime, unansweredQuestions)
-                                );
-                            });
+                                    self.$screenreaderWarningContainer.text(
+                                        message(remainingTime, unansweredQuestions)
+                                    );
+                                },
+                                1000,
+                                {
+                                    'leading': true,
+                                    'trailing': false
+                                }
+                            ));
                         }
                     })
                     .catch(handleError);

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -36,6 +36,7 @@ import timerboxFactory from 'taoQtiTest/runner/plugins/controls/timer/component/
 import timersFactory from 'taoQtiTest/runner/plugins/controls/timer/timers';
 import isReviewPanelEnabled from 'taoQtiTest/runner/helpers/isReviewPanelEnabled';
 import statsHelper from 'taoQtiTest/runner/helpers/stats';
+import screenreaderNotificationTpl from 'taoQtiTest/runner/plugins/controls/timer/component/tpl/screenreaderNotification.tpl';
 
 /**
  * Creates the plugin
@@ -264,7 +265,7 @@ export default pluginFactory({
     render: function render() {
         const $container = this.getAreaBroker().getControlArea();
 
-        this.$screenreaderWarningContainer = $('<div aria-live="polite" class="visible-hidden"></div>');
+        this.$screenreaderWarningContainer = $(screenreaderNotificationTpl());
         this.timerbox.render($container);
         $container.append(this.$screenreaderWarningContainer);
     },

--- a/src/plugins/controls/timer/timers.js
+++ b/src/plugins/controls/timer/timers.js
@@ -77,7 +77,7 @@ var warningMessages = {
 /**
  * The text of warning messages for screenreader
  */
-var warningMessagesForScreenreder = {
+const warningMessagesForScreenraeder = {
     item: __('You have %s remaining to complete the current item.'),
     section: __('You have %s left to answer remaining %s questions.'),
     testPart: __('You have %s left to answer remaining %s questions.'),
@@ -137,7 +137,7 @@ export default function getTimers(timeConstraints, isLinear, config) {
                         .humanize();
 
                     return format(
-                        warningMessagesForScreenreder[scope],
+                        warningMessagesForScreenraeder[scope],
                         displayRemaining,
                         unansweredQuestions
                     );

--- a/src/plugins/controls/timer/timers.js
+++ b/src/plugins/controls/timer/timers.js
@@ -75,6 +75,16 @@ var warningMessages = {
 };
 
 /**
+ * The text of warning messages for screenreader
+ */
+var warningMessagesForScreenreder = {
+    item: __('You have %s remaining to complete the current item.'),
+    section: __('You have %s left to answer remaining %s questions.'),
+    testPart: __('You have %s left to answer remaining %s questions.'),
+    test: __('You have %s left to answer remaining %s questions.')
+};
+
+/**
  * Get the timers objects from the time constraints andt the given config
  * @param {Object[]} timeConstraints - as defined in the testContext
  * @param {Boolean} isLinear - is the current navigation mode linear
@@ -98,12 +108,44 @@ export default function getTimers(timeConstraints, isLinear, config) {
                     threshold: parseInt(key, 10) * precision,
                     message: function applyMessage(remainingTime) {
                         var displayRemaining = moment.duration(remainingTime / precision, 'seconds').humanize();
+
                         return format(warningMessages[scope], displayRemaining);
                     },
                     level: value,
                     shown: false
                 };
             });
+            return acc;
+        },
+        {}
+    );
+
+
+    /**
+     * The warnings comes in a weird format (ie. {scope:[threshold, ...]}) , so we reformat them
+     */
+    const constraintsWarningsForScreenreader = _.reduce(
+        config.warningsForScreenreader,
+        (acc, warnings, qtiScope) => {
+            const scope = getScope(qtiScope);
+
+            acc[scope] = _.map(warnings, (value) => ({
+                threshold: parseInt(value, 10) * precision,
+                message: function applyMessage(remainingTime, unansweredQuestions) {
+                    const displayRemaining = moment
+                        .duration(remainingTime / precision, 'seconds')
+                        .humanize();
+
+                    return format(
+                        warningMessagesForScreenreder[scope],
+                        displayRemaining,
+                        unansweredQuestions
+                    );
+                },
+                scope,
+                shown: false
+            }));
+
             return acc;
         },
         {}
@@ -157,6 +199,7 @@ export default function getTimers(timeConstraints, isLinear, config) {
         //TODO supports warnings for other types
         if (type === 'max' && _.isArray(constraintsWarnings[timer.scope])) {
             timer.warnings = constraintsWarnings[timer.scope];
+            timer.warningsForScreenreader = constraintsWarningsForScreenreader[timer.scope];
         }
         return timer;
     };

--- a/src/plugins/controls/timer/timers.js
+++ b/src/plugins/controls/timer/timers.js
@@ -199,8 +199,12 @@ export default function getTimers(timeConstraints, isLinear, config) {
         //TODO supports warnings for other types
         if (type === 'max' && _.isArray(constraintsWarnings[timer.scope])) {
             timer.warnings = constraintsWarnings[timer.scope];
+        }
+
+        if (_.isArray(constraintsWarningsForScreenreader[timer.scope])) {
             timer.warningsForScreenreader = constraintsWarningsForScreenreader[timer.scope];
         }
+
         return timer;
     };
 

--- a/src/plugins/controls/title/title.js
+++ b/src/plugins/controls/title/title.js
@@ -22,55 +22,183 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 import $ from 'jquery';
+import __ from 'i18n';
+import _ from 'lodash';
 import pluginFactory from 'taoTests/runner/plugin';
 import titleTpl from 'taoQtiTest/runner/plugins/controls/title/title.tpl';
 import mapHelper from 'taoQtiTest/runner/helpers/map';
+import moment from 'moment';
+import statsHelper from 'taoQtiTest/runner/helpers/stats';
+
+const precision = 1000;
 
 export default pluginFactory({
     name: 'title',
     init: function init() {
-        var self = this;
-        var testRunner = this.getTestRunner();
-        var testMap = testRunner.getTestMap();
+        const testRunner = this.getTestRunner();
+        const testMap = testRunner.getTestMap();
 
-        var createElement = function() {
+        const updateTitles = () => {
             const testContext = testRunner.getTestContext();
+            const currentPart = mapHelper.getItemPart(
+                testMap,
+                testContext.itemPosition
+            );
+            const currentItem = mapHelper.getItem(
+                testMap,
+                testContext.itemIdentifier
+            );
 
-            const titles = [
-                {
-                    control: 'qti-test-title',
-                    text: testMap.title || ''
-                }
-            ];
+            // update test title
+            this.titles.test.$title.text(testMap.title).show();
 
+            // update part title
+            if (currentPart) {
+                this.titles.testPart.$title
+                    .text(` - ${currentPart.label}`)
+                    .show();
+            }
+
+            // update section title
             //@deprecated the following block seems to
             //be very specific and need to be reworked
             if (testContext.isDeepestSectionVisible) {
                 const section = mapHelper.getItemSection(
-                    testRunner.getTestMap(),
+                    testMap,
                     testContext.itemPosition
                 );
-                titles.push({
-                    //WTF !? isn't it the section title... ?
-                    control: 'qti-test-position',
-                    //testContext.sectionTitle is kept only for backward compat
-                    text: section.title || testContext.sectionTitle
-                });
+
+                //testContext.sectionTitle is kept only for backward compat
+                this.titles.section.$title
+                    .text(` - ${section.label || testContext.sectionTitle}`)
+                    .show();
             }
 
-            return $(titleTpl({ titles: titles }));
+            // update item title
+            this.titles.item.$title
+                .text(` - ${currentItem.label}`)
+                .show();
         };
 
-        this.$element = createElement();
+        testRunner
+            .after('renderitem', () => {
+                updateTitles();
 
-        testRunner.after('renderitem', function() {
-            var $element = createElement();
-            self.$element.replaceWith($element);
-            self.$element = $element;
-        });
+                _.forOwn(this.titles, (options, scope) => {
+                    if (scope === 'item') {
+                        return;
+                    }
+
+                    this.titles[scope].stats = statsHelper.getInstantStats(scope, testRunner);
+                });
+            })
+            .on('timertick', (remainingTime, scope) => {
+                const title = this.titles[scope];
+
+                if (!title) {
+                    return;
+                }
+
+                const {
+                    $timer,
+                    hours: currentHours,
+                    minutes: currentMinutes,
+                    stats,
+                    unansweredQuestions: currentUnansweredQuestions,
+                } = this.titles[scope];
+                const time = moment.duration(remainingTime / precision, 'seconds');
+                const hours = time.get('hours');
+                const minutes = time.get('minutes');
+                let timerMessage = '';
+
+                // check if notification should be updated
+                if (
+                    currentHours !== hours
+                    || currentMinutes !== minutes
+                    || (stats && ((stats.questions - stats.answered) !== currentUnansweredQuestions))
+                ) {
+                    const unansweredQuestions = stats && (stats.questions - stats.answered);
+
+                    this.titles[scope].hours = hours;
+                    this.titles[scope].minutes = minutes;
+                    this.titles[scope].unansweredQuestions = stats && (stats.questions - stats.answered);
+
+                    if (unansweredQuestions) {
+                        if (hours > 0) {
+                            timerMessage = __(
+                                '%sh %sm to answer remaining %s questions.',
+                                hours,
+                                minutes,
+                                unansweredQuestions
+                            );
+                        } else if (minutes > 0) {
+                            timerMessage = __(
+                                '%sm to answer remaining %s questions.',
+                                minutes,
+                                unansweredQuestions
+                            );
+                        } else {
+                            timerMessage = __(
+                                'Less than one minute to answer remaining %s questions.',
+                                unansweredQuestions
+                            );
+                        }
+                    } else {
+                        if (hours > 0) {
+                            timerMessage = __(
+                                '%sh %sm to answer the current question.',
+                                hours,
+                                minutes
+                            );
+                        } else if (minutes > 0) {
+                            timerMessage = __(
+                                '%sm to answer the current question.',
+                                minutes
+                            );
+                        } else {
+                            timerMessage = __(
+                                'Less than one minute to answer the current question.'
+                            );
+                        }
+                    }
+
+                    $timer.text(timerMessage);
+                }
+            })
+            .on('unloaditem', () => {
+                $('qti-controls', this.$element).hide();
+            });
     },
     render: function render() {
-        var $container = this.getAreaBroker().getControlArea();
+        const $container = this.getAreaBroker().getControlArea();
+        this.titles = {
+            test: {
+                attribute: 'qti-test-title',
+                className: '',
+            },
+            testPart: {
+                attribute: 'qti-test-part-title',
+                className: 'visible-hidden',
+            },
+            section: {
+                attribute: 'qti-test-position',
+                className: '',
+            },
+            item: {
+                attribute: 'qti-test-item-title',
+                className: 'visible-hidden',
+            },
+        };
+        this.$element = $(titleTpl({ titles: _.values(this.titles) }));
+
+        // hide titles by default
+        $('qti-controls', this.$element).hide();
+
         $container.append(this.$element);
-    }
+
+        _.forOwn(this.titles, ({ attribute }, scope) => {
+            this.titles[scope].$title = $container.find(`[data-control="${attribute}"]`);
+            this.titles[scope].$timer = $container.find(`[data-control="${attribute}-timer"]`);
+        });
+    },
 });

--- a/src/plugins/controls/title/title.js
+++ b/src/plugins/controls/title/title.js
@@ -86,25 +86,25 @@ export default pluginFactory({
             if (hours > 0) {
                 timerMessage = typeof unansweredQuestions === 'number'
                     ? __(
-                        '%sh %sm to answer remaining %s questions.',
+                        '%s hours %s minutes to answer remaining %s questions.',
                         hours,
                         minutes,
                         unansweredQuestions
                     )
                     : timerMessage = __(
-                        '%sh %sm to answer the current question.',
+                        '%s hours %s minutes to answer the current question.',
                         hours,
                         minutes
                     );
             } else if (minutes > 0) {
                 timerMessage = typeof unansweredQuestions === 'number'
                     ? __(
-                        '%sm to answer remaining %s questions.',
+                        '%s minutes to answer remaining %s questions.',
                         minutes,
                         unansweredQuestions
                     )
                     : __(
-                        '%sm to answer the current question.',
+                        '%s minutes to answer the current question.',
                         minutes
                     );
             } else {

--- a/src/plugins/controls/title/title.tpl
+++ b/src/plugins/controls/title/title.tpl
@@ -1,5 +1,6 @@
 <div role="heading" aria-level="1" class="title-box truncate">
     {{#each titles}}
-        <span data-control="{{control}}" class="qti-controls" title="{{text}}">{{#unless @first}} - {{/unless}}{{text}}</span>
+        <span data-control="{{attribute}}" class="qti-controls {{className}}"></span>
+        <span data-control="{{attribute}}-timer" class="visible-hidden"></span>
     {{/each}}
 </div>

--- a/test/plugins/controls/timer/countdown/test.js
+++ b/test/plugins/controls/timer/countdown/test.js
@@ -267,6 +267,41 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
                 ready();
             });
     });
+
+    QUnit.test('screenreader waringins', function(assert) {
+        const ready = assert.async();
+        const $container = $('#qunit-fixture .timer-box');
+        const message = () => {};
+        const scope = 'test';
+
+        assert.expect(3);
+
+        countdownFactory($container, {
+            id: 'timer-2',
+            label: 'Timer 02',
+            remainingTime: 3000,
+            polling: true,
+            warningsForScreenreader: [
+                {
+                    level: 'success',
+                    message,
+                    scope,
+                    threshold: 3000
+                }
+            ]
+        })
+            .on('render', function() {
+                this.start();
+            })
+            .on('warnscreenreader', (messageArg, remainingTime, scopeArg) => {
+                assert.equal(messageArg, message, 'the message is provided');
+                assert.equal(typeof remainingTime, 'number', 'the remaning time is provided');
+                assert.equal(scopeArg, scope, 'the scope is provided');
+
+                ready();
+            });
+    });
+
     QUnit.module('Visual test');
 
     QUnit.test('Countdow', function(assert) {

--- a/test/plugins/controls/title/test.html
+++ b/test/plugins/controls/title/test.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner Plugin - Title</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['taoQtiTest/test/runner/plugins/controls/title/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+        <div id="title-playground-container" class="qti-item runtime"></div>
+    </body>
+</html>

--- a/test/plugins/controls/title/test.js
+++ b/test/plugins/controls/title/test.js
@@ -303,28 +303,28 @@ define([
                 runner.trigger('timertick', 60000, 'test');
                 assert.equal(
                     $container.find('[data-control="qti-test-title-timer"]').text(),
-                    '1m to answer remaining 1 questions.',
+                    '1 minutes to answer remaining 1 questions.',
                     'Update test timer'
                 );
 
                 runner.trigger('timertick', 60000, 'testPart');
                 assert.equal(
                     $container.find('[data-control="qti-test-part-title-timer"]').text(),
-                    '1m to answer remaining 1 questions.',
+                    '1 minutes to answer remaining 1 questions.',
                     'Update part timer'
                 );
 
                 runner.trigger('timertick', 60000, 'section');
                 assert.equal(
                     $container.find('[data-control="qti-test-position-timer"]').text(),
-                    '1m to answer remaining 1 questions.',
+                    '1 minutes to answer remaining 1 questions.',
                     'Update section timer'
                 );
 
                 runner.trigger('timertick', 60000, 'item');
                 assert.equal(
                     $container.find('[data-control="qti-test-item-title-timer"]').text(),
-                    '1m to answer the current question.',
+                    '1 minutes to answer the current question.',
                     'Update item timer'
                 );
 

--- a/test/plugins/controls/title/test.js
+++ b/test/plugins/controls/title/test.js
@@ -1,0 +1,378 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Anton Tsymuk <anton@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/runner/plugins/controls/title/title'
+], function ($, _, runnerFactory, providerMock, pluginFactory) {
+    'use strict';
+
+    const providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    const titles = {
+        test: {
+            attribute: 'qti-test-title',
+            className: '',
+        },
+        testPart: {
+            attribute: 'qti-test-part-title',
+            className: 'visible-hidden',
+        },
+        section: {
+            attribute: 'qti-test-position',
+            className: '',
+        },
+        item: {
+            attribute: 'qti-test-item-title',
+            className: 'visible-hidden',
+        },
+    };
+
+    const sampleTestContext = {
+        itemIdentifier: 'item-1',
+        itemPosition: 0,
+        isDeepestSectionVisible: true,
+    };
+    const sampleTestMap = {
+        parts: {
+            p1: {
+                label: 'part-title',
+                sections: {
+                    s1: {
+                        label: 'section-title',
+                        items: {
+                            'item-1': {
+                                label: 'item-title'
+                            }
+                        },
+                        stats: {
+                            questions: 1,
+                            answered: 0,
+                        },
+                    }
+                },
+                stats: {
+                    questions: 1,
+                    answered: 0,
+                },
+            }
+        },
+        jumps: [{
+            identifier: 'item-1',
+            section: 's1',
+            part: 'p1',
+            position: 0
+        }],
+        title: 'test-title',
+        stats: {
+            questions: 1,
+            answered: 0,
+        },
+    };
+
+    /**
+     * The following tests applies to all plugins
+     */
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', (assert) => {
+        const runner = runnerFactory(providerName);
+
+        assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(
+            pluginFactory(runner),
+            pluginFactory(runner),
+            'The plugin factory provides a different instance on each call'
+        );
+    });
+
+    const pluginApi = [
+        { name: 'init', title: 'init' },
+        { name: 'render', title: 'render' },
+        { name: 'finish', title: 'finish' },
+        { name: 'destroy', title: 'destroy' },
+        { name: 'trigger', title: 'trigger' },
+        { name: 'getTestRunner', title: 'getTestRunner' },
+        { name: 'getAreaBroker', title: 'getAreaBroker' },
+        { name: 'getConfig', title: 'getConfig' },
+        { name: 'setConfig', title: 'setConfig' },
+        { name: 'getState', title: 'getState' },
+        { name: 'setState', title: 'setState' },
+        { name: 'show', title: 'show' },
+        { name: 'hide', title: 'hide' },
+        { name: 'enable', title: 'enable' },
+        { name: 'disable', title: 'disable' }
+    ];
+
+    QUnit.cases.init(pluginApi).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner);
+
+        assert.equal(
+            typeof plugin[data.name],
+            'function',
+            `The pluginFactory instances expose a "${data.name}" function`
+        );
+    });
+
+    QUnit.test('pluginFactory.init', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner);
+
+        plugin
+            .init()
+            .then(() => {
+                assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
+            })
+            .catch((err) => {
+                assert.ok(false, `The init failed: ${err}`);
+            })
+            .then(ready);
+    });
+
+    QUnit.test('pluginFactory.render', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getControlArea();
+        const plugin = pluginFactory(runner, areaBroker);
+
+        assert.expect(9);
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                _.forEach(_.values(titles), ({ attribute, className }) => {
+                    $container.find();
+
+                    assert.equal(
+                        $container.find(`${className ? `.${className}` : ''}[data-control="${attribute}"]`).length,
+                        1,
+                        'Add the title with the given css class to the container'
+                    );
+                    assert.equal(
+                        $container.find(`.visible-hidden[data-control="${attribute}-timer"]`).length,
+                        1,
+                        'Add the visible hidden title timer to the container'
+                    );
+                });
+
+                assert.equal(
+                    $container.find('.qti-controls').css('display'),
+                    'none',
+                    'Hide the titles by default'
+                );
+
+                ready();
+            });
+    });
+
+    QUnit.test('test runner events: renderitem', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getControlArea();
+        const plugin = pluginFactory(runner, areaBroker);
+
+        assert.expect(4);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+
+        runner.getCurrentItem = () => ({});
+        runner.getCurrentPart = () => ({ label: 'part-title' });
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                return runner.trigger('renderitem');
+            })
+            .then(() => {
+                assert.equal(
+                    $container.find('[data-control="qti-test-title"]').text(),
+                    'test-title',
+                    'Add test title'
+                );
+
+                assert.equal(
+                    $container.find('[data-control="qti-test-part-title"]').text(),
+                    ' - part-title',
+                    'Add part title'
+                );
+
+                assert.equal(
+                    $container.find('[data-control="qti-test-position"]').text(),
+                    ' - section-title',
+                    'Add section title'
+                );
+
+                assert.equal(
+                    $container.find('[data-control="qti-test-item-title"]').text(),
+                    ' - item-title',
+                    'Add item title'
+                );
+
+                ready();
+            });
+    });
+
+    QUnit.test('test runner events: unloaditem', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getControlArea();
+        const plugin = pluginFactory(runner, areaBroker);
+
+        assert.expect(1);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+
+        runner.getCurrentItem = () => ({});
+        runner.getCurrentPart = () => ({ label: 'part-title' });
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                return runner.trigger('renderitem');
+            })
+            .then(() => runner.trigger('unloaditem'))
+            .then(() => {
+                assert.equal(
+                    $container.find('.qti-controls').css('display'),
+                    'none',
+                    'Hide the titles after unloaditem'
+                );
+
+                ready();
+            });
+    });
+
+    QUnit.test('test runner events: timertick', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getControlArea();
+        const plugin = pluginFactory(runner, areaBroker);
+
+        assert.expect(5);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+
+        runner.getCurrentItem = () => ({});
+        runner.getCurrentPart = () => ({ label: 'part-title' });
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                return runner.trigger('renderitem');
+            })
+            .then(() => {
+                runner.trigger('timertick', 60000, 'test');
+                assert.equal(
+                    $container.find('[data-control="qti-test-title-timer"]').text(),
+                    '1m to answer remaining 1 questions.',
+                    'Update test timer'
+                );
+
+                runner.trigger('timertick', 60000, 'testPart');
+                assert.equal(
+                    $container.find('[data-control="qti-test-part-title-timer"]').text(),
+                    '1m to answer remaining 1 questions.',
+                    'Update part timer'
+                );
+
+                runner.trigger('timertick', 60000, 'section');
+                assert.equal(
+                    $container.find('[data-control="qti-test-position-timer"]').text(),
+                    '1m to answer remaining 1 questions.',
+                    'Update section timer'
+                );
+
+                runner.trigger('timertick', 60000, 'item');
+                assert.equal(
+                    $container.find('[data-control="qti-test-item-title-timer"]').text(),
+                    '1m to answer the current question.',
+                    'Update item timer'
+                );
+
+                const headingBeforeTimertick = $container.find('.title-box').text();
+                runner.trigger('timertick', 60000, 'wrongscope');
+                assert.equal(
+                    $container.find('.title-box').text(),
+                    headingBeforeTimertick,
+                    'Heading is not update if scope unknown'
+                );
+
+                ready();
+            });
+    });
+
+    QUnit.test('test runner events: timertick', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getControlArea();
+        const plugin = pluginFactory(runner, areaBroker);
+        const $playground = $('#title-playground-container');
+        $playground.append($container);
+
+        assert.expect(1);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+
+        runner.getCurrentItem = () => ({});
+        runner.getCurrentPart = () => ({ label: 'part-title' });
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                return runner.trigger('renderitem');
+            })
+            .then(() => {
+                runner.trigger('timertick', 60000, 'test');
+                runner.trigger('timertick', 60000, 'testPart');
+                runner.trigger('timertick', 60000, 'section');
+                runner.trigger('timertick', 60000, 'item');
+
+                assert.ok('Playground ready');
+
+                ready();
+            });
+    });
+});


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-525
 
Add invisible timers available for screen readers to H1 heading.
Introduce timer warning notification for screen readers
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a test with time constraints on test, part, section and item scope
- execute delivery as a test taker
- make sure that timers duplicated in h1 heading
- make sure that timers notifications announced by screen reader

#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1770
 - [ ] https://github.com/oat-sa/extension-tao-act/pull/1358