### PR TITLE
Release 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/duration/duration.js
+++ b/src/plugins/controls/duration/duration.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -22,16 +22,8 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 import _ from 'lodash';
-import pollingFactory from 'core/polling';
-import timerFactory from 'core/timer';
 import pluginFactory from 'taoTests/runner/plugin';
 import promiseQueue from 'core/promiseQueue';
-
-/**
- * Time interval between duration capture in ms
- * @type {Number}
- */
-const refresh = 1000;
 
 /**
  * Creates the timer plugin
@@ -43,7 +35,7 @@ export default pluginFactory({
      * Install step, add behavior before the lifecycle.
      */
     install: function install() {
-        //define the "duration" store as "volatile" (removed on browser change).
+        // define the "duration" store as "volatile" (removed on browser change).
         this.getTestRunner()
             .getTestStore()
             .setVolatile(this.getName());
@@ -51,9 +43,10 @@ export default pluginFactory({
 
     /**
      * Initializes the plugin (called during runner's init)
+     *
+     * @returns {Promise}
      */
     init: function init() {
-        const self = this;
         const testRunner = this.getTestRunner();
 
         /**
@@ -66,6 +59,7 @@ export default pluginFactory({
         return testRunner.getPluginStore(this.getName()).then((durationStore) => {
             /**
              * Gets the duration of a particular item from the store
+             *
              * @param {String} attemptId - the attempt id to get the duration for
              * @returns {Promise}
              */
@@ -80,19 +74,17 @@ export default pluginFactory({
             /**
              * Updates the duration of a particular item
              *
+             * @param {Number} elapsed - time elapsed since previous tick
              * @returns {Promise}
              */
-            const updateDuration = () => {
-                //how many time elapsed from the last tick ?
-
+            const updateDuration = (elapsed) => {
                 const context = testRunner.getTestContext();
 
                 //store by attempt
                 const itemAttemptId = `${context.itemIdentifier}#${context.attempt}`;
 
                 currentUpdatePromise = queue.serie(() => durationStore.getItem(itemAttemptId)
-                    .then(function(duration) {
-                        let elapsed = self.stopwatch.tick();
+                    .then(function (duration) {
                         duration = _.isNumber(duration) ? duration : 0;
                         elapsed = _.isNumber(elapsed) && elapsed > 0 ? elapsed / 1000 : 0;
 
@@ -125,30 +117,12 @@ export default pluginFactory({
                     .catch(_.noop);
             };
 
-            //one stopwatch to count the time
-            self.stopwatch = timerFactory({
-                autoStart: false,
-            });
-
-            //update the duration on a regular basis
-            self.polling = pollingFactory({
-                action: updateDuration,
-                interval: refresh,
-                autoStart: false,
-            });
-
             //change plugin state
             testRunner
-                .after('renderitem', () => {
-                    self.enable();
+                .on('tick', (elapsed) => {
+                    updateDuration(elapsed);
                 })
-                .on('enableitem', () => {
-                    self.enable();
-                })
-                .before('move skip exit timeout error disableitem', function() {
-                    self.disable();
-                })
-                .before('move skip exit timeout pause', () => currentUpdatePromise
+                .after('move skip exit timeout pause', () => currentUpdatePromise
                     .then(addDuractionToCallActionParams)
                     .catch(addDuractionToCallActionParams)
                 )
@@ -163,33 +137,5 @@ export default pluginFactory({
                     }
                 });
         });
-    },
-
-    /**
-     * Called during the runner's destroy phase
-     */
-    destroy: function destroy() {
-        this.polling.stop();
-        this.stopwatch.stop();
-    },
-
-    /**
-     * Enables the duration count
-     */
-    enable: function enable() {
-        if (!this.getState('enabled')) {
-            this.polling.start();
-            this.stopwatch.resume();
-        }
-    },
-
-    /**
-     * Disables the duration count
-     */
-    disable: function disable() {
-        if (this.getState('enabled')) {
-            this.polling.stop();
-            this.stopwatch.pause();
-        }
     }
 });

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -99,6 +99,8 @@ export default pluginFactory({
 
     /**
      * Initializes the plugin (called during runner's init)
+     *
+     * @returns {Promise}
      */
     init: function init() {
         const self = this;
@@ -164,9 +166,25 @@ export default pluginFactory({
                                 .catch(handleError);
                         }
                     })
-                    .on('enableitem', function() {
+                    .on('tick', function(elapsed) {
                         if (self.timerbox) {
-                            self.timerbox.start();
+                            const timers = self.timerbox.getTimers();
+
+                            const updatedTimers = Object.keys(timers).reduce((acc, timerName) => {
+                                acc[timerName] = Object.assign(
+                                    {},
+                                    timers[timerName],
+                                    {
+                                        remainingTime: timers[timerName].remainingTime - elapsed,
+                                    }
+                                );
+
+                                return acc;
+                            }, {});
+
+                            self.timerbox
+                                .update(updatedTimers)
+                                .catch(handleError);
                         }
                     })
                     .after('renderitem', function() {

--- a/test/plugins/controls/timer/countdown/test.js
+++ b/test/plugins/controls/timer/countdown/test.js
@@ -88,7 +88,7 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
         var ready = assert.async();
         var $container = $('#qunit-fixture');
 
-        assert.expect(24);
+        assert.expect(20);
 
         countdownFactory($container, {
             id: 'timer-1',
@@ -113,7 +113,6 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
                 this.off('start.first');
 
                 assert.ok(this.is('rendered'), 'The component is still rendered');
-                assert.ok(this.is('started'), 'The component is now  started');
                 assert.ok(this.is('running'), 'The component is now running');
                 assert.ok(!this.is('completed'), 'The component is not yet completed');
 
@@ -123,7 +122,6 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
                 this.off('stop.first');
 
                 assert.ok(this.is('rendered'), 'The component is still rendered');
-                assert.ok(this.is('started'), 'The component is still  started');
                 assert.ok(!this.is('running'), 'The component is not running anymore');
                 assert.ok(!this.is('completed'), 'The component is not yet completed');
 
@@ -131,7 +129,6 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
                     this.off('start.second');
 
                     assert.ok(this.is('rendered'), 'The component is still rendered');
-                    assert.ok(this.is('started'), 'The component is still  started');
                     assert.ok(this.is('running'), 'The component is running again');
                     assert.ok(!this.is('completed'), 'The component is not yet completed');
 
@@ -141,7 +138,6 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
             })
             .on('complete', function() {
                 assert.ok(this.is('rendered'), 'The component is still rendered');
-                assert.ok(this.is('started'), 'The component is still  started');
                 assert.ok(!this.is('running'), 'The component is not running anymore');
                 assert.ok(this.is('completed'), 'The component is now completed');
 
@@ -191,40 +187,6 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
 
             ready();
         });
-    });
-
-    QUnit.test('internal countdown', function(assert) {
-        var ready = assert.async();
-        var $container = $('#qunit-fixture .timer-box');
-        var $time;
-        assert.expect(5);
-
-        countdownFactory($container, {
-            id: 'timer-1',
-            label: 'Timer 01',
-            remainingTime: 3000
-        })
-            .on('render', function() {
-                $time = $('.time', this.getElement());
-                assert.equal($time.text(), '00:00:03', 'The time is displayed');
-
-                this.start();
-            })
-            .on('start', function() {
-                setTimeout(function() {
-                    assert.equal($time.text(), '00:00:02', 'The time is displayed');
-                }, 500);
-                setTimeout(function() {
-                    assert.equal($time.text(), '00:00:01', 'The time is displayed');
-                }, 1500);
-                setTimeout(function() {
-                    assert.equal($time.text(), '00:00:00', 'The time is displayed');
-                }, 2500);
-            })
-            .on('complete', function() {
-                assert.equal($time.text(), '00:00:00', 'The time is displayed');
-                ready();
-            });
     });
 
     QUnit.test('external countdown', function(assert) {
@@ -280,7 +242,6 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
             id: 'timer-2',
             label: 'Timer 02',
             remainingTime: 3000,
-            polling: true,
             warningsForScreenreader: [
                 {
                     level: 'success',
@@ -292,6 +253,9 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
         })
             .on('render', function() {
                 this.start();
+            })
+            .on('start', function() {
+                this.update(2000);
             })
             .on('warnscreenreader', (messageArg, remainingTime, scopeArg) => {
                 assert.equal(messageArg, message, 'the message is provided');
@@ -305,9 +269,10 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
     QUnit.module('Visual test');
 
     QUnit.test('Countdow', function(assert) {
-        var ready = assert.async();
-        var remaining = 10000;
-        var container = document.querySelector('#visual .timer-box');
+        const ready = assert.async();
+        const remaining = 10000;
+        const container = document.querySelector('#visual .timer-box');
+        let ticksCount = 10;
 
         assert.expect(1);
 
@@ -328,8 +293,18 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/countdown'
                 }
             ]
         })
+            .on('start', function() {
+                const self = this;
+
+                this.ticksInterval = setInterval(function() {
+                    self.update(--ticksCount * 1000);
+                }, 1000);
+            })
             .on('complete', function() {
                 assert.ok(true);
+
+                clearInterval(this.ticksInterval);
+
                 ready();
             })
             .on('change', function() {

--- a/test/plugins/controls/timer/timerbox/test.js
+++ b/test/plugins/controls/timer/timerbox/test.js
@@ -18,7 +18,7 @@
 /**
  * Test the time\'s plugin timerbox component
  */
-define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/timerbox'], function($, timerboxFactory) {
+define(['jquery', 'lodash', 'taoQtiTest/runner/plugins/controls/timer/component/timerbox'], function($, _, timerboxFactory) {
     'use strict';
 
     QUnit.module('API');
@@ -182,7 +182,13 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/timerbox']
                 this.render($container);
             })
             .on('update', function() {
+                const timers = this.getTimers();
+
                 this.start();
+
+                _.forOwn(timers, ({ countdown, remainingTime }) => {
+                    countdown.update(remainingTime - 1000);
+                });
             })
             .on('timerstart', function(timer) {
                 var self = this;
@@ -327,12 +333,23 @@ define(['jquery', 'taoQtiTest/runner/plugins/controls/timer/component/timerbox']
                         remainingTime: 1500
                     }
                 }).then(function() {
+                    const timers = self.getTimers();
+
                     self.start();
+
+                    self.ticksInterval = setInterval(function() {
+                        _.forOwn(timers, ({ countdown, remainingTime }) => {
+                            countdown.update(remainingTime - 1000);
+                        });
+                    }, 1000);
                 });
             })
             .on('timerend', function(timer) {
                 if (timer.id === 'timer-1') {
                     assert.ok(true);
+
+                    clearInterval(this.ticksInterval);
+
                     ready();
                 }
             })


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-522
 
Refactor duration and timers plugins to use test runner clock
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- disable a fix for ODS reports to have 0 remaining time in case of timeout https://github.com/oat-sa/extension-tao-act/blob/master/model/Ods/V1/OdsResultsPayload.php#L435
- prepare a delivery from a test with multiple sections which have timers and non-linear navigation configured
- execute test as test taker and navigate to the section with timer
- navigate further and backward between section's test items until the time is gone
- complete the test and check that ODS report has 0 time_remaining for the section
  
#### Dependencies
 
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1788