### PR TITLE
Fix/tca 741/alt shift t shortcut target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.2",
+    "version": "2.16.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.2",
+    "version": "2.16.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -89,7 +89,7 @@ export default pluginFactory({
             pluginShortcuts.goToTop && shortcut.add(
                 namespaceHelper.namespaceAll(pluginShortcuts.goToTop, this.getName(), true),
                 function() {
-                    $('body').attr('tabindex', '-1').focus();
+                    $('[tabindex]').first().focus();
                 },
                 {
                     avoidInput: true,


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-741
  
change behavior of Alt-Shift-T keyboard shortcut to `focus on first interactive element`
 
#### How to test:

- prepare a delivery accessibility mode enabled
- use Alt-Shift-T shortcut
- ensure focus changed to first interactive element (jumplink) and screen reader announces it
 
#### Dependencies

https://github.com/oat-sa/extension-tao-testqti/pull/1905