### PR TITLE
Fix/TR-81/Item duration shifted to the next item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/test/plugins/controls/duration/test.js
+++ b/test/plugins/controls/duration/test.js
@@ -179,9 +179,9 @@ define([
                     runner.trigger('tick', 10000);
                     setTimeout(
                         () => {
-                            runner.trigger('plugin-get.duration', {}, itemAttemptId, getDuration);
+                            runner.trigger('plugin-get.duration', itemAttemptId, getDuration);
                         },
-                        1000
+                        100
                     );
                 });
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-81

The `duration` plugin was shifting the item duration to the next item as it was adding it after the action have been processed.

This was introduced by https://github.com/oat-sa/tao-test-runner-qti-fe/pull/289.

The plugin has also been reworked to simplify it and prevent possible concurrency issues.

Prerequisite:
- update the dependency from taoQtiTest to this branch (or use the [companion PR](https://github.com/oat-sa/extension-tao-testqti/pull/1936))

Steps to reproduce:
- take a test with several items
- open the network panel before navigating
- observe the move actions:
    - the first one won't have any itemDuration
    - the following ones will receive the duration of the previous item
- on the backoffice, open the results page and see the first item is getting a 0 duration

How to test:
- `npm run test`
-  the issue should not be reproduced when taking a test