### PR TITLE
[TCA-710] Inconsistent Timer announcement in the top bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.6",
+    "version": "2.12.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.12.6",
+    "version": "2.12.7",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/timer/component/countdown.js
+++ b/src/plugins/controls/timer/component/countdown.js
@@ -85,7 +85,8 @@ var warningTimeout = {
  * @returns {countdown} the component, initialized and rendered
  */
 export default function countdownFactory($container, config) {
-    var $time;
+    let $time;
+    let $timeScreenreader;
 
     /**
      * @typedef {Object} countdown
@@ -122,7 +123,7 @@ export default function countdownFactory($container, config) {
                             const seconds = time.get('seconds');
 
                             $time.text(this.encodedTime);
-                            $time.attr('aria-label',
+                            $timeScreenreader.attr('aria-label',
                                 getTimerMessage(
                                     hours,
                                     minutes,
@@ -284,6 +285,7 @@ export default function countdownFactory($container, config) {
         })
         .on('render', function() {
             $time = $('.time', this.getElement());
+            $timeScreenreader = $('.time--screenreader', this.getElement());
 
             if (this.config.showBeforeStart === true) {
                 $time.text(timeEncoder.encode(this.remainingTime / precision));

--- a/src/plugins/controls/timer/component/countdown.js
+++ b/src/plugins/controls/timer/component/countdown.js
@@ -123,14 +123,15 @@ export default function countdownFactory($container, config) {
                             const seconds = time.get('seconds');
 
                             $time.text(this.encodedTime);
-                            $timeScreenreader.attr('aria-label',
+                            $timeScreenreader.text(
                                 getTimerMessage(
                                     hours,
                                     minutes,
                                     seconds,
                                     unansweredQuestions,
                                     this.config.scope
-                                ));
+                                )
+                            );
                         }
 
                         if (this.warnings) {

--- a/src/plugins/controls/timer/component/tpl/countdown.tpl
+++ b/src/plugins/controls/timer/component/tpl/countdown.tpl
@@ -1,4 +1,5 @@
 <div class="countdown" data-control="{{id}}" data-type="{{type}}" data-scope="{{scope}}" title="{{label}}" disabled>
     <span aria-label="{{label}}" class="label truncate">{{label}}</span>
-    <span class="time"></span>
+    <span class="time" aria-hidden="true"></span>
+    <div class="time--screenreader visible-hidden"></div>
 </div>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-710
 
Add hidden timer available only for screenreaders
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery with timers but without review panel
- execute the delivery as a test taker
- enable screenreader and navigate to timers using arrow keys
- listen to timers announcement
- make sure that it is consistent with timers in h1 heading
- make sure to check with NVDA and JAWS 
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/<EXT>/pull/<ID>