### PR TITLE
[TCA-737] Screen Reader : Answer options announced multiple times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-737
  
add `aria-labelledby` attribute to choice interaction once it receives focus 
 
#### How to test:

- prepare an instance of TAO with taoAct extension
- prepare a delivery with choice interaction and accessibility mode enabled
- execute delivery as a test taker
- focus choice interaction option with key navigation
- make sure that `aria-labelledby` attribute added to it
 
#### Dependencies

Companion PR :
 - [ ] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/92
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1500
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1883