### PR TITLE
version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.6",
+    "version": "2.16.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.7",
+    "version": "2.16.8",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/jumplinks/plugin.js
+++ b/src/plugins/content/accessibility/jumplinks/plugin.js
@@ -162,7 +162,7 @@ export default pluginFactory({
                     isReviewPanelEnabled: !isReviewPanelHidden(testRunner) && isReviewPanelEnabled(testRunner),
                     questionStatus: getItemStatus(currentItem)
                 };
-                const announcedText = __('%s loaded', currentItem.label);
+                const announcedText = __('Item %s loaded', currentItem.position);
                 let $announce = $('[aria-live=polite][role=alert]').first();
 
                 if ($announce.length !== 1) {


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TCA-733
 
Use item index instead of item label to announce next item
  
#### How to test

- create delivery with two sections
- navigate to second section using hotkeys
- set focus to `next` button
- ensure correct item index announced

#### Related PR's
https://github.com/oat-sa/extension-tao-testqti/pull/1927