### PR TITLE
Feature/tca 558/Add missing css class to hide the landmark title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -18,6 +18,13 @@
 
     height: calc(100vh - #{(map-get($heights, header) + map-get($heights, footer)) * 1px});
 
+    .landmark-title-hidden {
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        position: absolute;
+    }
+
     .test-runner-sections {
 
         /* flex column value */

--- a/src/plugins/navigation/review/review.js
+++ b/src/plugins/navigation/review/review.js
@@ -139,6 +139,22 @@ function canFlag(testRunner) {
 }
 
 /**
+ * Make review panel header visible for screen readers
+ * @param {Object} $header - the panel header element
+ */
+function showHeader($header) {
+    $header.attr('aria-hidden', false);
+}
+
+/**
+ * Make review panel header invisible for screen readers
+ * @param {Object} $header - the panel header element
+ */
+function hideHeader($header) {
+    $header.attr('aria-hidden', true);
+}
+
+/**
  * Creates the timer plugin
  */
 export default pluginFactory({
@@ -250,9 +266,11 @@ export default pluginFactory({
             if (isHidden) {
                 self.explicitlyHidden = false;
                 self.navigator.show();
+                showHeader(self.$header);
             } else {
                 self.explicitlyHidden = true;
                 self.navigator.hide();
+                hideHeader(self.$header);
             }
             updateButton(self.toggleButton, getToggleButtonData(self.navigator));
         }
@@ -278,6 +296,10 @@ export default pluginFactory({
         testRunner.on('alert.notallowed', function() {
             self.navigator.select(previousItemPosition);
         });
+
+        this.$header = this.getAreaBroker()
+            .getPanelArea()
+            .find('#test-sidebar-left-header');
 
         this.explicitlyHidden = false;
 
@@ -454,8 +476,10 @@ export default pluginFactory({
 
         if (!this.explicitlyHidden) {
             this.navigator.show();
+            showHeader(this.$header);
         } else {
             this.navigator.hide();
+            hideHeader(this.$header);
         }
     },
 
@@ -466,5 +490,6 @@ export default pluginFactory({
         this.flagItemButton.hide();
         this.toggleButton.hide();
         this.navigator.hide();
+        hideHeader(this.$header);
     }
 });

--- a/src/plugins/navigation/review/review.js
+++ b/src/plugins/navigation/review/review.js
@@ -139,22 +139,6 @@ function canFlag(testRunner) {
 }
 
 /**
- * Make review panel header visible for screen readers
- * @param {Object} $header - the panel header element
- */
-function showHeader($header) {
-    $header.attr('aria-hidden', false);
-}
-
-/**
- * Make review panel header invisible for screen readers
- * @param {Object} $header - the panel header element
- */
-function hideHeader($header) {
-    $header.attr('aria-hidden', true);
-}
-
-/**
  * Creates the timer plugin
  */
 export default pluginFactory({
@@ -266,11 +250,9 @@ export default pluginFactory({
             if (isHidden) {
                 self.explicitlyHidden = false;
                 self.navigator.show();
-                showHeader(self.$header);
             } else {
                 self.explicitlyHidden = true;
                 self.navigator.hide();
-                hideHeader(self.$header);
             }
             updateButton(self.toggleButton, getToggleButtonData(self.navigator));
         }
@@ -296,10 +278,6 @@ export default pluginFactory({
         testRunner.on('alert.notallowed', function() {
             self.navigator.select(previousItemPosition);
         });
-
-        this.$header = this.getAreaBroker()
-            .getPanelArea()
-            .find('#test-sidebar-left-header');
 
         this.explicitlyHidden = false;
 
@@ -476,10 +454,8 @@ export default pluginFactory({
 
         if (!this.explicitlyHidden) {
             this.navigator.show();
-            showHeader(this.$header);
         } else {
             this.navigator.hide();
-            hideHeader(this.$header);
         }
     },
 
@@ -490,6 +466,5 @@ export default pluginFactory({
         this.flagItemButton.hide();
         this.toggleButton.hide();
         this.navigator.hide();
-        hideHeader(this.$header);
     }
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TCA-558
Required by https://github.com/oat-sa/extension-tao-testqti/pull/1799

Add the missing CSS class to hide the landmark title.