### PR TITLE
Fix/tca 608/elements freeze dialog shortcut close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.2",
+    "version": "2.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.2",
+    "version": "2.6.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/previous.js
+++ b/src/plugins/navigation/previous.js
@@ -129,7 +129,7 @@ export default pluginFactory({
             var context = testRunner.getTestContext();
 
             function enableNav() {
-                testRunner.trigger('disablenav');
+                testRunner.trigger('enablenav');
             }
 
             function triggerAction() {
@@ -146,7 +146,7 @@ export default pluginFactory({
                             'You are about to go to the previous item. Click OK to continue and go to the previous item.'
                         ),
                         triggerAction, // if the test taker accept
-                        enableNav() // if he refuses
+                        enableNav // if he refuses
                     );
                 } else {
                     triggerAction();


### PR DESCRIPTION
**Related**
https://oat-sa.atlassian.net/browse/TCA-608

**Description**
Elements on the test page freeze when Go to Previous item shortcut (K) dialog is closed

**How to test**

_Preconditions:_
create a non-linear test with several attempts set to item 

_Steps:_

1. navigate to Item 2
2. Press "K" shortcut button to get to the previous item
3. do not confirm opened dialog: press Cancel or "X" close button, or press ESC