### PR TITLE
[TCA-712] Bottom Bar - Label Tools only usable for users with some vision as "Visual Tools" 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.6",
+    "version": "2.13.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.6",
+    "version": "2.13.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/highlighter/plugin.js
+++ b/src/plugins/tools/highlighter/plugin.js
@@ -85,7 +85,7 @@ export default pluginFactory({
                 control: 'highlight-trigger',
                 aria: {
                     pressed: 'false',
-                    label: __('Highlight Text')
+                    label: __('(Visual) Highlight Text')
                 },
                 text: __('Highlight')
             });
@@ -96,6 +96,9 @@ export default pluginFactory({
                 title: __('Clear all active highlights'),
                 icon: 'result-nok',
                 control: 'highlight-clear',
+                aria: {
+                    label: __('(Visual) Clear all active highlights')
+                },
                 text: __('Clear Highlights')
             });
 


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-712
 
Change aria-label attributes of highlighter tool controls 
  
#### How to test

- prepare an instance of TAO with taoAct extension
- prepare a delivery with highlighter tool enabled
- execute delivery as a test taker
- inspect highlighter tool controls in the bottom bar
- check `aria-label` attributes

#### Dependencies
 
Companion PR:
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1862