### PR TITLE
Fix/tca 455/Close tools menu when exceeding boundaries using keyboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -410,6 +410,9 @@ var menuComponentApi = {
                 this.closeMenu();
             }
             // move to the menu button
+        } else if (this.hoverIndex === 0) {
+            this.hoverIndex--;
+            this.closeMenu();
         }
     },
 

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2020 (original work) Open Assessment Technologies SA;
  */
 /**
  * This factory creates a component that allows to create a toolbox menu.
@@ -29,7 +29,7 @@
  * });
  * Optional setting: navType - navigation type 
  * navType: 'fromLast' (default behavior) - focus on button (if no active item) and then using UP go to last item, when press DOWN at last item menu will be closed,
- * navType: 'fromFirst' - focus on button (if no active item) and then using DOWN go to first item, when press UP at first item menu will be closed
+ * navType: 'fromFirst' - focus on button (if no active item) and then using DOWN go to first item. When press the DOWN key at the first item menu will be closed
  * toolbox.createMenu({
  *      control: 'menu-id',
  *      title: __('Html title'),
@@ -410,9 +410,6 @@ var menuComponentApi = {
                 this.closeMenu();
             }
             // move to the menu button
-        } else if (this.hoverIndex === 0  && this.navType === 'fromFirst') {
-            this.hoverIndex--;
-            this.closeMenu();
         }
     },
 
@@ -427,7 +424,7 @@ var menuComponentApi = {
                 this.closeMenu();
             }
             // move to the menu button
-        } else if (this.hoverIndex === this.menuItems.length - 1 && this.navType === 'fromLast') {
+        } else if (this.hoverIndex === this.menuItems.length - 1) {
             this.hoverIndex++;
             this.closeMenu();
         }


### PR DESCRIPTION
**Related**:
Comments in [TCA-455](https://oat-sa.atlassian.net/browse/TCA-455) 

**Description**
Menu in the bottom bar should become closed if user presses UP arrow at the first item or DOWN at the last item regardless of its navType (agreed with Luc)

**How to test**

1. Create a test with contrast and tools menu
2. Start test as a test taker
3. Open the tools menu
4. Try to close it by pressing UP arrows
5. Open again and try to close it by pressing DOWN
6. Repeat steps 3-5 for contrast menu