### PR TITLE
[TCA-603] Timer information (static, non-changing) is announced in the top bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -38,6 +38,9 @@ import isReviewPanelEnabled from 'taoQtiTest/runner/helpers/isReviewPanelEnabled
 import statsHelper from 'taoQtiTest/runner/helpers/stats';
 import screenreaderNotificationTpl from 'taoQtiTest/runner/plugins/controls/timer/component/tpl/screenreaderNotification.tpl';
 
+// timeout after which screenreader notifcation should be cleaned up
+const screenreaderNotificationTimeout = 20000;
+
 /**
  * Creates the plugin
  */
@@ -104,6 +107,7 @@ export default pluginFactory({
         const self = this;
         const testRunner = this.getTestRunner();
         const testRunnerOptions = testRunner.getOptions();
+        let screenreaderNotifcationTimeoutId;
 
         /**
          * Plugin config,
@@ -242,8 +246,17 @@ export default pluginFactory({
                                     const stats = statsHelper.getInstantStats(scope, testRunner);
                                     const unansweredQuestions = stats && (stats.questions - stats.answered);
 
+                                    if (screenreaderNotifcationTimeoutId) {
+                                        clearTimeout(screenreaderNotifcationTimeoutId);
+                                    }
+
                                     self.$screenreaderWarningContainer.text(
                                         message(remainingTime, unansweredQuestions)
+                                    );
+
+                                    screenreaderNotifcationTimeoutId = setTimeout(
+                                        () => self.$screenreaderWarningContainer.text(''),
+                                        screenreaderNotificationTimeout
                                     );
                                 },
                                 1000,

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -178,6 +178,8 @@ export default pluginFactory({
                             self.timerbox.getElement().find('timer-wrapper').attr('aria-hidden', isReviewPanelEnabled(testRunner));
                             self.timerbox.start();
                         }
+
+                        this.$screenreaderWarningContainer.text('');
                     })
                     .on('disableitem move skip', function() {
                         if (self.timerbox) {

--- a/src/plugins/controls/timer/plugin.js
+++ b/src/plugins/controls/timer/plugin.js
@@ -179,7 +179,7 @@ export default pluginFactory({
                             self.timerbox.start();
                         }
 
-                        this.$screenreaderWarningContainer.text('');
+                        self.$screenreaderWarningContainer.text('');
                     })
                     .on('disableitem move skip', function() {
                         if (self.timerbox) {


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-603
 
Clean up screenreader timer notification after timeout or navigation between items
  
#### How to test
 First scenario: 
- prepare an instance of TAO with taoAct extension
- prepare a delivery with a section timer set to 3 minutes
- execute a delivery as a test taker
- wait for screen reader notification about remaining time which will be triggered when timer reaches 2 minutes
- make sure that notification cleaned up after 20 seconds

Second scenario:
- prepare an instance of TAO with taoAct extension
- prepare a delivery with a section timer set to 3 minutes
- execute a delivery as a test taker
- wait for screen reader notification about remaining time which will be triggered when timer reaches 2 minutes
- navigate to the next item 
- make sure that notification cleaned up
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/<EXT>/pull/<ID>