### PR TITLE
Use builder node instead of master in CI builds

### DIFF
--- a/.Jenkinsfile
+++ b/.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'master'
+        label 'builder'
     }
     stages {
         stage('Frontend Tests') {


### PR DESCRIPTION
Every artefact must be built using the builder nodes, master is for orchestration only.

