### PR TITLE
Fix/tca 663/incorrect timer announcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.11.2",
+    "version": "2.11.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.11.2",
+    "version": "2.11.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/title/title.tpl
+++ b/src/plugins/controls/title/title.tpl
@@ -1,6 +1,6 @@
 <div role="heading" aria-level="1" class="title-box truncate">
     {{#each titles}}
         <span data-control="{{attribute}}" class="qti-controls {{className}}"></span>
-        <span data-control="{{attribute}}-timer" class="visible-hidden"></span>
+        <div data-control="{{attribute}}-timer" class="visible-hidden"></div>
     {{/each}}
 </div>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-663
 
Heading level 1 with part-section-item name and timer announced without pauses.
  
#### How to test
 
- prepare a delivery with timer(s)
- execute delivery as a test taker
- enable screen reader and navigate with cursor keys to announce invisible mentioned header 1lvl
- check if item and timer announces separated

#### Related to:
https://github.com/oat-sa/extension-tao-testqti/pull/1850