### PR TITLE
Fix [BSA 199] - Split onPartChange and onTestEnd in individual functions for show differents messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ typings/
 
 dist
 css/
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.7",
+    "version": "2.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.6",
+    "version": "2.13.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.7",
+    "version": "2.14.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.2",
+    "version": "2.13.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -30,7 +30,7 @@ import statsHelper from 'taoQtiTest/runner/helpers/stats';
  * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox
  * @returns {String} Returns the message text
  */
-function getExitMessage(scope, runner, sync) {
+function getExitMessage(scope, runner, message, sync) {
     let itemsCountMessage = '';
 
     const testRunnerOptions = runner.getOptions();
@@ -40,7 +40,7 @@ function getExitMessage(scope, runner, sync) {
         itemsCountMessage = getUnansweredItemsWarning(scope, runner, sync);
     }
 
-    return itemsCountMessage.trim();
+    return message ? message : itemsCountMessage.trim();
 }
 
 /**

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -30,17 +30,17 @@ import statsHelper from 'taoQtiTest/runner/helpers/stats';
  * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox
  * @returns {String} Returns the message text
  */
-function getExitMessage(message, scope, runner, sync) {
+function getExitMessage(scope, runner, sync) {
     let itemsCountMessage = '';
 
-    const testRunnerOptions = runner.getOptions();
+    const testRunnerOptions = sync.getOptions();
     const messageEnabled = testRunnerOptions.enableUnansweredItemsWarning;
 
     if (messageEnabled) {
         itemsCountMessage = getUnansweredItemsWarning(scope, runner, sync);
     }
 
-    return `${itemsCountMessage} ${message}`.trim();
+    return itemsCountMessage.trim();
 }
 
 /**
@@ -70,10 +70,13 @@ function getUnansweredItemsWarning(scope, runner, sync) {
             itemsCountMessage += `, ${__('and flagged %s of them', flaggedCount.toString())}`;
         }
     } else if (scope === 'test' || scope === 'testWithoutInaccessibleItems') {
-        if (unansweredCount === 0) {
-            itemsCountMessage = __('You answered all %s question(s) in this test', stats.questions.toString());
-        } else {
-            itemsCountMessage = __('You have %s unanswered question(s)', unansweredCount.toString());
+        itemsCountMessage = `<b>${__('You are about to submit the test.')}</b>`
+        if (unansweredCount > 1) {
+            itemsCountMessage += __('There are %s unanswered questions. You will not be able to return to this test after you submit your answers.', stats.questions.toString());
+        } else if (unansweredCount === 1) {
+            itemsCountMessage += __('There is %s unanswered question. You will not be able to return to this test after you submit your answers.', stats.questions.toString());
+        } else if (unansweredCount === 0) {
+            itemsCountMessage += __('You will not be able to return to this test after you submit your answers.');
         }
         if (flaggedCount) {
             itemsCountMessage += ` ${__(
@@ -82,10 +85,11 @@ function getUnansweredItemsWarning(scope, runner, sync) {
             )}`;
         }
     } else if (scope === 'part') {
-        if (unansweredCount === 0) {
-            itemsCountMessage = __('You answered all %s question(s)', stats.questions.toString());
-        } else {
-            itemsCountMessage = __('You have %s unanswered question(s)', unansweredCount.toString());
+        itemsCountMessage = `<b>${__('You are about to submit this test part.')}</b>`
+        if (unansweredCount > 1) {
+            itemsCountMessage += __('There are %s unanswered questions in this part of the test.', stats.questions.toString());
+        } else if (unansweredCount === 1) {
+            itemsCountMessage += __('There is %s unanswered question in this part of the test.', stats.questions.toString());
         }
         if (flaggedCount) {
             itemsCountMessage += ` ${__(

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -86,7 +86,7 @@ function getUnansweredItemsWarning(scope, runner, sync) {
         } else if (unansweredCount === 1) {
             itemsCountMessage += __('There is %s unanswered question in this part of the test', unansweredCount.toString());
         }
-        if (flaggedCount) {
+        if (unansweredCount && flaggedCount) {
             itemsCountMessage += ` ${__(
                 'and you flagged %s item(s) that you can review now',
                 flaggedCount.toString()

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -40,7 +40,7 @@ function getExitMessage(scope, runner, message, sync) {
         itemsCountMessage = getUnansweredItemsWarning(scope, runner, sync);
     }
 
-    return message ? message : itemsCountMessage.trim();
+    return `${itemsCountMessage} ${message}`.trim();
 }
 
 /**
@@ -59,7 +59,7 @@ function getUnansweredItemsWarning(scope, runner, sync) {
     if (scope === 'section' || scope === 'testSection') {
         itemsCountMessage = `<b>${__('You are about to leave this section.')}</b><br><br>`
         itemsCountMessage += __(
-            'You answered %s of %s question(s) for this section of the test.',
+            'You answered %s of %s question(s) for this section of the test',
             stats.answered.toString(),
             stats.questions.toString()
         );
@@ -69,11 +69,9 @@ function getUnansweredItemsWarning(scope, runner, sync) {
     } else if (scope === 'test' || scope === 'testWithoutInaccessibleItems') {
         itemsCountMessage = `<b>${__('You are about to submit the test.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions. You will not be able to return to this test after you submit your answers.', stats.answered.toString());
+            itemsCountMessage += __('There are %s unanswered questions.', stats.answered.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question. You will not be able to return to this test after you submit your answers.', stats.answered.toString());
-        } else if (unansweredCount === 0) {
-            itemsCountMessage += __('You will not be able to return to this test after you submit your answers.');
+            itemsCountMessage += __('There is %s unanswered question.', stats.answered.toString());
         }
         if (flaggedCount) {
             itemsCountMessage += ` ${__(
@@ -84,9 +82,9 @@ function getUnansweredItemsWarning(scope, runner, sync) {
     } else if (scope === 'part') {
         itemsCountMessage = `<b>${__('You are about to submit this test part.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions in this part of the test.', stats.answered.toString());
+            itemsCountMessage += __('There are %s unanswered questions in this part of the test', stats.answered.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question in this part of the test.', stats.answered.toString());
+            itemsCountMessage += __('There is %s unanswered question in this part of the test', stats.answered.toString());
         }
         if (flaggedCount) {
             itemsCountMessage += ` ${__(
@@ -96,6 +94,9 @@ function getUnansweredItemsWarning(scope, runner, sync) {
         }
     }
 
+    if (itemsCountMessage) {
+        itemsCountMessage += '.';
+    }
     return itemsCountMessage;
 }
 

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -73,7 +73,7 @@ function getUnansweredItemsWarning(scope, runner, sync) {
         } else if (unansweredCount === 1) {
             itemsCountMessage += __('There is %s unanswered question', unansweredCount.toString());
         }
-        if (flaggedCount) {
+        if (unansweredCount && flaggedCount) {
             itemsCountMessage += ` ${__(
                 'and you flagged %s item(s) that you can review now',
                 flaggedCount.toString()

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -33,7 +33,7 @@ import statsHelper from 'taoQtiTest/runner/helpers/stats';
 function getExitMessage(scope, runner, sync) {
     let itemsCountMessage = '';
 
-    const testRunnerOptions = sync.getOptions();
+    const testRunnerOptions = runner.getOptions();
     const messageEnabled = testRunnerOptions.enableUnansweredItemsWarning;
 
     if (messageEnabled) {
@@ -57,7 +57,7 @@ function getUnansweredItemsWarning(scope, runner, sync) {
     var itemsCountMessage = '';
 
     if (scope === 'section' || scope === 'testSection') {
-        itemsCountMessage = `<b>${__('You are about to leave this section.')}</b>`
+        itemsCountMessage = `<b>${__('You are about to leave this section.')}</b><br><br>`
         itemsCountMessage += __(
             'You answered %s of %s question(s) for this section of the test.',
             stats.answered.toString(),
@@ -67,11 +67,11 @@ function getUnansweredItemsWarning(scope, runner, sync) {
             itemsCountMessage += `, ${__('and flagged %s of them', flaggedCount.toString())}`;
         }
     } else if (scope === 'test' || scope === 'testWithoutInaccessibleItems') {
-        itemsCountMessage = `<b>${__('You are about to submit the test.')}</b>`
+        itemsCountMessage = `<b>${__('You are about to submit the test.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions. You will not be able to return to this test after you submit your answers.', stats.questions.toString());
+            itemsCountMessage += __('There are %s unanswered questions. You will not be able to return to this test after you submit your answers.', stats.answered.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question. You will not be able to return to this test after you submit your answers.', stats.questions.toString());
+            itemsCountMessage += __('There is %s unanswered question. You will not be able to return to this test after you submit your answers.', stats.answered.toString());
         } else if (unansweredCount === 0) {
             itemsCountMessage += __('You will not be able to return to this test after you submit your answers.');
         }
@@ -82,11 +82,11 @@ function getUnansweredItemsWarning(scope, runner, sync) {
             )}`;
         }
     } else if (scope === 'part') {
-        itemsCountMessage = `<b>${__('You are about to submit this test part.')}</b>`
+        itemsCountMessage = `<b>${__('You are about to submit this test part.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions in this part of the test.', stats.questions.toString());
+            itemsCountMessage += __('There are %s unanswered questions in this part of the test.', stats.answered.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question in this part of the test.', stats.questions.toString());
+            itemsCountMessage += __('There is %s unanswered question in this part of the test.', stats.answered.toString());
         }
         if (flaggedCount) {
             itemsCountMessage += ` ${__(
@@ -96,9 +96,6 @@ function getUnansweredItemsWarning(scope, runner, sync) {
         }
     }
 
-    if (itemsCountMessage) {
-        itemsCountMessage += '.';
-    }
     return itemsCountMessage;
 }
 

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -30,7 +30,7 @@ import statsHelper from 'taoQtiTest/runner/helpers/stats';
  * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox
  * @returns {String} Returns the message text
  */
-function getExitMessage(scope, runner, message, sync) {
+function getExitMessage(scope, runner, message = '', sync) {
     let itemsCountMessage = '';
 
     const testRunnerOptions = runner.getOptions();
@@ -69,9 +69,9 @@ function getUnansweredItemsWarning(scope, runner, sync) {
     } else if (scope === 'test' || scope === 'testWithoutInaccessibleItems') {
         itemsCountMessage = `<b>${__('You are about to submit the test.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions.', stats.answered.toString());
+            itemsCountMessage += __('There are %s unanswered questions', unansweredCount.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question.', stats.answered.toString());
+            itemsCountMessage += __('There is %s unanswered question', unansweredCount.toString());
         }
         if (flaggedCount) {
             itemsCountMessage += ` ${__(
@@ -82,9 +82,9 @@ function getUnansweredItemsWarning(scope, runner, sync) {
     } else if (scope === 'part') {
         itemsCountMessage = `<b>${__('You are about to submit this test part.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions in this part of the test', stats.answered.toString());
+            itemsCountMessage += __('There are %s unanswered questions in this part of the test', unansweredCount.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question in this part of the test', stats.answered.toString());
+            itemsCountMessage += __('There is %s unanswered question in this part of the test', unansweredCount.toString());
         }
         if (flaggedCount) {
             itemsCountMessage += ` ${__(
@@ -94,7 +94,7 @@ function getUnansweredItemsWarning(scope, runner, sync) {
         }
     }
 
-    if (itemsCountMessage) {
+    if (itemsCountMessage && unansweredCount !== 0) {
         itemsCountMessage += '.';
     }
     return itemsCountMessage;

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -57,15 +57,12 @@ function getUnansweredItemsWarning(scope, runner, sync) {
     var itemsCountMessage = '';
 
     if (scope === 'section' || scope === 'testSection') {
-        if (unansweredCount === 0) {
-            itemsCountMessage = __('You answered all %s question(s) in this section', stats.questions.toString());
-        } else {
-            itemsCountMessage = __(
-                'You answered only %s of the %s question(s) in this section',
-                stats.answered.toString(),
-                stats.questions.toString()
-            );
-        }
+        itemsCountMessage = `<b>${__('You are about to leave this section.')}</b>`
+        itemsCountMessage += __(
+            'You answered %s of %s question(s) for this section of the test.',
+            stats.answered.toString(),
+            stats.questions.toString()
+        );
         if (flaggedCount) {
             itemsCountMessage += `, ${__('and flagged %s of them', flaggedCount.toString())}`;
         }

--- a/src/plugins/controls/timer/strategy/warnSectionLeaving.js
+++ b/src/plugins/controls/timer/strategy/warnSectionLeaving.js
@@ -94,7 +94,7 @@ export default function warnSectionLeavingStrategy(testRunner, timer) {
                             ) {
                                 testRunner.trigger(
                                     'confirm.exittimed',
-                                    messages.getExitMessage(exitMessage, 'section', testRunner),
+                                    messages.getExitMessage('section', testRunner, exitMessage),
                                     resolve,
                                     reject,
                                     {

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -187,7 +187,7 @@ export default pluginFactory({
                         messages.getExitMessage(
                             warningScope,
                             testRunner,
-                            __('You will not be able to return to this test after you submit your answers')
+                            __('You will not be able to return to this test after you submit your answers.')
                         ),
                         triggerNextAction, // if the test taker accept
                         enableNav, // if he refuse

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -163,7 +163,14 @@ export default pluginFactory({
                     unansweredOnly: unansweredOnly
                 });
 
-                if (warningHelper.shouldWarnBeforeEnd()) {
+                if (warningHelper.shouldWarnBeforeEndPart()) {
+                    testRunner.trigger(
+                        'confirm.endTestPart',
+                        __('You are about to go to the next item. Click OK to continue and go to the next item.'),
+                        triggerNextAction, // if the test taker accept
+                        enableNav // if he refuse
+                    );
+                } else if (warningHelper.shouldWarnBeforeEnd()) {
                     testRunner.trigger(
                         'confirm.endTest',
                         messages.getExitMessage(

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -186,7 +186,8 @@ export default pluginFactory({
                         'confirm.endTest',
                         messages.getExitMessage(
                             warningScope,
-                            testRunner
+                            testRunner,
+                            __('You will not be able to return to this test after you submit your answers')
                         ),
                         triggerNextAction, // if the test taker accept
                         enableNav, // if he refuse

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -166,7 +166,10 @@ export default pluginFactory({
                 if (warningHelper.shouldWarnBeforeEndPart()) {
                     testRunner.trigger(
                         'confirm.endTestPart',
-                        __('You are about to go to the next item. Click OK to continue and go to the next item.'),
+                        messages.getExitMessage(
+                            warningScope,
+                            testRunner
+                        ),
                         triggerNextAction, // if the test taker accept
                         enableNav // if he refuse
                     );
@@ -174,9 +177,6 @@ export default pluginFactory({
                     testRunner.trigger(
                         'confirm.endTest',
                         messages.getExitMessage(
-                            __(
-                                'You are about to submit the test. You will not be able to access this test once submitted. Click OK to continue and submit the test.'
-                            ),
                             warningScope,
                             testRunner
                         ),

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -171,7 +171,15 @@ export default pluginFactory({
                             testRunner
                         ),
                         triggerNextAction, // if the test taker accept
-                        enableNav // if he refuse
+                        enableNav, // if he refuse
+                        {
+                            buttons: {
+                                labels: {
+                                    ok: __('SUBMIT THIS PART'),
+                                    cancel: __('CANCEL')
+                                }
+                            }
+                        }
                     );
                 } else if (warningHelper.shouldWarnBeforeEnd()) {
                     testRunner.trigger(
@@ -181,14 +189,22 @@ export default pluginFactory({
                             testRunner
                         ),
                         triggerNextAction, // if the test taker accept
-                        enableNav // if he refuse
+                        enableNav, // if he refuse
+                        {
+                            buttons: {
+                                labels: {
+                                    ok: __('SUBMIT THE TEST'),
+                                    cancel: __('CANCEL')
+                                }
+                            }
+                        }
                     );
                 } else if (warningHelper.shouldWarnBeforeNext()) {
                     testRunner.trigger(
                         'confirm.next',
                         __('You are about to go to the next item. Click OK to continue and go to the next item.'),
                         triggerNextAction, // if the test taker accept
-                        enableNav // if he refuse
+                        enableNav, // if he refuse
                     );
                 } else {
                     triggerNextAction();

--- a/src/plugins/navigation/next/nextWarningHelper.js
+++ b/src/plugins/navigation/next/nextWarningHelper.js
@@ -63,7 +63,8 @@ var nextWarningHelper = function nextWarningHelper(options) {
         testPartId = options.testPartId || '',
         unansweredOnly = toBoolean(options.unansweredOnly, false),
         warnBeforeNext = shouldWarnBeforeNext(),
-        warnBeforeEnd = shouldWarnBeforeEnd();
+        warnBeforeEnd = shouldWarnBeforeEnd(),
+        warnBeforeEndPart = shouldWarnBeforeEndPart();
 
     /**
      * Decide if we should display a warning before moving to the next item.
@@ -98,7 +99,14 @@ var nextWarningHelper = function nextWarningHelper(options) {
      * Decide if we should display a warning before ending the test
      */
     function shouldWarnBeforeEnd() {
-        return shouldWarnOnTestEnd() || shouldWarnOnPartChange();
+        return shouldWarnOnTestEnd();
+    }
+
+    /**
+     * Decide if we should display a warning before ending the test part
+     */
+    function shouldWarnBeforeEndPart() {
+        return shouldWarnOnPartChange();
     }
 
     /**
@@ -150,6 +158,9 @@ var nextWarningHelper = function nextWarningHelper(options) {
      * The helper object
      */
     return {
+        shouldWarnBeforeEndPart: function() {
+            return warnBeforeEndPart;
+        },
         shouldWarnBeforeEnd: function() {
             return warnBeforeEnd;
         },

--- a/src/plugins/navigation/nextSection.js
+++ b/src/plugins/navigation/nextSection.js
@@ -116,7 +116,6 @@ export default pluginFactory({
                     testRunner.trigger(
                         'confirm.nextsection',
                         messages.getExitMessage(
-                            __('Once you close this section, you cannot return to it or change your answers.'),
                             'section',
                             testRunner
                         ),

--- a/src/plugins/navigation/nextSection.js
+++ b/src/plugins/navigation/nextSection.js
@@ -124,8 +124,8 @@ export default pluginFactory({
                         {
                             buttons: {
                                 labels: {
-                                    ok: __('Close this Section'),
-                                    cancel: __('Review my Answers')
+                                    ok: __('CONTINUE TO THE NEXT SECTION'),
+                                    cancel: __('CANCEL')
                                 }
                             }
                         }

--- a/src/plugins/navigation/skip.js
+++ b/src/plugins/navigation/skip.js
@@ -122,11 +122,11 @@ export default pluginFactory({
                     testRunner.trigger(
                         'confirm.endTest',
                         messages.getExitMessage(
+                            'test',
+                            testRunner,
                             __(
                                 'You are about to submit the test. You will not be able to access this test once submitted. Click OK to continue and submit the test.'
-                            ),
-                            'test',
-                            testRunner
+                            )
                         ),
                         doSkip, // if the test taker accept
                         enable // if the test taker refuse

--- a/src/plugins/navigation/skip.js
+++ b/src/plugins/navigation/skip.js
@@ -125,7 +125,7 @@ export default pluginFactory({
                             'test',
                             testRunner,
                             __(
-                                'You are about to submit the test. You will not be able to access this test once submitted. Click OK to continue and submit the test.'
+                                'You will not be able to access this test once submitted. Click OK to continue and submit the test.'
                             )
                         ),
                         doSkip, // if the test taker accept

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -522,7 +522,7 @@ var qtiProvider = {
 
                 //The item is rendered but in a state that prevents us from interacting
                 if (context.isTimeout) {
-                    warning = __('Time limit reached for item "%s".', getItemLabel());
+                    warning = __('The time limit has been reached for this part of the test.');
                 } else if (context.itemSessionState > states.itemSession.interacting) {
                     if (context.remainingAttempts === 0) {
                         warning = __('No more attempts allowed for item "%s".', getItemLabel());

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -472,7 +472,7 @@ var qtiProvider = {
                             } else {
                                 self.trigger(
                                     'alert.timeout',
-                                    __('Time limit reached, this part of the test has ended.'),
+                                    __('The time limit has been reached for this part of the test.'),
                                     () => {
                                         self.trigger('timeoutAccepted');
 
@@ -522,7 +522,7 @@ var qtiProvider = {
 
                 //The item is rendered but in a state that prevents us from interacting
                 if (context.isTimeout) {
-                    warning = __('The time limit has been reached for this part of the test.');
+                    warning = __('Time limit reached for item "%s".', getItemLabel());
                 } else if (context.itemSessionState > states.itemSession.interacting) {
                     if (context.remainingAttempts === 0) {
                         warning = __('No more attempts allowed for item "%s".', getItemLabel());

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -85,9 +85,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage: '<b>You are about to submit the test.</b><br><br>You will not be able to return to this test after you submit your answers.',
+                testMessage: '<b>You are about to submit the test.</b><br><br>',
                 partMessage: '<b>You are about to submit this test part.</b><br><br>',
-                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test.'
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test'
             },
             {
                 title: 'current not answered, none flagged',
@@ -96,8 +96,8 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 2 },
                 currentItemResponse: null,
                 currentItemAnswered: false,
-                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers.',
-                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test.',
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 1 unanswered question.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 1 unanswered question in this part of the test.',
                 sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test.'
             },
             {
@@ -107,9 +107,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 2, flagged: 1 },
                 currentItemResponse: null,
                 currentItemAnswered: false,
-                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers. and you flagged 1 item(s) that you can review now',
-                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test. and you flagged 1 item(s) that you can review now',
-                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test., and flagged 1 of them'
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 1 unanswered question and you flagged 1 item(s) that you can review now.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 1 unanswered question in this part of the test and you flagged 1 item(s) that you can review now.',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test, and flagged 1 of them.'
             },
             {
                 title: 'all answered, one flagged',
@@ -118,9 +118,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3, flagged: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage: '<b>You are about to submit the test.</b><br><br>You will not be able to return to this test after you submit your answers. and you flagged 1 item(s) that you can review now',
+                testMessage: '<b>You are about to submit the test.</b><br><br> and you flagged 1 item(s) that you can review now',
                 partMessage: '<b>You are about to submit this test part.</b><br><br> and you flagged 1 item(s) that you can review now',
-                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test., and flagged 1 of them'
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test, and flagged 1 of them'
             },
             {
                 title: 'one flagged, test taker has just answered to the current item, but without moving from it yet',
@@ -129,9 +129,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 1, flagged: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: false,
-                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers. and you flagged 1 item(s) that you can review now',
-                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test. and you flagged 1 item(s) that you can review now',
-                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test., and flagged 1 of them'
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 1 unanswered question and you flagged 1 item(s) that you can review now.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 1 unanswered question in this part of the test and you flagged 1 item(s) that you can review now.',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test, and flagged 1 of them.'
             },
             {
                 title: 'none flagged, test taker has just answered to the current item, but without moving from it yet',
@@ -140,8 +140,8 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: false,
-                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers.',
-                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test.',
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 1 unanswered question.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 1 unanswered question in this part of the test.',
                 sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test.'
             },
             {
@@ -151,9 +151,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage: '<b>You are about to submit the test.</b><br><br>You will not be able to return to this test after you submit your answers.',
+                testMessage: '<b>You are about to submit the test.</b><br><br>',
                 partMessage: '<b>You are about to submit this test part.</b><br><br>',
-                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test.'
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test'
             },
             {
                 title: 'none flagged, all answered, test taker removes answer from a previously answered item',
@@ -162,8 +162,8 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3 },
                 currentItemResponse: null,
                 currentItemAnswered: true,
-                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers.',
-                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test.',
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 1 unanswered question.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 1 unanswered question in this part of the test.',
                 sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test.'
             }
         ])

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -96,20 +96,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 2 },
                 currentItemResponse: null,
                 currentItemAnswered: false,
-                testMessage: 'You have 1 unanswered question(s).',
-                partMessage: 'You have 1 unanswered question(s).',
-                sectionMessage: 'You answered only 2 of the 3 question(s) in this section.'
-            },
-            {
-                title: 'current not answered, none flagged',
-                testStats: { answered: 2 },
-                partStats: { answered: 2 },
-                sectionStats: { answered: 2 },
-                currentItemResponse: null,
-                currentItemAnswered: false,
-                testMessage: 'You have 1 unanswered question(s).',
-                partMessage: 'You have 1 unanswered question(s).',
-                sectionMessage: 'You answered only 2 of the 3 question(s) in this section.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test.',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test.'
             },
             {
                 title: 'current not answered, one flagged',
@@ -118,9 +107,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 2, flagged: 1 },
                 currentItemResponse: null,
                 currentItemAnswered: false,
-                testMessage: 'You have 1 unanswered question(s) and you flagged 1 item(s) that you can review now.',
-                partMessage: 'You have 1 unanswered question(s) and you flagged 1 item(s) that you can review now.',
-                sectionMessage: 'You answered only 2 of the 3 question(s) in this section, and flagged 1 of them.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers. and you flagged 1 item(s) that you can review now',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test. and you flagged 1 item(s) that you can review now',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test., and flagged 1 of them'
             },
             {
                 title: 'all answered, one flagged',
@@ -129,10 +118,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3, flagged: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage:
-                    'You answered all 3 question(s) in this test and you flagged 1 item(s) that you can review now.',
-                partMessage: 'You answered all 3 question(s) and you flagged 1 item(s) that you can review now.',
-                sectionMessage: 'You answered all 3 question(s) in this section, and flagged 1 of them.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>You will not be able to return to this test after you submit your answers. and you flagged 1 item(s) that you can review now',
+                partMessage: '<b>You are about to submit this test part.</b><br><br> and you flagged 1 item(s) that you can review now',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test., and flagged 1 of them'
             },
             {
                 title: 'one flagged, test taker has just answered to the current item, but without moving from it yet',
@@ -141,9 +129,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 1, flagged: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: false,
-                testMessage: 'You have 1 unanswered question(s) and you flagged 1 item(s) that you can review now.',
-                partMessage: 'You have 1 unanswered question(s) and you flagged 1 item(s) that you can review now.',
-                sectionMessage: 'You answered only 2 of the 3 question(s) in this section, and flagged 1 of them.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers. and you flagged 1 item(s) that you can review now',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test. and you flagged 1 item(s) that you can review now',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test., and flagged 1 of them'
             },
             {
                 title: 'none flagged, test taker has just answered to the current item, but without moving from it yet',
@@ -152,9 +140,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: false,
-                testMessage: 'You have 1 unanswered question(s).',
-                partMessage: 'You have 1 unanswered question(s).',
-                sectionMessage: 'You answered only 2 of the 3 question(s) in this section.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test.',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test.'
             },
             {
                 title: 'none flagged, all answered, test taker has just moved to an already answered item',
@@ -163,9 +151,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage: 'You answered all 3 question(s) in this test.',
-                partMessage: 'You answered all 3 question(s).',
-                sectionMessage: 'You answered all 3 question(s) in this section.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>You will not be able to return to this test after you submit your answers.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test.'
             },
             {
                 title: 'none flagged, all answered, test taker removes answer from a previously answered item',
@@ -174,9 +162,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3 },
                 currentItemResponse: null,
                 currentItemAnswered: true,
-                testMessage: 'You have 1 unanswered question(s).',
-                partMessage: 'You have 1 unanswered question(s).',
-                sectionMessage: 'You answered only 2 of the 3 question(s) in this section.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>There is 2 unanswered question. You will not be able to return to this test after you submit your answers.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>There is 2 unanswered question in this part of the test.',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 2 of 3 question(s) for this section of the test.'
             }
         ])
         .test('helpers/messages.getExitMessage (enabled)', function(testData, assert) {

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -118,8 +118,8 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3, flagged: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage: '<b>You are about to submit the test.</b><br><br> and you flagged 1 item(s) that you can review now',
-                partMessage: '<b>You are about to submit this test part.</b><br><br> and you flagged 1 item(s) that you can review now',
+                testMessage: '<b>You are about to submit the test.</b><br><br>',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>',
                 sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test, and flagged 1 of them'
             },
             {

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -85,9 +85,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage: 'You answered all 3 question(s) in this test.',
-                partMessage: 'You answered all 3 question(s).',
-                sectionMessage: 'You answered all 3 question(s) in this section.'
+                testMessage: '<b>You are about to submit the test.</b><br><br>You will not be able to return to this test after you submit your answers.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>',
+                sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test.'
             },
             {
                 title: 'current not answered, none flagged',
@@ -251,45 +251,45 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 }
             };
             var runner = runnerMock(map, context, data, responses, declarations);
-            var message = 'This is a test.';
+            var message = '';
 
             assert.expect(7);
 
             assert.equal(
-                messagesHelper.getExitMessage(message, 'test', runner),
-                `${testData.testMessage} ${message}`,
+                messagesHelper.getExitMessage('test', runner),
+                `${testData.testMessage}${message}`,
                 'message include the right stats for test scope'
             );
             assert.equal(
-                messagesHelper.getExitMessage(message, 'part', runner),
-                `${testData.partMessage} ${message}`,
+                messagesHelper.getExitMessage('part', runner),
+                `${testData.partMessage}${message}`,
                 'message include the right stats for part scope'
             );
             assert.equal(
-                messagesHelper.getExitMessage(message, 'section', runner),
-                `${testData.sectionMessage} ${message}`,
+                messagesHelper.getExitMessage('section', runner),
+                `${testData.sectionMessage}${message}`,
                 'message include the right stats for section scope'
             );
             assert.equal(
-                messagesHelper.getExitMessage(message, 'testWithoutInaccessibleItems', runner),
-                `${testData.testMessage} ${message}`,
+                messagesHelper.getExitMessage('testWithoutInaccessibleItems', runner),
+                `${testData.testMessage}${message}`,
                 'message include the right stats for testWithoutInaccessibleItems scope'
             );
 
             data.enableUnansweredItemsWarning = false;
 
             assert.equal(
-                messagesHelper.getExitMessage(message, 'test', runner),
+                messagesHelper.getExitMessage('test', runner),
                 message,
                 'no stats in test scope when option is disabled'
             );
             assert.equal(
-                messagesHelper.getExitMessage(message, 'part', runner),
+                messagesHelper.getExitMessage('part', runner),
                 message,
                 'no stats in part scope when option is disabled'
             );
             assert.equal(
-                messagesHelper.getExitMessage(message, 'section', runner),
+                messagesHelper.getExitMessage('section', runner),
                 message,
                 'no stats in session scope when option is disabled'
             );

--- a/test/plugins/navigation/nextWarningHelper/test.js
+++ b/test/plugins/navigation/nextWarningHelper/test.js
@@ -114,7 +114,7 @@ define(['lodash', 'taoQtiTest/runner/plugins/navigation/next/nextWarningHelper']
                 testPartId: 'CURRENT_PART',
                 nextPart: { id: 'NEXT_PART' }
             },
-            output: { warnNext: false, warnEnd: true }
+            output: { warnNext: false, warnEnd: false }
         },
         {
             title: 'nextPartWarning: next part different, unansweredOnly, no unanswered / flagged',
@@ -136,7 +136,7 @@ define(['lodash', 'taoQtiTest/runner/plugins/navigation/next/nextWarningHelper']
                 nextPart: { id: 'NEXT_PART' },
                 stats: { flagged: 5 }
             },
-            output: { warnNext: false, warnEnd: true }
+            output: { warnNext: false, warnEnd: false }
         },
         {
             title: 'nextPartWarning: next part different, unansweredOnly, unanswered',
@@ -147,7 +147,7 @@ define(['lodash', 'taoQtiTest/runner/plugins/navigation/next/nextWarningHelper']
                 nextPart: { id: 'NEXT_PART' },
                 stats: { questions: 10, answered: 5 }
             },
-            output: { warnNext: false, warnEnd: true }
+            output: { warnNext: false, warnEnd: false }
         },
         {
             title: 'nextPartWarning: next part different, unansweredOnly, unanswered & flagged',
@@ -158,7 +158,7 @@ define(['lodash', 'taoQtiTest/runner/plugins/navigation/next/nextWarningHelper']
                 nextPart: { id: 'NEXT_PART' },
                 stats: { flagged: 1, questions: 10, answered: 5 }
             },
-            output: { warnNext: false, warnEnd: true }
+            output: { warnNext: false, warnEnd: false }
         }
     ];
 


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/BSA-199

**Context**

`BOSA` has applied certain Navigation warnings in the test settings. The existing pop up messages are not meeting their needs as they confuse the candidate.

**User story description**

As a test author, I want the candidate to view comprehensive pop up warnings when navigating from one Test part to another or from one test section to another. By doing so, the candidate will understand clearly was expected of them in the test.

**AC**

- Have tow different messages for `endPart` and `endTest`