### PR TITLE
Fix TAO-10417 write css map in build time

### DIFF
--- a/build/scss.js
+++ b/build/scss.js
@@ -30,10 +30,9 @@ const limit = promiseLimit(5);
 /**
  * Build scss file with postcss and postcssScss plugin
  * @param {string} scssFile
- * @param {map: Boolean} options
  */
 const buildScss = async scssFile => {
-    const outputFile = scssFile.replace(/([\/\.])scss(\/|$)/g, '$1css$2');
+    const outputFile = scssFile.replace(/([\/.])scss(\/|$)/g, '$1css$2');
 
     // load file content
     let source;
@@ -81,7 +80,7 @@ const writeOutResult = async result => {
 
     // write out map if exist
     if (result.map) {
-        await writeFile(`${outputFile}.map`, result.map, { flag: 'w' });
+        await writeFile(`${outputFile}.map`, result.map.toString(), { flag: 'w' });
     }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2148,36 +2148,6 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "es-abstract": {
-            "version": "1.17.5",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-            "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-            "dev": true,
-            "requires": {
-                "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1",
-                "is-callable": "^1.1.5",
-                "is-regex": "^1.0.5",
-                "object-inspect": "^1.7.0",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
-                "string.prototype.trimleft": "^2.1.1",
-                "string.prototype.trimright": "^2.1.1"
-            }
-        },
-        "es-to-primitive": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-            "dev": true,
-            "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-            }
-        },
         "es6-error": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -2872,15 +2842,6 @@
                 "har-schema": "^2.0.0"
             }
         },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
-        },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -3185,18 +3146,6 @@
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
         },
-        "is-callable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-            "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-            "dev": true
-        },
-        "is-date-object": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-            "dev": true
-        },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3230,29 +3179,11 @@
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
             "dev": true
         },
-        "is-regex": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-            "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-            "dev": true,
-            "requires": {
-                "has-symbols": "^1.0.1"
-            }
-        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
             "dev": true
-        },
-        "is-symbol": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-            "dev": true,
-            "requires": {
-                "has-symbols": "^1.0.1"
-            }
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -3631,12 +3562,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-            "dev": true
-        },
-        "memorystream": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-            "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
             "dev": true
         },
         "meow": {
@@ -4152,23 +4077,6 @@
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
             "dev": true
         },
-        "npm-run-all": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
-            "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^3.2.1",
-                "chalk": "^2.4.1",
-                "cross-spawn": "^6.0.5",
-                "memorystream": "^0.3.1",
-                "minimatch": "^3.0.4",
-                "pidtree": "^0.3.0",
-                "read-pkg": "^3.0.0",
-                "shell-quote": "^1.6.1",
-                "string.prototype.padend": "^3.0.0"
-            }
-        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -4281,12 +4189,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
-        "object-inspect": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
             "dev": true
         },
         "object-keys": {
@@ -4505,12 +4407,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
-        },
-        "pidtree": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
-            "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
             "dev": true
         },
         "pify": {
@@ -5422,12 +5318,6 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
         },
-        "shell-quote": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
-            "dev": true
-        },
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -5550,58 +5440,6 @@
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^5.1.0"
-            }
-        },
-        "string.prototype.padend": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
-            "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.0-next.1"
-            }
-        },
-        "string.prototype.trimend": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-            "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
-            }
-        },
-        "string.prototype.trimleft": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-            "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimstart": "^1.0.0"
-            }
-        },
-        "string.prototype.trimright": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-            "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimend": "^1.0.0"
-            }
-        },
-        "string.prototype.trimstart": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-            "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
             }
         },
         "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.1",
+    "version": "2.13.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3379,6 +3379,12 @@
             "requires": {
                 "html-escaper": "^2.0.0"
             }
+        },
+        "jquery": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
+            "integrity": "sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=",
+            "dev": true
         },
         "jquery-mockjax": {
             "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.2",
+    "version": "2.13.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "build:watch": "rollup --config ./build/rollup.config.js --watch",
         "build:scss": "node ./build/scss.js",
         "lint": "eslint src test",
-        "prepare": "run-s build:scss build"
+        "prepare": "npm run build:scss && npm run build"
     },
     "repository": {
         "type": "git",
@@ -73,7 +73,6 @@
         "lodash": "2.4.1",
         "moment": "^2.27.0",
         "moment-timezone": "0.5.10",
-        "npm-run-all": "^4.1.5",
         "nyc": "^14.1.1",
         "open-cli": "^5.0.0",
         "popper.js": "1.15.0",


### PR DESCRIPTION
- [TAO-10417](https://oat-sa.atlassian.net/browse/TAO-10417) fix: cast CSS maps into `string` before writing them
- [TAO-10417](https://oat-sa.atlassian.net/browse/TAO-10417) chore(version): bump a fix one
- [TAO-10417](https://oat-sa.atlassian.net/browse/TAO-10417) chore: remove `npm-run-all` dependency and use `&&` to chain `prepare` tasks

`npm run build:scss` shouldn't produce any warnings and write CSS maps now.