### PR TITLE
Fix/tca 647/remaining time mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.3",
+    "version": "2.10.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.3",
+    "version": "2.10.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.1",
+    "version": "2.10.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/duration/duration.js
+++ b/src/plugins/controls/duration/duration.js
@@ -96,7 +96,7 @@ export default pluginFactory({
                 return currentUpdatePromise;
             };
 
-            const addDuractionToCallActionParams = () => {
+            const addDurationToCallActionParams = () => {
                 const context = testRunner.getTestContext();
                 const itemAttemptId = `${context.itemIdentifier}#${context.attempt}`;
 
@@ -122,9 +122,9 @@ export default pluginFactory({
                 .on('tick', (elapsed) => {
                     updateDuration(elapsed);
                 })
-                .after('move skip exit timeout pause', () => currentUpdatePromise
-                    .then(addDuractionToCallActionParams)
-                    .catch(addDuractionToCallActionParams)
+                .before('move skip exit timeout pause', () => currentUpdatePromise
+                    .then(addDurationToCallActionParams)
+                    .catch(addDurationToCallActionParams)
                 )
                 /**
                  * @event duration.get

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -387,8 +387,6 @@ var qtiProvider = {
                 // otherwise the state could be partially lost for tools that clean up when disabling
                 var itemResults = getItemResults();
 
-                stopwatch.stop();
-
                 this.trigger('disablenav disabletools');
 
                 computeNext(
@@ -401,8 +399,6 @@ var qtiProvider = {
                 );
             })
             .on('skip', function(scope) {
-                stopwatch.stop();
-
                 this.trigger('disablenav disabletools');
 
                 computeNext('skip', {
@@ -439,8 +435,6 @@ var qtiProvider = {
                     'noAlertTimeout',
                     true
                 );
-
-                stopwatch.stop();
 
                 context.isTimeout = true;
 
@@ -493,8 +487,6 @@ var qtiProvider = {
                 }
             })
             .on('pause', function(data) {
-                stopwatch.stop();
-
                 this.setState('closedOrSuspended', true);
 
                 this.getProxy()
@@ -513,6 +505,9 @@ var qtiProvider = {
                     .catch(function(err) {
                         self.trigger('error', err);
                     });
+            })
+            .before('move skip exit timeout pause', function() {
+                stopwatch.stop();
             })
             .on('loaditem', function() {
                 var context = this.getTestContext();

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -408,8 +408,6 @@ var qtiProvider = {
             .on('exit', function(reason) {
                 var context = self.getTestContext();
 
-                stopwatch.stop();
-
                 this.disableItem(context.itemIdentifier);
 
                 this.getProxy()


### PR DESCRIPTION
#### Related
https://oat-sa.atlassian.net/browse/TCA-647

#### Description
`itemDuration` parameter was missing in `pause` request.

#### How to test

- Set up a customer environment with proctoring enabled and test with a time limit
- Pause the test session from proctor interface
- During next heartbeat the pause will be detected and additional pause request will be sent to BE. Verify that the `pause` request has `itemDuration` parameter.
