### PR TITLE
Release 2.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
@@ -53,7 +53,29 @@ export default {
         this.managedNavigators = [];
         this.keyNavigators = [];
 
+        let testStatusNavigation;
         if ($navigator.length && !$navigator.hasClass('disabled')) {
+            const $testStatusHeader = $navigator.find('.qti-navigator-info.collapsible > .qti-navigator-label');
+            const navigableTestStatus = navigableDomElement.createFromDoms($testStatusHeader);
+
+            if (navigableTestStatus.length) {
+                testStatusNavigation = keyNavigator({
+                    keepState: config.keepState,
+                    id: 'navigator-test-status',
+                    propagateTab: false,
+                    elements: navigableTestStatus,
+                    group: $testStatusHeader,
+                });
+
+                setupItemsNavigator(testStatusNavigation, {
+                    keyNextItem: config.keyNextTab || config.keyNextItem,
+                    keyPrevItem: config.keyPrevTab || config.keyPrevItem
+                });
+
+                this.keyNavigators.push(testStatusNavigation);
+                this.managedNavigators.push(testStatusNavigation);
+            }
+
             $filters = $navigator.find('.qti-navigator-filters .qti-navigator-filter');
             navigableFilters = navigableDomElement.createFromDoms($filters);
             if (navigableFilters.length) {
@@ -165,21 +187,17 @@ export default {
                 }
 
                 if (config.keyNextTab && config.keyPrevTab) {
-                    if (config.keyNextTab) {
-                        itemsNavigator.on(config.keyNextTab, function (elem) {
-                            if (allowedToNavigateFrom(elem) && filtersNavigator) {
-                                filtersNavigator.focus().next();
-                            }
-                        });
-                    }
+                    itemsNavigator.on(config.keyNextTab, function (elem) {
+                        if (allowedToNavigateFrom(elem) && filtersNavigator) {
+                            filtersNavigator.focus().next();
+                        }
+                    });
 
-                    if (config.keyPrevTab) {
-                        itemsNavigator.on(config.keyPrevTab, function (elem) {
-                            if (allowedToNavigateFrom(elem) && filtersNavigator) {
-                                filtersNavigator.focus().previous();
-                            }
-                        });
-                    }
+                    itemsNavigator.on(config.keyPrevTab, function (elem) {
+                        if (allowedToNavigateFrom(elem) && filtersNavigator) {
+                            filtersNavigator.focus().previous();
+                        }
+                    });
                 } else {
                     this.keyNavigators.push(itemsNavigator);
                 }

--- a/test/plugins/content/keyNavigation/data/navigation.json
+++ b/test/plugins/content/keyNavigation/data/navigation.json
@@ -117,6 +117,13 @@
                 }
             },
             {
+                "label": "Navigation panel Test status",
+                "selector": ".qti-navigator-info.collapsible > .qti-navigator-label",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
                 "label": "Navigation panel All tab",
                 "selector": ".qti-navigator-filter[data-mode=\"all\"]",
                 "key": {
@@ -197,6 +204,14 @@
             {
                 "label": "Navigation panel Unanswered tab",
                 "selector": ".qti-navigator-filter[data-mode=\"unanswered\"]",
+                "key": {
+                    "keyCode": "TAB",
+                    "shiftKey": true
+                }
+            },
+            {
+                "label": "Navigation panel Test status + shift key",
+                "selector": ".qti-navigator-info.collapsible > .qti-navigator-label",
                 "key": {
                     "keyCode": "TAB",
                     "shiftKey": true
@@ -353,6 +368,13 @@
                 }
             },
             {
+                "label": "Navigation panel Test status",
+                "selector": ".qti-navigator-info.collapsible > .qti-navigator-label",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
                 "label": "Navigation panel All tab",
                 "selector": ".qti-navigator-filter[data-mode=\"all\"]",
                 "key": {
@@ -439,6 +461,14 @@
                 }
             },
             {
+                "label": "Navigation panel Test status + shift key",
+                "selector": ".qti-navigator-info.collapsible > .qti-navigator-label",
+                "key": {
+                    "keyCode": "TAB",
+                    "shiftKey": true
+                }
+            },
+            {
                 "label": "Home link",
                 "selector": "#home",
                 "key": {
@@ -478,6 +508,13 @@
             {
                 "label": "Exit link",
                 "selector": "#exit",
+                "key": {
+                    "keyCode": "TAB"
+                }
+            },
+            {
+                "label": "Navigation panel Test status",
+                "selector": ".qti-navigator-info.collapsible > .qti-navigator-label",
                 "key": {
                     "keyCode": "TAB"
                 }


### PR DESCRIPTION
_CASE 1_
**Related to:**
https://oat-sa.atlassian.net/browse/TCA-552

**Description**
Test status and structure" jump link sets focus on "Test status" button, but next TAB stop is on Exit button

**How to test**
_Preconditions:_
create a test with Review panel (Enable review scree, Enable mark for review test navigation settings are on)

_Steps:_

1. start the test from preconditions
2. hit TAB button to navigate to jump links
3. select "Test status and structure" jump link, hit Enter
4. navigate inside Review panel using KB

_CASE 2_
**Related to**
https://oat-sa.atlassian.net/browse/TCA-456#icft=TCA-456

**Description**
SR user can reach "Test status menu" only when scanning the page, although it's an interactive element and should have a TAB stop

**How to test**
_Preconditions:_
create a Delivery with "Review panel" enabled

_Steps:_

1. as a user start a test
2. using TAB navigate through the interactive elements on the page
3. change key navigator plugin strategy and test again 