### PR TITLE
Fix/ms 596/prevent applying navigation plugin styles on focused select2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.2",
+    "version": "2.17.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.2",
+    "version": "2.17.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/content/accessibility/scss/key-navigation.scss
+++ b/src/plugins/content/accessibility/scss/key-navigation.scss
@@ -2,7 +2,7 @@
 
 .test-runner-scope {
     .content-wrapper {
-        p.key-navigation-group, div.key-navigation-group {
+        p.key-navigation-group, div.key-navigation-group:not(.select2-container) {
             padding: 5px !important;
         }
         .key-navigation-group:not(.qti-extendedTextInteraction):not(.qti-textEntryInteraction) {


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/MS-596
- https://github.com/oat-sa/extension-tao-testqti/pull/1935

**Description:** Remove padding from focused select2.
For more details please check https://github.com/oat-sa/extension-tao-testqti/pull/1935

**Unit tests cli:** `npm run test`