### PR TITLE
[UNO-145] CUDIR-135: Preview - Contrast choice showing and disappears 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.5",
+    "version": "2.16.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.5",
+    "version": "2.16.6",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -153,6 +153,11 @@ export default pluginFactory({
                 icon: 'contrast',
                 text: __('Contrast')
             })
+            .after('render', () => {
+                if (!isPluginAllowed()) {
+                    self.hide();
+                }
+            })
             .on('click', function(e) {
                 e.preventDefault();
                 testRunner.trigger('tool-themeswitcher-toggle');
@@ -244,7 +249,7 @@ export default pluginFactory({
             })
             .on('tool-themeswitcher-setnavtype', function(type) {
                 self.menuButton.setNavigationType(type);
-            })
+            });
 
         return testRunner.getPluginStore(this.getName()).then(function(itemThemesStore) {
             self.storage = itemThemesStore;


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/UNO-145
 
Hide menu button of item theme switcher after render
  
#### How to test
  
- open preview of some test item
- check that contrast button does not appear

#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1923