### PR TITLE
Fix/tca 551/test status and structure jump link is present when review panel is not enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/helpers.js
+++ b/src/plugins/content/accessibility/jumplinks/helpers.js
@@ -83,3 +83,16 @@ export const getItemStatus = (item) => {
 
     return __('Not seen');
 };
+
+/**
+ * Detects if review panel hidden or not.
+ *
+ * @param {TestRunner} testRunner
+ *
+ * @returns {Boolean}
+ */
+export const isReviewPanelHidden = (testRunner) => testRunner
+    .getAreaBroker()
+    .getPanelArea()
+    .find('.qti-navigator')
+    .is('.hidden');

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -24,7 +24,7 @@ import __ from 'i18n';
 import $ from 'jquery';
 import pluginFactory from 'taoTests/runner/plugin';
 import isReviewPanelEnabled from 'taoQtiTest/runner/helpers/isReviewPanelEnabled';
-import { getJumpElementFactory, getItemStatus } from './helpers';
+import { getJumpElementFactory, getItemStatus, isReviewPanelHidden } from './helpers';
 import jumplinksFactory from './jumplinks';
 import shortcutsFactory from './shortcuts';
 import shortcut from 'util/shortcut';
@@ -159,7 +159,7 @@ export default pluginFactory({
             .on('loaditem', () => {
                 const currentItem = testRunner.getCurrentItem();
                 const updatedConfig = {
-                    isReviewPanelEnabled: isReviewPanelEnabled(testRunner),
+                    isReviewPanelEnabled: !isReviewPanelHidden(testRunner) && isReviewPanelEnabled(testRunner),
                     questionStatus: getItemStatus(currentItem)
                 };
 
@@ -174,11 +174,7 @@ export default pluginFactory({
                 this.jumplinks.trigger('changeQuesitionStatus', questionStatus);
             })
             .on('tool-reviewpanel', () => {
-                const wasHidden = testRunner
-                    .getAreaBroker()
-                    .getPanelArea()
-                    .find('.qti-navigator')
-                    .is('.hidden');
+                const wasHidden = isReviewPanelHidden(testRunner);
 
                 this.jumplinks.trigger('changeReviewPanel', wasHidden);
             });


### PR DESCRIPTION
**Related**
https://oat-sa.atlassian.net/browse/TCA-551

**Description**
Review panel remain hidden, but “Test status and structure“ jump button is present again

**How to test**

1. Create the test with enabled review panel
2. Check the list of Jump links 
3. in a test with Review panel enabled press “Hide review“ button in the tools menu
4. Check the list of Jump links 
5. move to the next item, check the list of Jump links 
6. Check jump links for the test with disabled review panel