### PR TITLE
Feature/tca 595/Apply WCAG behavior on group of radio choices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.1",
+    "version": "2.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.1",
+    "version": "2.7.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.3.0",
         "@oat-sa/tao-core-sdk": "^0.8.1",
-        "@oat-sa/tao-core-ui": "^1.1.1",
+        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TCA-595/set-focus-following-the-movement-direction",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-item-runner-qti": "^0.3.2",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/src/plugins/content/accessibility/keyNavigation/modes/defaultMode.js
+++ b/src/plugins/content/accessibility/keyNavigation/modes/defaultMode.js
@@ -32,6 +32,7 @@ export default {
             strategies: ['rubrics', 'stimulus', 'item', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: Object.assign({
                 autoFocus: true,
+                wcagBehavior: false,
                 keepState: true,
                 propagateTab: false,
                 flatNavigation: false,

--- a/src/plugins/content/accessibility/keyNavigation/modes/linearMode.js
+++ b/src/plugins/content/accessibility/keyNavigation/modes/linearMode.js
@@ -32,6 +32,7 @@ export default {
             strategies: ['rubrics', 'stimulus', 'linearItem', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: Object.assign({
                 autoFocus: true,
+                wcagBehavior: false,
                 keepState: true,
                 propagateTab: false,
                 flatNavigation: false,

--- a/src/plugins/content/accessibility/keyNavigation/modes/nativeMode.js
+++ b/src/plugins/content/accessibility/keyNavigation/modes/nativeMode.js
@@ -33,6 +33,7 @@ export default {
             strategies: ['jump-links', 'header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'stimulus', 'item', 'toolbar'],
             config: Object.assign({
                 autoFocus: false,
+                wcagBehavior: false,
                 keepState: false,
                 propagateTab: true,
                 flatNavigation: true,

--- a/src/plugins/content/accessibility/keyNavigation/strategies/headerNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/headerNavigation.js
@@ -55,7 +55,8 @@ export default {
                     id,
                     group,
                     elements,
-                    propagateTab: false
+                    propagateTab: false,
+                    defaultPosition: 0
                 });
 
                 setupItemsNavigator(navigator, config);

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -153,7 +153,7 @@ export default {
                         });
 
                         // applies WCAG behavior for the radio buttons
-                        if (config.wcagBehavior) {
+                        if (navigator && config.wcagBehavior) {
                             navigator.on('focus', cursor => {
                                 const $element = cursor.navigable.getElement();
                                 if (!$element.is(':checked')) {

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -55,15 +55,17 @@ export default {
          * Creates and registers a keyNavigator for the supplied list of elements
          * @param {jQuery} $elements - The list of navigable elements
          * @param {jQuery} group - The group container
-         * @param {Number|Function} [defaultPosition=0] - the default position the group should set the focus on
+         * @param {Boolean} [loop=false] - Allow cycling the list when a boundary is reached
+         * @param {Number|Function} [defaultPosition=0] - The default position the group should set the focus on
          * @returns {keyNavigator} - the created navigator, if the list of element is not empty
          */
-        const addNavigator = ($elements, group, defaultPosition = 0) => {
+        const addNavigator = ($elements, group, loop = false, defaultPosition = 0) => {
             const elements = navigableDomElement.createFromDoms($elements);
             if (elements.length) {
                 const navigator = keyNavigator({
                     elements,
                     group,
+                    loop,
                     defaultPosition,
                     propagateTab: false
                 });
@@ -76,11 +78,12 @@ export default {
          * Creates and setups a keyNavigator for the interaction inputs.
          * @param {jQuery} $elements - The list of navigable elements
          * @param {jQuery} group - The group container
-         * @param {Number|Function} [defaultPosition=0] - the default position the group should set the focus on
+         * @param {Boolean} [loop=false] - Allow cycling the list when a boundary is reached
+         * @param {Number|Function} [defaultPosition=0] - The default position the group should set the focus on
          * @returns {keyNavigator} - The supplied keyNavigator
          */
-        const addInputsNavigator = ($elements, group, defaultPosition = 0) => {
-            const navigator = addNavigator($elements, group, defaultPosition);
+        const addInputsNavigator = ($elements, group, loop, defaultPosition = 0) => {
+            const navigator = addNavigator($elements, group, loop, defaultPosition);
             if (navigator) {
                 setupItemsNavigator(navigator, config);
                 setupClickableNavigator(navigator);
@@ -135,7 +138,7 @@ export default {
                     if (config.flatNavigation && choiceType !== 'radio') {
                         $inputs.each((i, input) => addInputsNavigator($(input), $itemElement));
                     } else {
-                        const navigator = addInputsNavigator($inputs, $itemElement, () => {
+                        const navigator = addInputsNavigator($inputs, $itemElement, true, () => {
                             let position = 0;
 
                             // autofocus the selected radio button if any

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -152,12 +152,15 @@ export default {
                             return position;
                         });
 
-                        navigator.on('focus', cursor => {
-                            const $element = cursor.navigable.getElement();
-                            if (!$element.is(':checked')) {
-                                $element.click();
-                            }
-                        });
+                        // applies WCAG behavior for the radio buttons
+                        if (config.wcagBehavior) {
+                            navigator.on('focus', cursor => {
+                                const $element = cursor.navigable.getElement();
+                                if (!$element.is(':checked')) {
+                                    $element.click();
+                                }
+                            });
+                        }
                     }
                 } else {
                     addNavigator($itemElement, $itemElement);

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -139,7 +139,8 @@ export default {
                         $inputs.each((i, input) => addInputsNavigator($(input), $itemElement));
                     } else {
                         const navigator = addInputsNavigator($inputs, $itemElement, true, () => {
-                            let position = 0;
+                            // keep default positioning for now
+                            let position = -1;
 
                             // autofocus the selected radio button if any
                             $inputs.each((index, input) => {

--- a/src/plugins/content/accessibility/keyNavigation/strategies/linearItemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/linearItemNavigation.js
@@ -40,14 +40,12 @@ export default {
     init() {
         const config = this.getConfig();
         const $content = this.getTestRunner().getAreaBroker().getContentArea();
-        const $qtiIteractionsNodeList = $content
+        const $qtiInteractions = $content
             .find('.key-navigation-focusable,.qti-interaction')
-            .filter(function () {
-                //filter out interaction as it will be managed separately
-                return !$(this).parents('.qti-interaction').length;
-            });
+            //filter out interaction as it will be managed separately
+            .filter((i, node) => !$(node).parents('.qti-interaction').length);
 
-        const $qtiChoiceNodesList = $qtiIteractionsNodeList.find('.qti-choice');
+        const $qtiChoices = $qtiInteractions.find('.qti-choice');
         let $lastParent = null;
         let list = [];
         const setupListNavigator = () => {
@@ -67,9 +65,11 @@ export default {
         this.choicesNavigators = [];
 
         // the item focusable body elements are considered scrollable
-        $content.find('.key-navigation-focusable').addClass('key-navigation-scrollable');
+        $content
+            .find('.key-navigation-focusable')
+            .addClass('key-navigation-scrollable');
 
-        $qtiChoiceNodesList.each((i, el) => {
+        $qtiChoices.each((i, el) => {
             const $itemElement = $(el);
             const $parent = $itemElement.parent();
             const choiceNavigator = keyNavigator({

--- a/src/plugins/content/accessibility/keyNavigation/strategiesManager.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategiesManager.js
@@ -34,6 +34,7 @@ import * as strategies from 'taoQtiTest/runner/plugins/content/accessibility/key
  * Defines the config structure for the navigation strategies
  * @typedef {Object} keyNavigationStrategyConfig
  * @property {Boolean} autoFocus - auto select the main action when available in a group
+ * @property {Boolean} wcagBehavior - apply WCAG recommended behavior for radio buttons and similar elements
  * @property {Boolean} keepState - for strategies able to keep the state, allow to keep the position of the focused
  * element when moving away from the group and restore it when the group retrieves the focus
  * @property {Boolean} propagateTab - propagate the Tab key to the upper level

--- a/test/plugins/content/keyNavigation/modesManager/test.js
+++ b/test/plugins/content/keyNavigation/modesManager/test.js
@@ -45,6 +45,7 @@ define([
             strategies: ['rubrics', 'stimulus', 'item', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: {
                 autoFocus: true,
+                wcagBehavior: false,
                 keepState: true,
                 propagateTab: false,
                 flatNavigation: false,
@@ -69,6 +70,7 @@ define([
             strategies: ['rubrics', 'stimulus', 'linearItem', 'toolbar', 'header', 'top-toolbar', 'navigator', 'page'],
             config: {
                 autoFocus: true,
+                wcagBehavior: false,
                 keepState: true,
                 propagateTab: false,
                 flatNavigation: false,
@@ -93,6 +95,7 @@ define([
             strategies: ['jump-links', 'header', 'top-toolbar', 'navigator', 'page', 'rubrics', 'stimulus', 'item', 'toolbar'],
             config: {
                 autoFocus: false,
+                wcagBehavior: false,
                 keepState: false,
                 propagateTab: true,
                 flatNavigation: true,


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TCA-595

Companion PRs:
- https://github.com/oat-sa/tao-core/pull/2526
- https://github.com/oat-sa/extension-tao-testqti/pull/1802

Requires: 
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/133

When navigating to a list of radio choices, this behavior is now applied:
- if a choice is selected, focus it
- if no choice is selected yet:
    - if the navigation was moving forward, focus the first choice
    - if the navigation was moving backward, focus the last choice

When navigating inside a list of radio choices:
- the user can use the ARROW keys
- the user can cycle through all choices (loop mode)
- by default, only the focus is changed, the selection is not affected by the navigation. The option `wcagBehavior` allows applying the native mode where the radio buttons are selected at the same time they are focused.
