### PR TITLE
Fix filter selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -696,23 +696,16 @@ function navigatorFactory(config, map, context) {
 
                     // select the button
                     $filters.removeClass(_cssCls.active);
+                    $filters.attr('aria-selected', false);
                     $component.removeClass(_cssCls.collapsed);
                     $btn.addClass(_cssCls.active);
+                    $btn.attr('aria-selected', true);
 
                     // filter the items
                     self.filter(mode);
 
                     //after filtering, ensure that the active item (if exists) is visible
                     self.autoScroll();
-                }
-            });
-
-            // click on a filter button
-            $filterBar.on(`focus${_selectors.component}`, _selectors.filter, function() {
-                if (!self.is('disabled')) {
-                    const $btn = $(this);
-                    $filters.attr('aria-selected', false);
-                    $btn.attr('aria-selected', true);
                 }
             });
 


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-483

**Description**
Fix: set "aria-selected" only for the active tab

**How to test**
1. as a user start a test
2. enable JAWS
3. navigate to All / Unanswered / Flagged tabs
4. set focus to each tab, listen to SR's announcements

It should announce "selected" only for the tab in active state.
