### PR TITLE
Fix NEX 1184 - Clear selected contrast on destroy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -260,7 +260,7 @@ export default pluginFactory({
      * Called during the runner's destroy phase
      */
     destroy: function destroy() {
-        this.init();
+        self.storage.setItem('itemThemeId', '');
         shortcut.remove(`.${this.getName()}`);
     },
 

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -260,7 +260,7 @@ export default pluginFactory({
      * Called during the runner's destroy phase
      */
     destroy: function destroy() {
-        self.storage.setItem('itemThemeId', '');
+        this.storage.setItem('itemThemeId', '');
         shortcut.remove(`.${this.getName()}`);
     },
 

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -259,6 +259,7 @@ export default pluginFactory({
      * Called during the runner's destroy phase
      */
     destroy: function destroy() {
+        state.selectedTheme = this.defaultTheme;
         shortcut.remove(`.${this.getName()}`);
     },
 

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -132,6 +132,7 @@ export default pluginFactory({
             if (themesConfig.default) {
                 state.defaultTheme = themesConfig.default;
                 state.selectedTheme = themesConfig.default;
+                changeTheme(themesConfig.default);
             }
             if (themesConfig.available) {
                 _.forEach(themesConfig.available, function(theme) {
@@ -259,7 +260,7 @@ export default pluginFactory({
      * Called during the runner's destroy phase
      */
     destroy: function destroy() {
-        state.selectedTheme = this.defaultTheme;
+        this.init();
         shortcut.remove(`.${this.getName()}`);
     },
 


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/NEX-1184

**Description**

When the user selects any contrast color in Preview and quits Preview mode, this selected color remains when the next Preview mode is opened, however when devices selector is change from default, every new Preview it is back to default.

**Steps to reproduce**

- Open an item (or shared stimulus) in Preview mode
- Change contrast color to 'White on Black'
- Quit Preview mode
- Open another item (or shared stimulus) in Preview mode

**Actual result:** Next Preview mode opened has the contrast color as was set previously.

**Expected result:** Every new opening of Preview mode has contrast color set to default 'Black on white'. 