### PR TITLE
Release 2.10.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.7",
+    "version": "2.10.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.7",
+    "version": "2.10.8",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/helpers.js
+++ b/src/plugins/content/accessibility/jumplinks/helpers.js
@@ -83,3 +83,16 @@ export const getItemStatus = (item) => {
 
     return __('Not seen');
 };
+
+/**
+ * Detects if review panel hidden or not.
+ *
+ * @param {TestRunner} testRunner
+ *
+ * @returns {Boolean}
+ */
+export const isReviewPanelHidden = (testRunner) => testRunner
+    .getAreaBroker()
+    .getPanelArea()
+    .find('.qti-navigator')
+    .is('.hidden');

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -24,7 +24,7 @@ import __ from 'i18n';
 import $ from 'jquery';
 import pluginFactory from 'taoTests/runner/plugin';
 import isReviewPanelEnabled from 'taoQtiTest/runner/helpers/isReviewPanelEnabled';
-import { getJumpElementFactory, getItemStatus } from './helpers';
+import { getJumpElementFactory, getItemStatus, isReviewPanelHidden } from './helpers';
 import jumplinksFactory from './jumplinks';
 import shortcutsFactory from './shortcuts';
 import shortcut from 'util/shortcut';
@@ -159,7 +159,7 @@ export default pluginFactory({
             .on('loaditem', () => {
                 const currentItem = testRunner.getCurrentItem();
                 const updatedConfig = {
-                    isReviewPanelEnabled: isReviewPanelEnabled(testRunner),
+                    isReviewPanelEnabled: !isReviewPanelHidden(testRunner) && isReviewPanelEnabled(testRunner),
                     questionStatus: getItemStatus(currentItem)
                 };
 
@@ -174,11 +174,7 @@ export default pluginFactory({
                 this.jumplinks.trigger('changeQuesitionStatus', questionStatus);
             })
             .on('tool-reviewpanel', () => {
-                const wasHidden = testRunner
-                    .getAreaBroker()
-                    .getPanelArea()
-                    .find('.qti-navigator')
-                    .is('.hidden');
+                const wasHidden = isReviewPanelHidden(testRunner);
 
                 this.jumplinks.trigger('changeReviewPanel', wasHidden);
             });


### PR DESCRIPTION
Version 2.10.8

**Release notes :**
- [fix] [TCA-551](https://oat-sa.atlassian.net/browse/TCA-551)

Review panel remain hidden, but “Test status and structure“ jump button is present again

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/254