### PR TITLE
Release 2.13.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.4",
+    "version": "2.13.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.13.4",
+    "version": "2.13.5",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",


### PR DESCRIPTION
Version 2.13.6

**Release notes :**
- [feature] [TCA-700](https://oat-sa.atlassian.net/browse/TCA-700)

Amount of seconds was added to request parameters before item duration update with the last stopwatch tick.

https://github.com/oat-sa/tao-test-runner-qti-fe/pull/289