### PR TITLE
[TCA-401] Test session re-positioning when time increased during timeout event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.4",
+    "version": "2.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.4",
+    "version": "2.7.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -481,11 +481,7 @@ var qtiProvider = {
                                 self.trigger(
                                     'alert.timeout',
                                     __('Time limit reached, this part of the test has ended.'),
-                                    () => {
-                                        self.getProxy().acceptTimeout()
-                                            .then(resolve)
-                                            .catch(resolve);
-                                    }
+                                    resolve
                                 );
                             }
                         })

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -481,7 +481,11 @@ var qtiProvider = {
                                 self.trigger(
                                     'alert.timeout',
                                     __('Time limit reached, this part of the test has ended.'),
-                                    resolve
+                                    () => {
+                                        self.trigger('timeoutAccepted');
+
+                                        resolve();
+                                    }
                                 );
                             }
                         })

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -481,7 +481,11 @@ var qtiProvider = {
                                 self.trigger(
                                     'alert.timeout',
                                     __('Time limit reached, this part of the test has ended.'),
-                                    resolve
+                                    () => {
+                                        self.getProxy().acceptTimeout()
+                                            .then(resolve)
+                                            .catch(resolve);
+                                    }
                                 );
                             }
                         })

--- a/src/proxy/cache/proxy.js
+++ b/src/proxy/cache/proxy.js
@@ -625,16 +625,7 @@ export default _.defaults(
                     deferred
                 );
             });
-        },
-        /**
-         * Discard the stored timeout event.
-         *
-         * @returns {Promise} - Returns a promise. The context object will be provided on resolve.
-         *                      Any error will be provided if rejected.
-         */
-        accceptTimeout: function accceptTimeout() {
-            return this.request(this.configStorage.getTestActionUrl('acceptTimeout'), {}, null, true);
-        },
+        }
     },
     qtiServiceProxy
 );

--- a/src/proxy/cache/proxy.js
+++ b/src/proxy/cache/proxy.js
@@ -625,7 +625,16 @@ export default _.defaults(
                     deferred
                 );
             });
-        }
+        },
+        /**
+         * Discard the stored timeout event.
+         *
+         * @returns {Promise} - Returns a promise. The context object will be provided on resolve.
+         *                      Any error will be provided if rejected.
+         */
+        accceptTimeout: function accceptTimeout() {
+            return this.request(this.configStorage.getTestActionUrl('acceptTimeout'), {}, null, true);
+        },
     },
     qtiServiceProxy
 );


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-401
 
Trigger timeoutAccepted event on timeout dialog accept
  
#### How to test
 
- prepare an instance of TAO
- prepare a delivery with timer
- executed delivery as a test taker
- wait until timer runs out and make sure that event triggered

#### Related PRs
- [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1813