### PR TITLE
[TCA-521] Timer Correction - Introduce new central timer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.1",
+    "version": "2.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.1",
+    "version": "2.4.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/provider/stopwatch.js
+++ b/src/provider/stopwatch.js
@@ -34,54 +34,69 @@ const defaultOptions = {
  * @param {Number} [options.interval]
  * @returns {Object} stopwatch instance
  */
-export default function stopwatchFactory(options) {
+export default function stopwatchFactory(options = {}) {
     const config = Object.assign({}, defaultOptions, options);
+    let initialized = false;
+    let polling;
+    let stopwatch;
 
     return eventifier({
+        /**
+         * Is this instance initialized
+         * @returns {Boolean}
+         */
+        isInitialized() {
+            return initialized;
+        },
         /**
          * Initialize stopwatch
          */
         init() {
-            this.stopwatch = timerFactory({
+            stopwatch = timerFactory({
                 autoStart: false,
             });
 
             /**
              * @fires tick - every time when interval is elapsed
              */
-            this.polling = pollingFactory({
-                action: () => this.trigger('tick', this.stopwatch.tick()),
+            polling = pollingFactory({
+                action: () => this.trigger('tick', stopwatch.tick()),
                 interval: config.interval,
                 autoStart: false,
             });
 
-            this.initialized = true;
+            initialized = true;
         },
         /**
          * Start stopwatch
          */
         start() {
-            if (this.initialized) {
-                this.stopwatch.resume();
-                this.polling.start();
+            if (this.isInitialized()) {
+                stopwatch.resume();
+                polling.start();
             }
         },
         /**
          * Stop stopwatch
          */
         stop() {
-            if (this.initialized) {
-                this.stopwatch.pause();
-                this.polling.stop();
+            if (this.isInitialized()) {
+                stopwatch.pause();
+                polling.stop();
             }
         },
         /**
          * Destory stopwatch by stoping the timer
          */
         destroy() {
-            if (this.initialized) {
-                this.stopwatch.stop();
-                this.polling.stop();
+            if (this.isInitialized()) {
+                initialized = false;
+
+                polling.stop();
+                polling = null;
+
+                stopwatch.stop();
+                stopwatch = null;
             }
         }
     });

--- a/src/provider/stopwatch.js
+++ b/src/provider/stopwatch.js
@@ -1,0 +1,88 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+/**
+ * Tick elapsed time
+ */
+import eventifier from 'core/eventifier';
+import pollingFactory from 'core/polling';
+import timerFactory from 'core/timer';
+
+const defaultOptions = {
+    interval: 1000,
+};
+
+/**
+ * The stopwatch factory
+ * @param {Object} options
+ * @param {Number} [options.interval]
+ * @returns {Object} stopwatch instance
+ */
+export default function stopwatchFactory(options) {
+    const config = Object.assign({}, defaultOptions, options);
+
+    return eventifier({
+        /**
+         * Initialize stopwatch
+         */
+        init() {
+            this.stopwatch = timerFactory({
+                autoStart: false,
+            });
+
+            /**
+             * @fires tick - every time when interval is elapsed
+             */
+            this.polling = pollingFactory({
+                action: () => this.trigger('tick', this.stopwatch.tick()),
+                interval: config.interval,
+                autoStart: false,
+            });
+
+            this.initialized = true;
+        },
+        /**
+         * Start stopwatch
+         */
+        start() {
+            if (this.initialized) {
+                this.stopwatch.resume();
+                this.polling.start();
+            }
+        },
+        /**
+         * Stop stopwatch
+         */
+        stop() {
+            if (this.initialized) {
+                this.stopwatch.pause();
+                this.polling.stop();
+            }
+        },
+        /**
+         * Destory stopwatch by stoping the timer
+         */
+        destroy() {
+            if (this.initialized) {
+                this.stopwatch.stop();
+                this.polling.stop();
+            }
+        }
+    });
+}

--- a/test/provider/stopwatch/test.html
+++ b/test/provider/stopwatch/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner - QTI Provider</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['taoQtiTest/test/runner/provider/stopwatch/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/provider/stopwatch/test.html
+++ b/test/provider/stopwatch/test.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8" />
-        <title>Test Runner - QTI Provider</title>
+        <title>Test Runner - Stopwatch</title>
         <script type="text/javascript" src="/environment/require.js"></script>
         <script type="text/javascript">
             require(['/environment/config.js'], function() {

--- a/test/provider/stopwatch/test.js
+++ b/test/provider/stopwatch/test.js
@@ -1,0 +1,132 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+define([
+    'taoQtiTest/runner/provider/stopwatch'
+], function (stopwatchFactory) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module', assert => {
+        assert.expect(3);
+
+        assert.equal(typeof stopwatchFactory, 'function', 'The module exports a function');
+        assert.equal(typeof stopwatchFactory({}), 'object', 'The stopwatch factory produces an instance');
+        assert.notStrictEqual(
+            stopwatchFactory({}),
+            stopwatchFactory({}),
+            'The stopwatch factory provides a different instance on each call'
+        );
+    });
+
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'start' },
+        { title: 'stop' },
+        { title: 'destroy' },
+    ]).test('The stopwatch factory expose API', (data, assert) => {
+        assert.equal(typeof stopwatchFactory({})[data.title], 'function', 'The method is exposed');
+    });
+
+    QUnit.test('stopwatch.init', (assert) => {
+        const stopwatch = stopwatchFactory({});
+
+        assert.expect(1);
+
+        stopwatch.init();
+
+        assert.equal(stopwatch.isInitialized(), true, 'The stopwatch is initialized');
+    });
+
+    QUnit.test('stopwatch.start', (assert) => {
+        const ready = assert.async();
+        const stopwatch = stopwatchFactory({});
+
+        assert.expect(1);
+
+        stopwatch.init();
+
+        stopwatch.on('tick', () => {
+            assert.ok('the tick event has been triggered');
+
+            stopwatch.stop();
+
+            ready();
+        });
+
+        stopwatch.start();
+    });
+
+    QUnit.test('stopwatch.stop', (assert) => {
+        const ready = assert.async();
+        const interval = 500;
+        const stopwatch = stopwatchFactory({ interval });
+
+        assert.expect(2);
+
+        stopwatch.init();
+
+        stopwatch.on('tick', () => {
+            assert.ok('the tick event has been triggered');
+
+            stopwatch.off('tick');
+            stopwatch.on('tick', () => {
+                assert.notOk('the stopwatch has been stopped, tick should not be triggered');
+            });
+
+            stopwatch.stop();
+
+            setTimeout(() => {
+                assert.ok('the tick has not been triggered');
+
+                ready();
+            }, interval * 2);
+        });
+
+        stopwatch.start();
+    });
+
+    QUnit.test('stopwatch.stop', (assert) => {
+        const ready = assert.async();
+        const interval = 500;
+        const stopwatch = stopwatchFactory({ interval });
+
+        assert.expect(2);
+
+        stopwatch.init();
+
+        stopwatch.on('tick', () => {
+            assert.ok('the tick event has been triggered');
+
+            stopwatch.off('tick');
+            stopwatch.on('tick', () => {
+                assert.notOk('the stopwatch has been destroyed, tick should not be triggered');
+            });
+
+            stopwatch.destroy();
+
+            setTimeout(() => {
+                assert.equal(stopwatch.isInitialized(), false, 'The stopwatch has been destroyed');
+
+                ready();
+            }, interval * 2);
+        });
+
+        stopwatch.start();
+    });
+});


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-521
 
Introduce ф central timer inside test runner provider. 
The timer is client based and its responsibility is to counts out the time spent on the test.
The timer continues counting the time only when the test is interactive otherwise it is paused.
The central timer can be used by subscription to `tick` test runner event.
  
#### How to test
 
**Note:** Currently the timer is not used anywhere, but you still can make some change to subscribe to the test runner `tick` event to check if it is working

`testRunner.on('tick', function(...args) { console.log(args); })`

- prepare an instance of TAO with taoAct extension
- prepare a delivery
- make some change to subscribe to `tick` test runner event
- execute the delivery as a test taker and check that event is triggered

Requires :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1783