### PR TITLE
Fix/tca 419/extra aria attributs on the bottom bar buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/ui/toolbox/entry.js
+++ b/src/ui/toolbox/entry.js
@@ -84,7 +84,7 @@ var itemComponentApi = {
         this.setState('active', true);
 
         const element = this.getElement()
-        if (!element) {
+        if (!element || (element.attr('role') !== 'option')) { // Not pretty bit quick
             return;
         }
 
@@ -100,7 +100,7 @@ var itemComponentApi = {
         this.setState('active', false);
 
         const element = this.getElement()
-        if (!element) {
+        if (!element || (element.attr('role') !== 'option')) { // Not pretty bit quick
             return;
         }
 


### PR DESCRIPTION
**Related**
https://oat-sa.atlassian.net/browse/TCA-419

**Description**
Adjust Attributes for Tools in Bottom Bar on TestRunner Page

**How to test**

1. as a user start a test
2. select a tool in the bottom bar
3. inspect tool in the DevMode
4. Bottom bar buttons shouldn't have aria-checked and aria-selected attributes
5. Theme switcher and tools menu options should have these attributes and they should work correctly