### PR TITLE
[TCA-682] "Flagged" status remains in Jump to question when item is unflagged

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -168,7 +168,7 @@ export default pluginFactory({
             .on('tool-flagitem', () => {
                 const currentItem = testRunner.getCurrentItem();
                 const questionStatus = getItemStatus(
-                    Object.assign({}, currentItem, { flagged: !item.flagged })
+                    Object.assign({}, currentItem, { flagged: !currentItem.flagged })
                 );
 
                 this.jumplinks.trigger('changeQuesitionStatus', questionStatus);


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-682
 
Get item flagged status from current item
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery with accessibility feature enabled, review panel and possibility to flag items
- execute delivery as a test taker
- navigate from the fist item
- try to flag and unflag item
- make sure that item status is correctly update in corresponding jumplink 

#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1851