### PR TITLE
Fix/tca 552/review panel jumplinks key navigator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",


### PR DESCRIPTION
_CASE 1_
**Related to:**
https://oat-sa.atlassian.net/browse/TCA-552

**Description**
Test status and structure" jump link sets focus on "Test status" button, but next TAB stop is on Exit button

**How to test**
_Preconditions:_
create a test with Review panel (Enable review scree, Enable mark for review test navigation settings are on)

_Steps:_

1. start the test from preconditions
2. hit TAB button to navigate to jump links
3. select "Test status and structure" jump link, hit Enter
4. navigate inside Review panel using KB

_CASE 2_
**Related to**
https://oat-sa.atlassian.net/browse/TCA-456#icft=TCA-456

**Description**
SR user can reach "Test status menu" only when scanning the page, although it's an interactive element and should have a TAB stop

**How to test**
_Preconditions:_
create a Delivery with "Review panel" enabled

_Steps:_

1. as a user start a test
2. using TAB navigate through the interactive elements on the page
3. change key navigator plugin strategy and test again 