### PR TITLE
Feature/tca 664/close shortcuts popup by esc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.2",
+    "version": "2.10.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/shortcuts.js
+++ b/src/plugins/content/accessibility/jumplinks/shortcuts.js
@@ -71,9 +71,9 @@ const defaults = {
  * @returns {shortcutsBox} the component, initialized and rendered
  */
 export default function shortcutsBoxFactory(config) {
+    const ESK_KEY_CODE = 27;
     const shortcutsBox = component({}, defaults)
         .on('render', function () {
-            const ESK_KEY_CODE = 27;
             const $element = this.getElement();
             const $closeBtn = $element.find('.btn-close');
             const $keyNavigationItems = this.getElement()
@@ -86,7 +86,7 @@ export default function shortcutsBoxFactory(config) {
                     this.trigger('close');
                 }
             });
-            $element.on('keydown', (e) => {
+            $element.on('keyup', (e) => {
                 if (e.keyCode === ESK_KEY_CODE) {
                     this.trigger('close');
                 }

--- a/src/plugins/content/accessibility/jumplinks/shortcuts.js
+++ b/src/plugins/content/accessibility/jumplinks/shortcuts.js
@@ -73,6 +73,7 @@ const defaults = {
 export default function shortcutsBoxFactory(config) {
     const shortcutsBox = component({}, defaults)
         .on('render', function () {
+            const ESK_KEY_CODE = 27;
             const $element = this.getElement();
             const $closeBtn = $element.find('.btn-close');
             const $keyNavigationItems = this.getElement()
@@ -82,6 +83,11 @@ export default function shortcutsBoxFactory(config) {
             // handle overlay click
             $element.on('click', (e) => {
                 if ($element.is(e.target)) {
+                    this.trigger('close');
+                }
+            });
+            $element.on('keydown', (e) => {
+                if (e.keyCode === ESK_KEY_CODE) {
                     this.trigger('close');
                 }
             });


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-664
 
shortcuts popup is closable by ESC key
  
#### How to test
 
- prepare an instance of TAO
- prepare a delivery with enabled accesibility mode
- execute the delivery as a test taker
- try to navigate to shortcuts popup via jumplinks
- make sure shortcuts popup is closable by ESC key
  
#### Dependencies

Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1826