### PR TITLE
Release 2.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.6.4",
+    "version": "2.6.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_apip-text-to-speech.scss
+++ b/scss/inc/_apip-text-to-speech.scss
@@ -169,7 +169,7 @@ $activeApipElementBackgroundColor: yellow;
 .tts-playing.tts-component-container {
     .test-runner-sections {
         .tts-content-node {
-            &.tts-active-content-node {
+            &.tts-active-content-node, &.tts-active-content-node * {
                 color: $textColor !important;
                 background-color: $activeApipElementBackgroundColor !important;
 


### PR DESCRIPTION
Version 2.6.5

**Release notes :**
- [fix] [TCA-611](https://oat-sa.atlassian.net/browse/TCA-611)

Mathjax element highlighted incorrectly for TTS plugin

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/226