### PR TITLE
fix mathjax elements background color with tts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.2",
+    "version": "2.6.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_apip-text-to-speech.scss
+++ b/scss/inc/_apip-text-to-speech.scss
@@ -169,7 +169,7 @@ $activeApipElementBackgroundColor: yellow;
 .tts-playing.tts-component-container {
     .test-runner-sections {
         .tts-content-node {
-            &.tts-active-content-node {
+            &.tts-active-content-node, &.tts-active-content-node * {
                 color: $textColor !important;
                 background-color: $activeApipElementBackgroundColor !important;
 


### PR DESCRIPTION
#### Related to:
https://oat-sa.atlassian.net/browse/TCA-611
 
Mathjax element highlighted incorrectly for TTS plugin

#### How to test
- launch a test with APIP content and Mathjax element
- check the correct height of APIP highlighting
  
#### Dependencies
https://github.com/oat-sa/extension-tao-testqti/pull/1803