### PR TITLE
fix focus for tools menus after activate submenu item via keyboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/ui/toolbox/menu.js
+++ b/src/ui/toolbox/menu.js
@@ -27,7 +27,7 @@
  *      icon: 'icon',
  *      text: __('Displayed label')
  * });
- * Optional setting: navType - navigation type 
+ * Optional setting: navType - navigation type
  * navType: 'fromLast' (default behavior) - focus on button (if no active item) and then using UP go to last item, when press DOWN at last item (or UP at the first) menu will be closed,
  * navType: 'fromFirst' - focus on button (if no active item) and then using DOWN go to first item. When press the DOWN key at the first item (or UP at the first) menu will be closed
  * toolbox.createMenu({
@@ -149,7 +149,7 @@ var menuComponentApi = {
      * Changes hoverIndex and hover item.
      *
      * @param {Number} index - item index to hover.
-     * 
+     *
      * @returns the menu item.
      */
     hoverByIndex(index) {
@@ -471,9 +471,7 @@ var menuComponentApi = {
             this.closeMenu();
 
             // give back the focus
-            if (document.activeElement) {
-                document.activeElement.blur();
-            }
+            this.$component.focus();
         }
     },
 


### PR DESCRIPTION
Related to : 
- https://oat-sa.atlassian.net/browse/TCA-735
 
tools menus lose focus when submenu item activated via keyboard
  
#### How to test

- execute delivery as a test taker
- try to switch contrast heme using keyboard
- check focus is on menu item
 
#### Dependencies
 
https://github.com/oat-sa/extension-tao-testqti/pull/1899