### PR TITLE
Fix/con 53/items title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.8",
+    "version": "2.16.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.16.8",
+    "version": "2.16.9",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",
@@ -54,7 +54,7 @@
         "@oat-sa/tao-item-runner": "^0.3.1",
         "@oat-sa/tao-item-runner-qti": "^0.3.2",
         "@oat-sa/tao-qunit-testrunner": "^0.1.3",
-        "@oat-sa/tao-test-runner": "^0.5.0",
+        "@oat-sa/tao-test-runner": "^0.5.1",
         "async": "0.2.10",
         "autoprefixer": "^9.6.1",
         "decimal.js": "10.1.1",

--- a/src/plugins/controls/title/title.js
+++ b/src/plugins/controls/title/title.js
@@ -50,10 +50,12 @@ export default pluginFactory({
             );
 
             // update test title
-            this.titles.test.$title.text(testMap.title).show();
+            if (testMap.title) {
+                this.titles.test.$title.text(testMap.title).show();
+            }
 
             // update part title
-            if (currentPart) {
+            if (currentPart && currentPart.label) {
                 this.titles.testPart.$title
                     .text(` - ${currentPart.label}`)
                     .show();
@@ -75,9 +77,11 @@ export default pluginFactory({
             }
 
             // update item title
-            this.titles.item.$title
-                .text(` - ${currentItem.label}`)
-                .show();
+            if (currentItem.label) {
+                this.titles.item.$title
+                    .text(` - ${currentItem.label}`)
+                    .show();
+            }
         };
 
         testRunner


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/CON-53

We have some cases when a title for an item should be empty. Because of that, we don't need to generate the title for a current item for example.