### PR TITLE
[TCA-542] WTP-1554 - Implement proper error response handling in FE test runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -250,6 +250,13 @@ var qtiProvider = {
             //catch server errors
             var submitError = function submitError(err) {
                 if (err && err.unrecoverable){
+                    self.trigger(
+                        'alert.error',
+                        __(
+                            'An unrecoverable error occurred. Your test session will be paused.'
+                        )
+                    );
+
                     self.trigger('pause', {message : err.message});
                 } else if (err.code === 200) {
                     //some server errors are valid, so we don't fail (prevent empty responses)
@@ -770,6 +777,9 @@ var qtiProvider = {
                     }
                 })
                 .then(function() {
+                    probeOverseer.stop();
+                })
+                .catch(function() {
                     probeOverseer.stop();
                 });
         } else {


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-542
 
Handle sync request error before leaving the test
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery with a few items
- execute the delivery as a test taker
- apply changes to trigger sync error from related PR
- try to navigate to the next item and check if the test is paused
 
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1765