### PR TITLE
[TCA-505] Confirmation in Go to the next section dialog doesn't work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.5",
+    "version": "2.10.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.5",
+    "version": "2.10.6",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.6",
+    "version": "2.10.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-505
 
Do not show confirmation dialog on skip section if it is configured to be shown by timer plugin
  
#### How to test
 
- prepare an instance of TAO
- prepare a delivery with possibility to skip section and section timer
- execute the delivery as a test taker
- try to skip section using section skip button
- make sure that there is only one confirmation dialog 
  
#### Dependencies

Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1822