### PR TITLE
Fix/tca 497/focus at the bottom bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -28,8 +28,8 @@
  *      text: __('Displayed label')
  * });
  * Optional setting: navType - navigation type 
- * navType: 'fromLast' (default behavior) - focus on button (if no active item) and then using UP go to last item, when press DOWN at last item menu will be closed,
- * navType: 'fromFirst' - focus on button (if no active item) and then using DOWN go to first item. When press the DOWN key at the first item menu will be closed
+ * navType: 'fromLast' (default behavior) - focus on button (if no active item) and then using UP go to last item, when press DOWN at last item (or UP at the first) menu will be closed,
+ * navType: 'fromFirst' - focus on button (if no active item) and then using DOWN go to first item. When press the DOWN key at the first item (or UP at the first) menu will be closed
  * toolbox.createMenu({
  *      control: 'menu-id',
  *      title: __('Html title'),
@@ -244,7 +244,7 @@ var menuComponentApi = {
         this.trigger('closemenu', this);
 
         // Move focus if the menu wasn't disabled before the close action was launched.
-        if (!this.is('disabled')) {
+        if (!this.is('disabled') || !this.$component.prop('disabled')) {
             this.$menuButton.parent().focus();  // It needs for screenreaders to correctly read menu button after submenu was closed
         }
     },

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -244,7 +244,7 @@ var menuComponentApi = {
         this.trigger('closemenu', this);
 
         // Move focus if the menu wasn't disabled before the close action was launched.
-        if (!this.is('disabled') || !this.$component.prop('disabled')) {
+        if (!this.is('disabled') && !this.$component.prop('disabled')) {
             this.$menuButton.parent().focus();  // It needs for screenreaders to correctly read menu button after submenu was closed
         }
     },


### PR DESCRIPTION
Related
https://oat-sa.atlassian.net/browse/TCA-497

Description
[NVDA] KB focus stays in the Bottom bar menu when navigating from item to item

How to test
1. Create a test
2. Start a test as a test taker
3. Enable SR
4. Press next / previous item and next section
5. Listen to the SR