### PR TITLE
Release 2.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.5.1",
+    "version": "2.5.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/mainLandmark/header.js
+++ b/src/plugins/content/accessibility/mainLandmark/header.js
@@ -1,0 +1,78 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Test Runner Content Accessibility Plugin : MainLandmark
+ *
+ * @author Anastasia Razumovskaya <nastya.razum96@gmail.com>
+ */
+import $ from 'jquery';
+import __ from 'i18n';
+import pluginFactory from 'taoTests/runner/plugin';
+import headerTpl from 'taoQtiTest/runner/plugins/content/accessibility/mainLandmark/header.tpl';
+
+function getState(item) {
+    let state = __('Unseen');
+    if (item.flagged) {
+        state = __('Flagged');
+    } else if (item.answered) {
+        state = __('Answered');
+    } else if (item.viewed) {
+        state = __('Viewed');
+    }
+    return state;
+}
+
+export default pluginFactory({
+    name: 'mainLandmark',
+    init() {
+        const testRunner = this.getTestRunner();
+
+        const updateTitle = (item) => {
+            this.$title
+                .text(`${item.label}`)
+                .show();
+        };
+
+        const updateState = (item) => {
+            this.$state
+                .text(`${getState(item)}`)
+                .show();
+        };
+
+        testRunner
+            .after('renderitem', () => {
+                const item = testRunner.getCurrentItem();
+                updateTitle(item);
+                updateState(item);
+            })
+            .on('tool-flagitem', () => {
+                let item = testRunner.getCurrentItem();
+                item = { ...item, flagged: !item.flagged};
+                updateState(item);
+            });
+    },
+    render() {
+        const $container = this.getAreaBroker().getArea('mainLandmark');
+        this.$element = $(headerTpl());
+        $container.append(this.$element);
+
+        this.$title = $container.find(`[data-control="qti-test-item-title"]`);
+        this.$state = $container.find(`[data-control="qti-test-item-state"]`);
+    },
+});

--- a/src/plugins/content/accessibility/mainLandmark/header.tpl
+++ b/src/plugins/content/accessibility/mainLandmark/header.tpl
@@ -1,0 +1,2 @@
+<span data-control="qti-test-item-title"></span>
+<span data-control="qti-test-item-state"></span>

--- a/src/provider/layout.tpl
+++ b/src/provider/layout.tpl
@@ -1,4 +1,6 @@
-<main class="test-runner-scope">
+<main aria-labelledby="test-title-header" class="test-runner-scope">
+    <h2 id="test-title-header" class="landmark-title-hidden"></h2>
+
     <div class="action-bar content-action-bar horizontal-action-bar top-action-bar">
         <div class="control-box size-wrapper"></div>
     </div>

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -57,6 +57,7 @@ var qtiProvider = {
             content: $('#qti-content', $layout),
             toolbox: $('.tools-box', $layout),
             navigation: $('.navi-box-list', $layout),
+            mainLandmark: $('#test-title-header', $layout),
             control: $('.top-action-bar .control-box', $layout),
             actionsBar: $('.bottom-action-bar .control-box', $layout),
             panel: $('.test-sidebar-left', $layout),

--- a/test/mocks/areaBrokerMock.js
+++ b/test/mocks/areaBrokerMock.js
@@ -56,6 +56,7 @@ define(['jquery', 'lodash', 'ui/areaBroker', 'taoQtiTest/runner/ui/toolbox/toolb
                 'content', //where the content is renderer, for example an item
                 'toolbox', //the place to add arbitrary tools, like a zoom, a comment box, etc.
                 'navigation', //the navigation controls like next, previous, skip
+                'mainLandmark', //the header landmark for the main
                 'control', //the control center of the test, progress, timers, etc.
                 'header', //the area that could contains the test titles
                 'panel' //a panel to add more advanced GUI (item review, navigation pane, etc.)

--- a/test/mocks/areaBrokerMock/test.js
+++ b/test/mocks/areaBrokerMock/test.js
@@ -32,7 +32,7 @@ define(['lodash', 'taoQtiTest/test/runner/mocks/areaBrokerMock'], function(_, ar
 
     QUnit.test('factory', function(assert) {
         var extraArea = 'extra';
-        var areas = ['content', 'toolbox', 'navigation', 'control', 'header', 'panel'];
+        var areas = ['content', 'toolbox', 'navigation', 'mainLandmark', 'control', 'header', 'panel'];
         var broker = areaBrokerMock();
 
         assert.equal(typeof broker, 'object', 'The factory creates an object');
@@ -87,7 +87,7 @@ define(['lodash', 'taoQtiTest/test/runner/mocks/areaBrokerMock'], function(_, ar
     });
 
     QUnit.test('toolbox component', function(assert) {
-        var areas = ['content', 'toolbox', 'navigation', 'control', 'header', 'panel'];
+        var areas = ['content', 'toolbox', 'navigation', 'mainLandmark', 'control', 'header', 'panel'];
         var broker = areaBrokerMock({ areas: areas }),
             component;
 

--- a/test/plugins/content/mainLandmark/test.html
+++ b/test/plugins/content/mainLandmark/test.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner Plugin - Main Landmark</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['taoQtiTest/test/runner/plugins/content/mainLandmark/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+        <div id="test-title-header"></div>
+    </body>
+</html>

--- a/test/plugins/content/mainLandmark/test.js
+++ b/test/plugins/content/mainLandmark/test.js
@@ -1,0 +1,206 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Anastasia Razumovskaya <nastya.razum96@gmail.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'taoTests/runner/runner',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/runner/plugins/content/accessibility/mainLandmark/header'
+], function ($, _, runnerFactory, providerMock, pluginFactory) {
+    'use strict';
+
+    const providerName = 'mock';
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    const sampleTestContext = {
+        itemIdentifier: 'item-1',
+        itemPosition: 0,
+        isDeepestSectionVisible: true,
+    };
+
+    const item = {
+        label: 'item-title',
+        viewed: true,
+        flagged: false,
+        answered: true
+    };
+    const sampleTestMap = {
+        parts: {
+            p1: {
+                label: 'part-title',
+                sections: {
+                    s1: {
+                        label: 'section-title',
+                        items: {
+                            'item-1': item
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    /**
+     * The following tests applies to all plugins
+     */
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', (assert) => {
+        const runner = runnerFactory(providerName);
+
+        assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(
+            pluginFactory(runner),
+            pluginFactory(runner),
+            'The plugin factory provides a different instance on each call'
+        );
+    });
+
+    const pluginApi = [
+        {name: 'init', title: 'init'},
+        {name: 'render', title: 'render'}
+    ];
+
+    QUnit.cases.init(pluginApi).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner);
+
+        assert.equal(
+            typeof plugin[data.name],
+            'function',
+            `The pluginFactory instances expose a "${data.name}" function`
+        );
+    });
+
+    QUnit.test('pluginFactory.init', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner);
+
+        plugin
+            .init()
+            .then(() => {
+                assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
+            })
+            .catch((err) => {
+                assert.ok(false, `The init failed: ${err}`);
+            })
+            .then(ready);
+    });
+
+    QUnit.test('pluginFactory.render', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getArea('mainLandmark');
+        const plugin = pluginFactory(runner, areaBroker);
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                assert.equal(
+                    $container.find(`span[data-control="qti-test-item-title"]`).length,
+                    1,
+                    'Add the question title to the container'
+                );
+                assert.equal(
+                    $container.find(`span[data-control="qti-test-item-state"]`).length,
+                    1,
+                    'Add the question state to the container'
+                );
+
+                ready();
+            });
+    });
+
+    QUnit.test('test runner events: renderitem', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getArea('mainLandmark');
+        const plugin = pluginFactory(runner, areaBroker);
+
+        assert.expect(2);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+        runner.getCurrentItem = () => item;
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                return runner.trigger('renderitem');
+            })
+            .then(() => {
+                assert.equal(
+                    $container.find('[data-control="qti-test-item-title"]').text(),
+                    'item-title',
+                    'Add item title'
+                );
+
+                assert.equal(
+                    $container.find('[data-control="qti-test-item-state"]').text(),
+                    'Answered',
+                    'Add item state'
+                );
+
+                ready();
+            });
+    });
+
+    QUnit.test('test runner events: tool-flagitem', (assert) => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getArea('mainLandmark');
+
+        const plugin = pluginFactory(runner, areaBroker);
+
+        assert.expect(1);
+
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+        runner.getCurrentItem = () => item;
+
+        plugin
+            .init()
+            .then(() => {
+                plugin.render();
+
+                return runner.trigger('renderitem');
+            })
+            .then(() => runner.trigger('tool-flagitem'))
+            .then(() => {
+                assert.equal(
+                    $container.find('[data-control="qti-test-item-state"]').text(),
+                    'Flagged',
+                    'Change item state'
+                );
+
+                ready();
+            });
+    });
+});


### PR DESCRIPTION
**Related to**
https://oat-sa.atlassian.net/browse/TCA-558

**Description**
Add `<h2>` to `<main>` tag and link with Landmark

**How to test**
1. Update taoAct extension
2. As a user start a test
3. Header with the following content should be present in `<main>` tag:
 ```
<h2 id="test-title-header" class="landmark-title-hidden">
      <span data-control="qti-test-item-title">Current item name</span>
      <span data-control="qti-test-item-state">Current item state</span>
</h2>
```
