### PR TITLE
[TCA-665] Incorrect KB navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.3",
+    "version": "2.10.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.3",
+    "version": "2.10.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation/keyNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/keyNavigation.js
@@ -120,6 +120,14 @@ export default function keyNavigationFactory(testRunner, config = {}) {
         },
 
         /**
+         * Returns keyNavigation active state
+         * @returns {Boolean}
+         */
+        isActive() {
+            return groupNavigator !== null;
+        },
+
+        /**
          * Tears down the keyNavigator
          * @returns {testRunnerKeyNavigator}
          */

--- a/src/plugins/content/accessibility/keyNavigation/plugin.js
+++ b/src/plugins/content/accessibility/keyNavigation/plugin.js
@@ -54,6 +54,8 @@ export default pluginFactory({
          */
         testRunner
             .after('renderitem', () => {
+                // make sure that keyNavigator is destroyed
+                // to preevent multiple instances to be active at the same time
                 if (keyNavigator.isActive()) {
                     keyNavigator.destroy();
                 }

--- a/src/plugins/content/accessibility/keyNavigation/plugin.js
+++ b/src/plugins/content/accessibility/keyNavigation/plugin.js
@@ -53,8 +53,16 @@ export default pluginFactory({
          *  Update plugin state based on changes
          */
         testRunner
-            .after('renderitem', () => keyNavigator.init())
-            .on('unloaditem', () => keyNavigator.destroy())
+            .after('renderitem', () => {
+                if (keyNavigator.isActive()) {
+                    keyNavigator.destroy();
+                }
+
+                keyNavigator.init();
+            })
+            .on('unloaditem', () => {
+                keyNavigator.destroy();
+            })
 
             /**
              * @param {string} type - type of content tab navigation,


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-665
 
Make sure that keyNavigation is destroyed before initialization for the next item
 
#### How to test

- prepare an instance of TAO with taoAct extension
- find the delivery mentioned in the ticket
- activate accessibility mode for it
- execute delivery as a test taker
- try to navigate between items using next item shortcut `ALT+SHIFT+N`
- make sure that keyNavigation remains working properly after navigation
  
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1831