### PR TITLE
[TCA-671] Remove role="menubar" from header and role="menuitem" from <li>s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.0",
+    "version": "2.12.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/timer/component/tpl/countdown.tpl
+++ b/src/plugins/controls/timer/component/tpl/countdown.tpl
@@ -1,4 +1,4 @@
 <div class="countdown" data-control="{{id}}" data-type="{{type}}" data-scope="{{scope}}" title="{{label}}" disabled>
     <span aria-label="{{label}}" class="label truncate">{{label}}</span>
-    <span role= "menuitem" class="time"></span>
+    <span class="time"></span>
 </div>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-671
 
- Remove role attribute `menuitem` from timer
  
#### How to test

- prepare an instance of TAO with taoAct extension
- prepare a delivery with timer
- execute delivery as a test taker
- check that timer does not have role attribute

#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/<EXT>/pull/<ID>
