### PR TITLE
[TCA-551] "Test status and structure" jump link is present when Review panel is not enabled in the test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -156,7 +156,7 @@ export default pluginFactory({
             });
 
         testRunner
-            .on('loaditem', () => {
+            .on('renderitem', () => {
                 const currentItem = testRunner.getCurrentItem();
                 const updatedConfig = {
                     isReviewPanelEnabled: !isReviewPanelHidden(testRunner) && isReviewPanelEnabled(testRunner),


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-551
 
handle `renderitem` instead of `loaditem` since review panel is not update during item load
  
#### How to test

- prepare an instance of TAO with taoAct extension
- prepare a delivery with two section. the fist one should be without review panel and the second with
- execute delivery as a test taker
- navigate from the section without review panel to the section with
- make sure that "Test status and structure" jumplink is available
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/<EXT>/pull/<ID>