### PR TITLE
Fix/BSA-209/move header message from unanswered stat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.14.0",
+    "version": "2.14.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -57,6 +57,8 @@ function getHeader(scope) {
     } else if (scope === 'part') {
         return `<b>${__('You are about to submit this test part.')}</b><br><br>`;
     }
+
+    return '';
 }
 /**
  * Build message if not all items have answers

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -45,8 +45,6 @@ function getExitMessage(scope, runner, message = '', sync) {
 /**
  * Build message if not all items have answers
  * @param {String} scope - scope to consider for calculating the stats
- * @param {Object} runner - testRunner instance
- * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox. Default false
  * @returns {String} Returns the message text
  */
 function getHeader(scope) {

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2020 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
@@ -40,9 +40,24 @@ function getExitMessage(scope, runner, message = '', sync) {
         itemsCountMessage = getUnansweredItemsWarning(scope, runner, sync);
     }
 
-    return `${itemsCountMessage} ${message}`.trim();
+    return `${getHeader(scope)}${itemsCountMessage} ${message}`.trim();
 }
-
+/**
+ * Build message if not all items have answers
+ * @param {String} scope - scope to consider for calculating the stats
+ * @param {Object} runner - testRunner instance
+ * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox. Default false
+ * @returns {String} Returns the message text
+ */
+function getHeader(scope) {
+    if (scope === 'section' || scope === 'testSection') {
+        return `<b>${__('You are about to leave this section.')}</b><br><br>`;
+    } else if (scope === 'test' || scope === 'testWithoutInaccessibleItems') {
+        return `<b>${__('You are about to submit the test.')}</b><br><br>`;
+    } else if (scope === 'part') {
+        return `<b>${__('You are about to submit this test part.')}</b><br><br>`;
+    }
+}
 /**
  * Build message if not all items have answers
  * @param {String} scope - scope to consider for calculating the stats
@@ -51,14 +66,13 @@ function getExitMessage(scope, runner, message = '', sync) {
  * @returns {String} Returns the message text
  */
 function getUnansweredItemsWarning(scope, runner, sync) {
-    var stats = statsHelper.getInstantStats(scope, runner, sync);
-    var unansweredCount = stats && stats.questions - stats.answered;
-    var flaggedCount = stats && stats.flagged;
-    var itemsCountMessage = '';
+    const stats = statsHelper.getInstantStats(scope, runner, sync);
+    const unansweredCount = stats && stats.questions - stats.answered;
+    const flaggedCount = stats && stats.flagged;
+    let itemsCountMessage = '';
 
     if (scope === 'section' || scope === 'testSection') {
-        itemsCountMessage = `<b>${__('You are about to leave this section.')}</b><br><br>`
-        itemsCountMessage += __(
+        itemsCountMessage = __(
             'You answered %s of %s question(s) for this section of the test',
             stats.answered.toString(),
             stats.questions.toString()
@@ -67,11 +81,10 @@ function getUnansweredItemsWarning(scope, runner, sync) {
             itemsCountMessage += `, ${__('and flagged %s of them', flaggedCount.toString())}`;
         }
     } else if (scope === 'test' || scope === 'testWithoutInaccessibleItems') {
-        itemsCountMessage = `<b>${__('You are about to submit the test.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions', unansweredCount.toString());
+            itemsCountMessage = __('There are %s unanswered questions', unansweredCount.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question', unansweredCount.toString());
+            itemsCountMessage = __('There is %s unanswered question', unansweredCount.toString());
         }
         if (unansweredCount && flaggedCount) {
             itemsCountMessage += ` ${__(
@@ -80,11 +93,10 @@ function getUnansweredItemsWarning(scope, runner, sync) {
             )}`;
         }
     } else if (scope === 'part') {
-        itemsCountMessage = `<b>${__('You are about to submit this test part.')}</b><br><br>`
         if (unansweredCount > 1) {
-            itemsCountMessage += __('There are %s unanswered questions in this part of the test', unansweredCount.toString());
+            itemsCountMessage = __('There are %s unanswered questions in this part of the test', unansweredCount.toString());
         } else if (unansweredCount === 1) {
-            itemsCountMessage += __('There is %s unanswered question in this part of the test', unansweredCount.toString());
+            itemsCountMessage = __('There is %s unanswered question in this part of the test', unansweredCount.toString());
         }
         if (unansweredCount && flaggedCount) {
             itemsCountMessage += ` ${__(

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -240,6 +240,9 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
             };
             var runner = runnerMock(map, context, data, responses, declarations);
             var message = '';
+            var messageEntTestNoStat = '<b>You are about to submit the test.</b><br><br>';
+            var messageEntTestPartNoStat = '<b>You are about to submit this test part.</b><br><br>';
+            var messageEntSectionNoStat = '<b>You are about to leave this section.</b><br><br>';
 
             assert.expect(7);
 
@@ -268,17 +271,17 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
 
             assert.equal(
                 messagesHelper.getExitMessage('test', runner),
-                message,
+                messageEntTestNoStat,
                 'no stats in test scope when option is disabled'
             );
             assert.equal(
                 messagesHelper.getExitMessage('part', runner),
-                message,
+                messageEntTestPartNoStat,
                 'no stats in part scope when option is disabled'
             );
             assert.equal(
                 messagesHelper.getExitMessage('section', runner),
-                message,
+                messageEntSectionNoStat,
                 'no stats in session scope when option is disabled'
             );
         });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/BSA-209
https://oat-sa.atlassian.net/browse/BSA-199

Moved header message outside unanswered statistic message.

How to test:

- set `'test-taker-unanswered-items-message' => false,` in `config/taoQtiTest/testRunner.conf.php`
- create a test with an item and set navigation warnings `Display Next Part Warning` or `Display End Test Warning`
- create delivery
- run delivery, don't answer item
- click Next
- check a popup, should not be a message about unanswered items