### PR TITLE
fix undefined navigator obj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -35,10 +35,13 @@ const addLabelledByAttribute = cursor => {
     const value = $element.attr('value');
     const name = $element.attr('name');
 
-    $element.attr(
-        'aria-labelledby',
-        `${name.replace('response-', 'choice-')}-${value}`
-    );
+    if (name) {
+        $element.attr(
+            'aria-labelledby',
+            `${name.replace('response-', 'choice-')}-${value}`
+        );
+    }
+    
 };
 
 /**

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -52,6 +52,18 @@ const removeLabelledByAttribute = cursor => {
 };
 
 /**
+ * Adds attributes on navigation focus and blur
+ * 
+ * @param {Navigator} navigator 
+ */
+const manageLabelledByAttribute = (navigator) => {
+    if (navigator) {
+        navigator.on('focus', addLabelledByAttribute);
+        navigator.on('blur', removeLabelledByAttribute); // applies WCAG behavior for the radio buttons
+    }
+}
+
+/**
  * Key navigator strategy applying inside the item.
  * Navigable item content are interaction choices and body element with the special class "key-navigation-focusable".
  * @type {Object} keyNavigationStrategy
@@ -165,9 +177,7 @@ export default {
                         $inputs.each((i, input) => {
                             const navigator = addInputsNavigator($(input), $itemElement);
 
-                            navigator.on('focus', addLabelledByAttribute);
-
-                            navigator.on('blur', removeLabelledByAttribute);
+                            manageLabelledByAttribute(navigator);
                         });
                     } else {
                         const navigator = addInputsNavigator($inputs, $itemElement, true, () => {
@@ -184,9 +194,7 @@ export default {
                             return position;
                         });
 
-                        navigator.on('focus', addLabelledByAttribute);
-
-                        navigator.on('blur', removeLabelledByAttribute);
+                        manageLabelledByAttribute(navigator);
 
                         // applies WCAG behavior for the radio buttons
                         if (navigator && config.wcagBehavior) {


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TAO-10465

### What has changed?

- Event delegation on navigator obj is wrapped in a condition

### How to test?

- Create a test with graphic interaction
- Start the test and navigate between items
- There should not be any error in the console

### Related PRs

This PR(https://github.com/oat-sa/extension-tao-testqti/pull/1902) needs to be updated and merged after the current PR is merged and a new version of `test runner qti fe` is released