### PR TITLE
[TCA-674] Move the <h2> to the top of the item canvas section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.8",
+    "version": "2.10.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.10.8",
+    "version": "2.10.9",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/provider/layout.tpl
+++ b/src/provider/layout.tpl
@@ -1,6 +1,4 @@
 <main aria-labelledby="test-title-header" class="test-runner-scope">
-    <h2 id="test-title-header" class="landmark-title-hidden"></h2>
-
     <div class="action-bar content-action-bar horizontal-action-bar top-action-bar">
         <div class="control-box size-wrapper"></div>
     </div>
@@ -12,6 +10,7 @@
         </aside>
 
         <section class="content-wrapper">
+            <h2 id="test-title-header" class="landmark-title-hidden"></h2>
             <div id="qti-content"></div>
         </section>
     </div>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-674
 
Move the h2 to the top of the item canvas section
  
#### How to test
- prepare an instance of TAO with taoAct extension
- prepare a delivery with accessibility mode enabled
- execute delivery as a test taker
- make sure that h2 placed on the top of item content markup 
 
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1842/files