### PR TITLE
Fix/tca 594/remove tab stop from timer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-action-bars.scss
+++ b/scss/inc/_test-action-bars.scss
@@ -69,7 +69,7 @@
 
             &.top-action-bar > .control-box {
 
-                height: #{(map-get($heights, horizontal-action-bar)) * 1px };
+                height: #{(map-get($heights, horizontal-action-bar) - 2) * 1px };
 
                 display: -ms-flexbox;
                 display: -webkit-flex;

--- a/src/plugins/content/accessibility/keyNavigation/strategies/topToolbarNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/topToolbarNavigation.js
@@ -23,6 +23,7 @@ import {
     setupItemsNavigator,
     setupClickableNavigator
 } from 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/helpers';
+import isReviewPanelEnabled from 'taoQtiTest/runner/helpers/isReviewPanelEnabled';
 
 /**
  * The identifier the keyNavigator group
@@ -45,7 +46,10 @@ export default {
     init() {
         const config = this.getConfig();
         const $topToolbar = this.getTestRunner().getAreaBroker().getContainer().find('.top-action-bar');
-        const $toolbarElements = $topToolbar.find('.countdown, .jump-link');
+        const $toolbarElements = $topToolbar.find('.jump-link');
+        if (!isReviewPanelEnabled(this.getTestRunner())) {
+            $toolbarElements.concat($topToolbar.find('.timer-toggler'));
+        }
 
         const registerTopToolbarNavigator = (id, group, $elements) => {
             const elements = navigableDomElement.createFromDoms($elements);

--- a/src/plugins/content/accessibility/keyNavigation/strategies/topToolbarNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/topToolbarNavigation.js
@@ -46,10 +46,7 @@ export default {
     init() {
         const config = this.getConfig();
         const $topToolbar = this.getTestRunner().getAreaBroker().getContainer().find('.top-action-bar');
-        const $toolbarElements = $topToolbar.find('.jump-link');
-        if (!isReviewPanelEnabled(this.getTestRunner())) {
-            $.merge($toolbarElements, $topToolbar.find('.timer-toggler'));
-        }
+        const $toolbarElements = $topToolbar.find('.jump-link, .timer-toggler');
 
         const registerTopToolbarNavigator = (id, group, $elements) => {
             const elements = navigableDomElement.createFromDoms($elements);

--- a/src/plugins/controls/timer/component/scss/timerbox.scss
+++ b/src/plugins/controls/timer/component/scss/timerbox.scss
@@ -48,6 +48,9 @@
         &:hover,&:active,&:focus{
             outline: unset;
         }
+        &:active,&:focus{
+            border: 2px solid white;
+        }
         &:hover {
             opacity: .93;
             @include transition(opacity);

--- a/src/plugins/controls/timer/component/tpl/timerbox.tpl
+++ b/src/plugins/controls/timer/component/tpl/timerbox.tpl
@@ -1,8 +1,8 @@
-<div class="timer-box" aria-hidden="{{ariaHidden}}">
+<div class="timer-box">
     {{#if zenMode.enabled}}
     <a href="#" class="timer-toggler hidden" title="{{__ 'Hide timers'}}" role="button"><span class="icon-clock"></span></a>
     {{/if}}
-    <div class="timer-wrapper">
+    <div class="timer-wrapper" aria-hidden="{{ariaHidden}}">
 
     </div>
 </div>

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -171,7 +171,7 @@ export default pluginFactory({
                     })
                     .after('renderitem', function() {
                         if (self.timerbox) {
-                            self.timerbox.getElement().attr('aria-hidden', isReviewPanelEnabled(testRunner));
+                            self.timerbox.getElement().find('timer-wrapper').attr('aria-hidden', isReviewPanelEnabled(testRunner));
                             self.timerbox.start();
                         }
                     })


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-594

**Description**
There should be NO TAB on timer in Top bar

**How to test**
1. As a user start a test
2. Navigate with TAB
3. If the review panel is disabled, "Hide timers" link should have a TAB stop
    Timers in the top bar should not have a TAB stop.
