### PR TITLE
Feature TAO-10467 - Better highlight of a current delivery item label in review mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_navigator.scss
+++ b/scss/inc/_navigator.scss
@@ -424,6 +424,7 @@ $borderColor: $textHighlight;
         background: white();
         &.active {
             background: $info;
+            color: $textHighlight;
         }
         &:hover {
             background: lighten($lightBlueGrey, 3);

--- a/scss/inc/_navigator.scss
+++ b/scss/inc/_navigator.scss
@@ -422,8 +422,12 @@ $borderColor: $textHighlight;
     }
     .qti-navigator-item {
         background: white();
-        &.active, &:hover {
+        &.active {
             background: $info;
+            color: $textHighlight;
+        }
+        &:hover {
+            background: darken($info, 10);
             color: $textHighlight;
         }
         &.disabled {

--- a/scss/inc/_navigator.scss
+++ b/scss/inc/_navigator.scss
@@ -423,7 +423,7 @@ $borderColor: $textHighlight;
     .qti-navigator-item {
         background: white();
         &.active {
-            background: lighten($lightBlueGrey, 5);
+            background: $info;
         }
         &:hover {
             background: lighten($lightBlueGrey, 3);

--- a/scss/inc/_navigator.scss
+++ b/scss/inc/_navigator.scss
@@ -422,12 +422,9 @@ $borderColor: $textHighlight;
     }
     .qti-navigator-item {
         background: white();
-        &.active {
+        &.active, &:hover {
             background: $info;
             color: $textHighlight;
-        }
-        &:hover {
-            background: lighten($lightBlueGrey, 3);
         }
         &.disabled {
             background-color: mix($textHighlight, $grey, 65%) !important;


### PR DESCRIPTION
**Related to this issue**

It's related to this issue but for product we will implement variable `$info` that is some blue color

https://oat-sa.atlassian.net/browse/TAO-10467

**Description**

**As** test taker
**I would like** when browsing the review screen/navigator to have a more distinct color on the current Item
**so that** that I can identify instantly in which item I am on in respect to the whole section/test part.

**Context**

Ability to mark the color of the page on which you are in the preview on the left side of the page a little more so that it is quicker for candidates to identify it? For example, by displaying it in blue? In this way, the candidate can identify at a glance which page he or she is on in the preview. (Because at the moment there is only a very slight difference in color between the pages viewed and the page on which the candidate is on).

**Acceptance criteria**

- AC1

**GIVEN** test taker is during delivery execution which has enabled the review screen/navigator
**WHEN** test taker browses on review screen/navigator
**THEN** the current item on the review panel menu **MUST** be colorized

**Expected result**

![imagen](https://user-images.githubusercontent.com/34692207/90366838-1b738e80-e068-11ea-9163-813bb99b3f20.png)

