### PR TITLE
fix text status announcement for multiple timers

### DIFF
--- a/src/plugins/controls/timer/component/timerbox.js
+++ b/src/plugins/controls/timer/component/timerbox.js
@@ -213,7 +213,8 @@ export default function timerboxFactory(config) {
                             })
                             .on('change', function(value) {
                                 if (self.timers[id]) {
-                                    self.trigger('timertick', this.remainingTime, self.timers[id].scope); // propogate current timer data
+                                    const minValue = Math.min( ... _.toArray(self.timers).map( ctimer => Math.floor(ctimer.remainingTime)));
+                                    self.trigger('timertick', Math.floor(this.remainingTime), self.timers[id].scope, { minValue }); // propogate current timer data
 
                                     //keep the current timer data in sync
                                     self.timers[id].remainingTime = value;


### PR DESCRIPTION
#### Related to:
https://oat-sa.atlassian.net/browse/TCA-543
 
Timer announce must be not contained in test status button. There is added fixes for case with multiple timers.

#### How to test
- prepare an instance of TAO with taoAct extension
- prepare a test with with timer 
- listen to screen reader announces
  
#### Dependencies
https://github.com/oat-sa/extension-tao-act/pull/1384