### PR TITLE
Fix NEX 1184 - Clear selected contrast on destroy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.5",
+    "version": "2.12.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.2",
+    "version": "2.12.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.5",
+    "version": "2.12.6",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.2",
+    "version": "2.12.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -261,7 +261,9 @@ export default pluginFactory({
      */
     destroy: function destroy() {
         shortcut.remove(`.${this.getName()}`);
-        return this.storage.setItem('itemThemeId', '');
+        return this.getTestRunner().getPluginStore(this.getName()).then(function(itemThemesStore) {
+            return itemThemesStore.setItem('itemThemeId', '');
+        });
     },
 
     /**

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -262,7 +262,7 @@ export default pluginFactory({
     destroy: function destroy() {
         shortcut.remove(`.${this.getName()}`);
         return this.getTestRunner().getPluginStore(this.getName()).then(function(itemThemesStore) {
-            return itemThemesStore.setItem('itemThemeId', '');
+            return itemThemesStore.removeItem('itemThemeId');
         });
     },
 

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -260,8 +260,8 @@ export default pluginFactory({
      * Called during the runner's destroy phase
      */
     destroy: function destroy() {
-        this.storage.setItem('itemThemeId', '');
         shortcut.remove(`.${this.getName()}`);
+        return this.storage.setItem('itemThemeId', '');
     },
 
     /**


### PR DESCRIPTION
**PR related**

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/263

**Issue**

https://oat-sa.atlassian.net/browse/NEX-1184

**Description**

When the user selects any contrast color in Preview and quits Preview mode, this selected color remains when the next Preview mode is opened, however when devices selector is change from default, every new Preview it is back to default.

**Steps to reproduce**

- Open an item (or shared stimulus) in Preview mode
- Change contrast color to 'White on Black'
- Quit Preview mode
- Open another item (or shared stimulus) in Preview mode

**Actual result:** Next Preview mode opened has the contrast color as was set previously.

**Expected result:** Every new opening of Preview mode has contrast color set to default 'Black on white'. 