### PR TITLE
Fix/tca 551/test status review structure juml link hide review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -119,6 +119,16 @@ export default pluginFactory({
 
                 this.jumplinks.trigger('changeQuesitionStatus', questionStatus);
             })
+            .on('tool-reviewpanel', () => {
+                const wasHidden = testRunner
+                    .getAreaBroker()
+                    .getPanelArea()
+                    .find('.qti-navigator')
+                    .is('.hidden');
+
+                this.jumplinks.trigger('changeReviewPanel', wasHidden);
+            });
+
         this.shortcuts = shortcutsFactory({});
     },
 


### PR DESCRIPTION
**Related**
https://oat-sa.atlassian.net/browse/TCA-551

**Description**
"Test status and structure" jump link is present when Review panel is hidden in the test

**How to test**
1. Create the test with enabled review screen
2. Start the test as a test tacker
3. Check that "Test status and structure" jump link exists
4. Press hide review button check the JL again
5. Click the show review button and check the JL again