### PR TITLE
add announce for current item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -162,14 +162,17 @@ export default pluginFactory({
                     isReviewPanelEnabled: !isReviewPanelHidden(testRunner) && isReviewPanelEnabled(testRunner),
                     questionStatus: getItemStatus(currentItem)
                 };
-                const $announce = $("h2#test-title-header").first();
+                const announcedText = __('%s loaded', currentItem.label);
+                let $announce = $('[aria-live=polite][role=alert]').first();
+
+                if ($announce.length !== 1) {
+                    const $announcedItem = $('h2#test-title-header').first();
+                    $announce = $('<div aria-live="polite" role="alert" class="visible-hidden"></div>');
+                    $announcedItem.append($announce);
+                }
+                $announce.text(announcedText);
 
                 this.jumplinks.trigger('update', updatedConfig);
-
-                $announce.attr({
-                    'role': 'alert',
-                    'aria-live': 'assertive'
-                });
             })
             .on('tool-flagitem', () => {
                 const currentItem = testRunner.getCurrentItem();

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -162,8 +162,14 @@ export default pluginFactory({
                     isReviewPanelEnabled: !isReviewPanelHidden(testRunner) && isReviewPanelEnabled(testRunner),
                     questionStatus: getItemStatus(currentItem)
                 };
+                const $announce = $("h2#test-title-header").first();
 
                 this.jumplinks.trigger('update', updatedConfig);
+
+                $announce.attr({
+                    'role': 'alert',
+                    'aria-live': 'assertive'
+                });
             })
             .on('tool-flagitem', () => {
                 const currentItem = testRunner.getCurrentItem();

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -232,9 +232,6 @@ export default pluginFactory({
             .on('loaditem', () => {
                 updateElement(this.$element, isLastItem());
             })
-            .on('renderitem', () => {
-                $("h2#test-title-header").attr('tabindex', -1).attr('role', 'alert').focus();
-            })
             .on('enablenav', function() {
                 self.enable();
             })

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -106,7 +106,7 @@ export default pluginFactory({
         const pluginShortcuts = (testRunnerOptions.shortcuts || {})[this.getName()] || {};
 
         /**
-         * Check if the currrent item is the last item
+         * Check if the current item is the last item
          * @returns {Boolean} true if the last
          */
         function isLastItem(){
@@ -231,6 +231,9 @@ export default pluginFactory({
         testRunner
             .on('loaditem', () => {
                 updateElement(this.$element, isLastItem());
+            })
+            .on('renderitem', () => {
+                $("h2#test-title-header").attr('tabindex', -1).attr('role', 'alert').focus();
             })
             .on('enablenav', function() {
                 self.enable();


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-733
 
Add announcement for current item after navigate via `next` button
  
#### How to test
 
- prepare an instance of TAO 
- run the assesment with enabled screen reader
- listen the item annoncement after load new item

#### related PR

- https://github.com/oat-sa/extension-tao-testqti/pull/1879