### PR TITLE
[TCA-501] TestRunner - Passages - Ability to scroll item content using KB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation/modes/defaultMode.js
+++ b/src/plugins/content/accessibility/keyNavigation/modes/defaultMode.js
@@ -29,7 +29,7 @@ export default {
      */
     init(config = {}) {
         return {
-            strategies: ['rubrics', 'item', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
+            strategies: ['rubrics', 'stimulus', 'item', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: Object.assign({
                 autoFocus: true,
                 keepState: true,

--- a/src/plugins/content/accessibility/keyNavigation/modes/linearMode.js
+++ b/src/plugins/content/accessibility/keyNavigation/modes/linearMode.js
@@ -29,7 +29,7 @@ export default {
      */
     init(config = {}) {
         return {
-            strategies: ['rubrics', 'linearItem', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
+            strategies: ['rubrics', 'stimulus', 'linearItem', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: Object.assign({
                 autoFocus: true,
                 keepState: true,

--- a/src/plugins/content/accessibility/keyNavigation/modes/nativeMode.js
+++ b/src/plugins/content/accessibility/keyNavigation/modes/nativeMode.js
@@ -30,7 +30,7 @@ export default {
     init(config = {}) {
         return {
             // todo: add access to the page and the rubric blocks
-            strategies: ['header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'item', 'toolbar'],
+            strategies: ['header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'stimulus', 'item', 'toolbar'],
             config: Object.assign({
                 autoFocus: false,
                 keepState: false,

--- a/src/plugins/content/accessibility/keyNavigation/strategies/index.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/index.js
@@ -24,3 +24,4 @@ export { default as pageNavigationStrategy } from './pageNavigation';
 export { default as rubricsNavigationStrategy } from './rubricsNavigation';
 export { default as itemNavigationStrategy } from './itemNavigation';
 export { default as linearItemNavigationStrategy } from './linearItemNavigation';
+export { default as stimulusNavigationStrategy } from './stimulusNavigation';

--- a/src/plugins/content/accessibility/keyNavigation/strategies/stimulusNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/stimulusNavigation.js
@@ -1,0 +1,91 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 Open Assessment Technologies SA ;
+ */
+
+import $ from 'jquery';
+import keyNavigator from 'ui/keyNavigation/navigator';
+import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
+import {
+    setupItemsNavigator
+} from 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/helpers';
+
+/**
+* The identifier the keyNavigator group
+* @type {String}
+*/
+const groupId = 'stimulus-element-navigation-group';
+
+/**
+ * Key navigator strategy applying on stimulus items with scrollbar.
+ * Navigable item content are body elements with the special class "stimulus-container".
+ * @type {Object} keyNavigationStrategy
+ */
+export default {
+    name: 'stimulus',
+
+    /**
+     * Builds the item navigation strategy.
+     *
+     * @returns {keyNavigationStrategy}
+     */
+    init() {
+        const config = this.getConfig();
+        this.keyNavigators = [];
+
+        const $content = this.getTestRunner().getAreaBroker().getContentArea();
+        $content
+            .find('.stimulus-container')
+            // filter out nodes without scrollbar
+            .filter(function () {
+                return this.scrollHeight > this.clientHeight;
+            })
+            .addClass('key-navigation-scrollable')
+            .each((i, el) => {
+                const $element = $(el);
+                const navigator = keyNavigator({
+                    id: `${groupId}-${i}`,
+                    elements: navigableDomElement.createFromDoms($element),
+                    group: $element,
+                    propagateTab: false
+                });
+
+                setupItemsNavigator(navigator, config);
+                this.keyNavigators.push(navigator);
+            });
+
+        return this;
+    },
+
+    /**
+     * Gets the list of applied navigators
+     * @returns {keyNavigator[]}
+     */
+    getNavigators() {
+        return this.keyNavigators;
+    },
+
+    /**
+     * Tears down the keyNavigator strategy
+     * @returns {keyNavigationStrategy}
+     */
+    destroy() {
+        this.keyNavigators.forEach(navigator => navigator.destroy());
+        this.keyNavigators = [];
+
+        return this;
+    }
+};

--- a/test/plugins/content/keyNavigation/modesManager/test.js
+++ b/test/plugins/content/keyNavigation/modesManager/test.js
@@ -42,7 +42,7 @@ define([
             additional: 'foo'
         },
         expected: {
-            strategies: ['rubrics', 'item', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
+            strategies: ['rubrics', 'stimulus', 'item', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: {
                 autoFocus: true,
                 keepState: true,
@@ -66,7 +66,7 @@ define([
             additional: 'foo'
         },
         expected: {
-            strategies: ['rubrics', 'linearItem', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
+            strategies: ['rubrics', 'stimulus', 'linearItem', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: {
                 autoFocus: true,
                 keepState: true,
@@ -90,7 +90,7 @@ define([
             additional: 'foo'
         },
         expected: {
-            strategies: ['header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'item', 'toolbar'],
+            strategies: ['header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'stimulus', 'item', 'toolbar'],
             config: {
                 autoFocus: false,
                 keepState: false,

--- a/test/plugins/content/keyNavigation/strategiesManager/test.js
+++ b/test/plugins/content/keyNavigation/strategiesManager/test.js
@@ -116,7 +116,8 @@ define([
         { title: 'toolbar' },
         { title: 'item' },
         { title: 'linearItem' },
-        { title: 'navigator' }
+        { title: 'navigator' },
+        { title: 'stimulus' }
     ]).test('Navigation strategy ', (data, assert) => {
         const result = strategiesManager(data.title, testRunnerMock);
         assert.equal(typeof result, 'object', `The strategy ${data.title} has been created`);


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-501
 
Add stimulus navigation strategy
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare an item with shared stimulus(item can be found in the comment to the ticket)
- prepare a delivery with the item
- Execute a delivery as a test taker
- Try to navigate to the shared stimulus using keyboard navigation and scroll it's content
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1780