### PR TITLE
[TCA-648] WTP-1576 - Speed control is off screen with initial placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.1",
+    "version": "2.13.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/apipTextToSpeech/textToSpeech.js
+++ b/src/plugins/tools/apipTextToSpeech/textToSpeech.js
@@ -308,17 +308,12 @@ function maskingComponentFactory(container, config) {
          */
         toggleSettings() {
             const isSettings = this.is('settings');
-            // offset from right
-            const offsetFromRight = 10;
 
             this.setState('settings', !isSettings);
 
             // if settings was enabled make sure that component still inside the container
             if (!isSettings) {
-                const { x, y } = this.getPosition();
-                const maxXPosition = window.innerWidth - this.getElement().width() - offsetFromRight;
-
-                this.moveTo(x > maxXPosition ? maxXPosition : x, y);
+                this.handleResize();
             }
         },
         /**

--- a/src/plugins/tools/apipTextToSpeech/textToSpeech.js
+++ b/src/plugins/tools/apipTextToSpeech/textToSpeech.js
@@ -308,9 +308,30 @@ function maskingComponentFactory(container, config) {
          */
         toggleSettings() {
             const isSettings = this.is('settings');
+            // offset from right
+            const offsetFromRight = 10;
 
             this.setState('settings', !isSettings);
+
+            // if settings was enabled make sure that component still inside the container
+            if (!isSettings) {
+                const { x, y } = this.getPosition();
+                const maxXPosition = window.innerWidth - this.getElement().width() - offsetFromRight;
+
+                this.moveTo(x > maxXPosition ? maxXPosition : x, y);
+            }
         },
+        /**
+         * Handle browser resize
+         */
+        handleResize() {
+            // offset from right
+            const offsetFromRight = 10;
+            const { x, y } = this.getPosition();
+            const maxXPosition = window.innerWidth - this.getElement().width() - offsetFromRight;
+
+            this.moveTo(x > maxXPosition ? maxXPosition : x, y);
+        }
     };
 
     const ttsComponent = component(spec, defaultConfig);
@@ -403,6 +424,8 @@ function maskingComponentFactory(container, config) {
                 this.initNextItem();
             });
 
+            window.addEventListener('resize', this.handleResize);
+
             // move to initial position
             this.moveTo(left, top);
         })
@@ -416,6 +439,8 @@ function maskingComponentFactory(container, config) {
             container.removeClass('tts-component-container');
             this.clearAPIPElements();
             this.stop();
+
+            window.removeEventListener('resize', this.handleResize);
         });
 
     ttsComponent.init(config);


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-648
 
Make sure that component inside the container after resize or settings expanding
  
#### How to test

- prepare an instance of TAO with taoAct extension 
- prepare a delivery with APIP content and TTS plugin enabled
- execute the delivery as a test taker
- try to expand TTS component settings and check if it shift to stay on the page
- try to resize the page and check if component moved with page
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/<EXT>/pull/<ID>