### PR TITLE
Release 2.13.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.3",
+    "version": "2.13.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation/strategies/stimulusNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/stimulusNavigation.js
@@ -17,6 +17,7 @@
  */
 
 import $ from 'jquery';
+import __ from 'i18n';
 import keyNavigator from 'ui/keyNavigation/navigator';
 import navigableDomElement from 'ui/keyNavigation/navigableDomElement';
 import {
@@ -72,6 +73,9 @@ export default {
                 const $element = $(el);
                 const elements = navigableDomElement.createFromDoms($element)
                     .map(isEnabledDecorator);
+
+                // assign aria attributes
+                $element.attr('aria-label', __('Passage'));
 
                 const navigator = keyNavigator({
                     id: `${groupId}-${i}`,

--- a/src/provider/layout.tpl
+++ b/src/provider/layout.tpl
@@ -9,7 +9,7 @@
             <h2 id="test-sidebar-left-header" class="landmark-title--hidden">{{__ 'Test status and review structure'}}</h2>
         </aside>
 
-        <section class="content-wrapper">
+        <section class="content-wrapper" aria-labelledby="test-title-header">
             <h2 id="test-title-header" class="landmark-title-hidden"></h2>
             <div id="qti-content"></div>
         </section>


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-731
 
- add `aria-label` attribute to passages
- add `aria-labelledby` attribute to test item section
  
#### How to test
 
- prepare an instance of TAO with taoAct extension
- prepare a delivery with passage and accessibility mode enabled
- execute delivery as a test taker
- check that test item section has `aria-labelledby` attribute
- check that passage has `aria-label` attribute
 
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1882