### PR TITLE
[TCA-609] Timer is announced in title for items where it's not being set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/title/title.js
+++ b/src/plugins/controls/title/title.js
@@ -82,15 +82,16 @@ export default pluginFactory({
 
         testRunner
             .after('renderitem', () => {
-                updateTitles();
-
                 _.forOwn(this.titles, (options, scope) => {
-                    if (scope === 'item') {
-                        return;
-                    }
+                    this.titles[scope].$title.text('');
+                    this.titles[scope].$timer.text('');
 
-                    this.titles[scope].stats = statsHelper.getInstantStats(scope, testRunner);
+                    if (scope !== 'item') {
+                        this.titles[scope].stats = statsHelper.getInstantStats(scope, testRunner);
+                    }
                 });
+
+                updateTitles();
             })
             .on('timertick', (remainingTime, scope) => {
                 const title = this.titles[scope];


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-609
 
clean up title after item render
  
#### How to test
 
- prepare an instance of TAO
- prepare a delivery with possibility to skip section and multiple timers 
- execute the delivery as a test taker
- try to navigate between items
- make sure that title is cleaned up after navigation
  
#### Dependencies

Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1823