### PR TITLE
[TAO-10298] Deckard: Timer doesn't countdown in timed section during the delivery execution.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -148,12 +148,14 @@ export default {
                             return position;
                         });
 
-                        navigator.on('focus', cursor => {
-                            const $element = cursor.navigable.getElement();
-                            if (!$element.is(':checked')) {
-                                $element.click();
-                            }
-                        });
+                        if (navigator) {
+                            navigator.on('focus', cursor => {
+                                const $element = cursor.navigable.getElement();
+                                if (!$element.is(':checked')) {
+                                    $element.click();
+                                }
+                            });
+                        }
                     }
                 } else {
                     addNavigator($itemElement, $itemElement);


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-10298
 
Check if navigator was created before assign focus event handler
  
#### How to test
 
- prepare an instance of TAO
- import delivery assigned to ticket
- start the delivery as a test taker
- make sure that timer countdown
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1804