### PR TITLE
next button announcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.3",
+    "version": "2.16.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.3",
+    "version": "2.16.4",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -166,9 +166,8 @@ export default pluginFactory({
                 let $announce = $('[aria-live=polite][role=alert]').first();
 
                 if ($announce.length !== 1) {
-                    const $announcedItem = $('h2#test-title-header').first();
                     $announce = $('<div aria-live="polite" role="alert" class="visible-hidden"></div>');
-                    $announcedItem.append($announce);
+                    $('main').first().append($announce);
                 }
                 $announce.text(announcedText);
 

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -40,13 +40,13 @@ import buttonTpl from 'taoQtiTest/runner/plugins/templates/button';
 var buttonData = {
     next: {
         control: 'move-forward',
-        title: 'Submit and go to the item %s',
+        title: __('Submit and go to the item %s'),
         icon: 'forward',
         text: __('Next')
     },
     end: {
         control: 'move-end',
-        title: 'Submit and go to the end of the test',
+        title: __('Submit and go to the end of the test'),
         icon: 'fast-forward',
         text: __('End test')
     }

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -40,13 +40,13 @@ import buttonTpl from 'taoQtiTest/runner/plugins/templates/button';
 var buttonData = {
     next: {
         control: 'move-forward',
-        title: __('Submit and go to the next item'),
+        title: 'Submit and go to the item %s',
         icon: 'forward',
         text: __('Next')
     },
     end: {
         control: 'move-end',
-        title: __('Submit and go to the end of the test'),
+        title: 'Submit and go to the end of the test',
         icon: 'fast-forward',
         text: __('End test')
     }
@@ -65,14 +65,19 @@ var createElement = function createElement(isLast = false) {
 /**
  * Update the button based on the context
  * @param {jQueryElement} $element - the element to update
+ * @param {TestRunner} [testRunner] - the test runner instance
  * @param {Boolean} [isLast=false] - is the current item the last
  */
-const updateElement = function updateElement($element, isLast = false) {
+const updateElement = function updateElement($element, testRunner, isLast = false) {
     const dataType = isLast ? 'end' : 'next';
+    const testContext = testRunner.getTestContext();
+    const nextItemPosition = testContext.itemPosition + 1;
+    if (dataType === 'next') {
+        $element.attr('title', __(buttonData[dataType].title, nextItemPosition));
+    }
     if ($element.attr('data-control') !== buttonData[dataType].control) {
         $element
             .attr('data-control', buttonData[dataType].control)
-            .attr('title', buttonData[dataType].title)
             .find('.text')
             .text(buttonData[dataType].text);
 
@@ -254,7 +259,7 @@ export default pluginFactory({
         //change plugin state
         testRunner
             .on('loaditem', () => {
-                updateElement(this.$element, isLastItem());
+                updateElement(this.$element, testRunner, isLastItem());
             })
             .on('enablenav', function() {
                 self.enable();

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -72,9 +72,7 @@ const updateElement = function updateElement($element, testRunner, isLast = fals
     const dataType = isLast ? 'end' : 'next';
     const testContext = testRunner.getTestContext();
     const nextItemPosition = testContext.itemPosition + 1;
-    if (dataType === 'next') {
-        $element.attr('title', __(buttonData[dataType].title, nextItemPosition));
-    }
+    $element.attr('title', __(buttonData[dataType].title, nextItemPosition));
     if ($element.attr('data-control') !== buttonData[dataType].control) {
         $element
             .attr('data-control', buttonData[dataType].control)


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-733
 
- enhance `next` button announcement
- move announcement container to <main>
  
#### How to test

- prepare an instance of TAO
- execute delivery as a test taker
- check that next button announcement contains item number


