### PR TITLE
Feature/TCA-634/Allows scrolling from boundaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,9 +1066,9 @@
             }
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.3.0.tgz",
-            "integrity": "sha512-FiJtmKoL3BPLy8a/SKySMt0v3CY5j3ZeUrW6f+tz2VpyjbQkZlwXCmVhFfx7rR5tV5LMSjyZJl659GhPjgHdZg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.5.0.tgz",
+            "integrity": "sha512-VPlsp8egj8f1CpFxP2uBgKWL0A2KeEOJSe0s9HR6BHYW2BYhYrLbfcMlUucSnPZqyJAP8X3Em4oF97OSMi7Vbg==",
             "dev": true
         },
         "@oat-sa/tao-item-runner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.11.2",
+    "version": "2.12.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.3.0",
         "@oat-sa/tao-core-sdk": "^0.8.1",
-        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TCA-634/Allows-scrolling-from-boundaries",
+        "@oat-sa/tao-core-ui": "^1.5.0",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-item-runner-qti": "^0.3.2",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.11.2",
+    "version": "2.12.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.3.0",
         "@oat-sa/tao-core-sdk": "^0.8.1",
-        "@oat-sa/tao-core-ui": "^1.3.0",
+        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TCA-634/Allows-scrolling-from-boundaries",
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-item-runner-qti": "^0.3.2",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",

--- a/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
@@ -69,6 +69,8 @@ export default {
             const $testStatusHeader = $navigator.find('.qti-navigator-info.collapsible > .qti-navigator-label');
             const navigableTestStatus = navigableDomElement.createFromDoms($testStatusHeader);
 
+            $testStatusHeader.addClass('key-navigation-actionable');
+
             if (navigableTestStatus.length) {
                 testStatusNavigation = keyNavigator({
                     keepState: config.keepState,

--- a/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/navigatorNavigation.js
@@ -149,6 +149,10 @@ export default {
             const skipAheadEnabled = $panel.find('.qti-navigator').is('.skipahead-enabled');
             const $trees = $navigator.find(skipAheadEnabled ? selectors.allItems : selectors.unseenItems);
             const navigableTrees = navigableDomElement.createFromDoms($trees);
+
+            $trees.first().addClass('key-navigation-scrollable-up');
+            $trees.last().addClass('key-navigation-scrollable-down');
+
             if (navigableTrees.length) {
                 //instantiate a key navigator but do not add it to the returned list of navigators as this is not supposed to be reached with tab key
                 itemsNavigator = keyNavigator({


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TCA-634

Requires: 
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/144

Allow scrolling up or down from the first or the last element of the list of items in the review panel.
Allow applying the Enter key on the Test status header in the review panel.

To test:
* take a test with the review panel enabled
* zoom the browser up to 200%
* navigate to the review panel using keyboard
* try to scroll the list of items


Note: When the companion PR has been merged, do not forget to update the package.json with the proper version for `@oat-sa/tao-core-ui`