### PR TITLE
Feature/tca 307/review panel expose status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -979,9 +979,8 @@
             }
         },
         "@oat-sa/tao-core-ui": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.26.1.tgz",
-            "integrity": "sha512-hzrgOoYmvIxXmcYU6wgUUgN9cSn14yRFP2njEOHpkUGsaV7v1kOhl8I199aTEe67T1/5VoXGnq+MQtXssTH6+Q==",
+            "version": "github:oat-sa/tao-core-ui-fe#8cb07e3261177eb6029258699170d9526e9d06d5",
+            "from": "github:oat-sa/tao-core-ui-fe#breaking/ACTP-429/keynavigation-issue-in-native-mode",
             "dev": true
         },
         "@oat-sa/tao-item-runner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.1.2",
+    "version": "2.2.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -374,6 +374,18 @@ var navigatorApi = {
 
             itm.cls = cls.join(' ');
             itm.icon = icon;
+
+            if (!itm.viewed) {
+                itm.ariaLabel = 'not seen'
+            } else {
+                if (itm.flagged) {
+                    itm.ariaLabel = 'flagged'
+                } else if (itm.answered) {
+                    itm.ariaLabel = 'answered'
+                } else {
+                    itm.ariaLabel = 'not answered'
+                }
+            }
         });
     },
 

--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -374,18 +374,6 @@ var navigatorApi = {
 
             itm.cls = cls.join(' ');
             itm.icon = icon;
-
-            if (!itm.viewed) {
-                itm.ariaLabel = 'not seen'
-            } else {
-                if (itm.flagged) {
-                    itm.ariaLabel = 'flagged'
-                } else if (itm.answered) {
-                    itm.ariaLabel = 'answered'
-                } else {
-                    itm.ariaLabel = 'not answered'
-                }
-            }
         });
     },
 

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -33,7 +33,7 @@
                         <span class="qti-navigator-label truncate" title="{{label}}"
                               role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
                               {{#if active}}aria-current="page"{{/if}}
-                              aria-label="{{index}} of {{../stats.questions}} {{icon}}">
+                              aria-label="{{index}} of {{../stats.total}} {{icon}}">
                             <span class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -29,12 +29,12 @@
                 </span>
                 <ul class="qti-navigator-items collapsible-panel plain">
                     {{#each items}}
-                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}"
-                        tabindex="-1" role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
-                        {{#if active}}aria-current="page"{{/if}}>
-                        <span class="qti-navigator-label truncate" title="{{label}}">
-                            <span aria-label="{{#if flagged}}flagged{{else}}{{#if answered}}answered{{else}}{{#if viewed}}viewed{{else}}unseen{{/if}}{{/if}}{{/if}}"
-                                  class="qti-navigator-icon icon-{{icon}}"></span>
+                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}" tabindex="-1" >
+                        <span class="qti-navigator-label truncate" title="{{label}}"
+                              role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
+                              {{#if active}}aria-current="page"{{/if}}
+                              aria-label="item {{index}} of {{../stats.questions}} total {{label}} {{#if flagged}}flagged{{else}}{{#if answered}}answered{{else}}{{#if viewed}}viewed{{else}}unseen{{/if}}{{/if}}{{/if}}">
+                            <span class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}
                         </span>

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -33,7 +33,7 @@
                         <span class="qti-navigator-label truncate" title="{{label}}"
                               role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
                               {{#if active}}aria-current="page"{{/if}}
-                              aria-label="{{icon}} {{index}} of {{../stats.questions}}">
+                              aria-label="{{index}} of {{../stats.questions}} {{icon}}">
                             <span class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -20,14 +20,14 @@
             </p>
         </div>
         {{else}}
-        <ul class="qti-navigator-sections collapsible-panel plain">
+        <ul aria-label="{{label}}" class="qti-navigator-sections collapsible-panel plain">
             {{#each sections}}
             <li class="qti-navigator-section collapsible {{#if active}}active{{else}}collapsed{{/if}}" data-id="{{id}}">
                 <span class="qti-navigator-label" title="{{label}}">
                     <span class="qti-navigator-text">{{label}}</span>
                     <span class="qti-navigator-counter">{{stats.answered}}/{{stats.total}}</span>
                 </span>
-                <ul class="qti-navigator-items collapsible-panel plain">
+                <ul aria-label="{{label}}" class="qti-navigator-items collapsible-panel plain">
                     {{#each items}}
                     <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}" tabindex="0" >
                         <span class="qti-navigator-label truncate" title="{{label}}"

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -33,7 +33,7 @@
                         <span class="qti-navigator-label truncate" title="{{label}}"
                               role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
                               {{#if active}}aria-current="page"{{/if}}
-                              aria-label="item {{index}} of {{../stats.questions}} total {{label}} {{icon}}">
+                              aria-label="{{label}} {{icon}} {{index}} of {{../stats.questions}}">
                             <span class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -29,11 +29,11 @@
                 </span>
                 <ul class="qti-navigator-items collapsible-panel plain">
                     {{#each items}}
-                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}" tabindex="-1" >
+                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}" tabindex="0" >
                         <span class="qti-navigator-label truncate" title="{{label}}"
                               role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
                               {{#if active}}aria-current="page"{{/if}}
-                              aria-label="item {{index}} of {{../stats.questions}} total {{label}} {{#if flagged}}flagged{{else}}{{#if answered}}answered{{else}}{{#if viewed}}viewed{{else}}unseen{{/if}}{{/if}}{{/if}}">
+                              aria-label="item {{index}} of {{../stats.questions}} total {{label}} {{icon}}">
                             <span class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -29,9 +29,11 @@
                 </span>
                 <ul class="qti-navigator-items collapsible-panel plain">
                     {{#each items}}
-                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}">
+                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}"
+                        tabindex="-1" role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
+                        {{#if active}}aria-current="page"{{/if}}>
                         <span class="qti-navigator-label truncate" title="{{label}}">
-                            <span class="qti-navigator-icon icon-{{icon}}"></span>
+                            <span aria-label="{{ariaLabel}}" class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}
                         </span>

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -29,7 +29,7 @@
                 </span>
                 <ul aria-label="{{label}}" class="qti-navigator-items collapsible-panel plain">
                     {{#each items}}
-                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}" tabindex="0" >
+                    <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}">
                         <span class="qti-navigator-label truncate" title="{{label}}"
                               role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
                               {{#if active}}aria-current="page"{{/if}}

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -33,7 +33,7 @@
                         <span class="qti-navigator-label truncate" title="{{label}}"
                               role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
                               {{#if active}}aria-current="page"{{/if}}
-                              aria-label="{{label}} {{icon}} {{index}} of {{../stats.questions}}">
+                              aria-label="{{icon}} {{index}} of {{../stats.questions}}">
                             <span class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}

--- a/src/plugins/navigation/review/navigatorTree.tpl
+++ b/src/plugins/navigation/review/navigatorTree.tpl
@@ -33,7 +33,8 @@
                         tabindex="-1" role="link" aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
                         {{#if active}}aria-current="page"{{/if}}>
                         <span class="qti-navigator-label truncate" title="{{label}}">
-                            <span aria-label="{{ariaLabel}}" class="qti-navigator-icon icon-{{icon}}"></span>
+                            <span aria-label="{{#if flagged}}flagged{{else}}{{#if answered}}answered{{else}}{{#if viewed}}viewed{{else}}unseen{{/if}}{{/if}}{{/if}}"
+                                  class="qti-navigator-icon icon-{{icon}}"></span>
                             <span class="qti-navigator-number">{{index}}</span>
                             {{label}}
                         </span>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-307
 
TestRunner - ReviewPanel - Expose the status of parts, sections and items.
  
#### How to test

- Create a test with the review panel enabled
- Start a test as a test taker
- Navigate to the review panel via Tab
- Check that screen reader announces:
  - the label of the test part (if present)
  - the label of the test section (if present)
  - the position of the focused item
  - the state of the focused item (answered, viewed, etc.)
  - that it is a link
  - that it is current
  - the label of the item

(Keyboard navigation issues are not taken into account here)
