### PR TITLE
Fix/tca 700/ods section time remaining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/duration/duration.js
+++ b/src/plugins/controls/duration/duration.js
@@ -122,7 +122,11 @@ export default pluginFactory({
                 .on('tick', (elapsed) => {
                     updateDuration(elapsed);
                 })
-                .before('move skip exit timeout pause', () => currentUpdatePromise
+                .after('move skip timeout', () => currentUpdatePromise
+                    .then(addDurationToCallActionParams)
+                    .catch(addDurationToCallActionParams)
+                )
+                .before('pause exit', () => currentUpdatePromise
                     .then(addDurationToCallActionParams)
                     .catch(addDurationToCallActionParams)
                 )


### PR DESCRIPTION
Fix incorrect itemDuration on timeout
 
Related to : https://oat-sa.atlassian.net/browse/TCA-700

Amount of seconds was added to request parameters before item duration update with the last stopwatch tick.
 
#### Steps to reproduce (from ticket description)
 - Start a test as TT, Guest or via LTI
 - Pass all items in the first section (don’t move to the next section) pass all items and wait until time is over 
 - Log in as Admin open Results in main menu
 - Select passed Delivery
 - Click Transmission Monitoring button at top. Click View button for last test result
 - Click Export ODS button at left, download .json file.
 - Open the file in browser/other editor and check `time_remaining` value
  
#### How to test
 - Start a test as TT, Guest or via LTI, stay on the first item
 - Open brower developer tools, the network tab
 - Wait for the timeout event
 - Verify that `itemDuration` in the timeout request has same or greater amount of seconds as the section time limit
