### PR TITLE
[TCA-655][TCA-670] Typo in Navigation overlay; Not possible to Flag item 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -168,7 +168,7 @@ export default pluginFactory({
             .on('tool-flagitem', () => {
                 const currentItem = testRunner.getCurrentItem();
                 const questionStatus = getItemStatus(
-                    Object.assign(currentItem, { flagged: !item.flagged })
+                    Object.assign({}, currentItem, { flagged: !item.flagged })
                 );
 
                 this.jumplinks.trigger('changeQuesitionStatus', questionStatus);

--- a/src/plugins/content/accessibility/jumplinks/shortcuts.tpl
+++ b/src/plugins/content/accessibility/jumplinks/shortcuts.tpl
@@ -9,7 +9,7 @@
                 {{__ "Keyboard shortcuts for the Accessibility Tools are available to the Test-taker."}}
             </p>
             <p class="shortcuts-list-description">
-                {{__ "You can magnify the content by op to 200%. Check your browser settings to find out how to do it."}}
+                {{__ "You can magnify the content by up to 200%. Check your browser settings to find out how to do it."}}
             </p>
         </div>
         <button aria-label="Close dialog" class="btn-close small" data-control="close-btn" type="button">


### PR DESCRIPTION
Related to : 
- https://oat-sa.atlassian.net/browse/TCA-655 
- https://oat-sa.atlassian.net/browse/TCA-670
 
#### Changes description

- fix typo on keyboard shortcuts dialog
- fix problem of item flagging because of current item state mutation
  
#### How to test
- prepare an instance of TAO with taoAct extension
- prepare a delivery with possibility to flag items for review and accessibility mode enabled
- execute delivery as a test taker
- access keyboard shortcuts dialog using jump links and make sure that typo is fixed
- try to flag item for review and make sure that it works as expected
 
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1836