### PR TITLE
Feature/TR-121/Add a plugin to pause on error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.5",
+    "version": "2.18.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.17.5",
+    "version": "2.18.0",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -1,0 +1,65 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+import __ from 'i18n';
+import pluginFactory from 'taoTests/runner/plugin';
+import dialogTpl from 'taoQtiTest/runner/plugins/controls/connectivity/pauseOnError.tpl';
+
+const name = 'pauseOnError';
+const dialogMessage = {
+    title: __('Something unexpected happened.'),
+    message: __('Please try reloading the page or pause the test. If you pause, you will be able to resume the test from this page.')
+};
+const dialogConfig = {
+    buttons: {
+        labels: {
+            ok: __('Pause the test'),
+            cancel: __('Reload the page')
+        }
+    }
+};
+const pauseMessage = __('You encountered an unexpected issue. The test has been suspended.');
+const pauseContext = {
+    reasons: {
+        category: 'technical',
+        subCategory: 'error'
+    },
+    message: pauseMessage,
+    originalMessage: 'Due to an unexpected issue the test has been suspended.'
+};
+
+export default pluginFactory({
+    name,
+
+    /**
+     * Initialize the plugin (called during runner's init)
+     */
+    init() {
+        const testRunner = this.getTestRunner();
+        const returnToHome = () => testRunner.trigger('pause', pauseContext);
+        const reloadPage = () => testRunner.trigger('reloadpage');
+        const processError = () => {
+            testRunner
+                .on('reloadpage', () => window.location.reload())
+                .trigger('disablenav disabletools hidenav')
+                .trigger(`confirm.${name}`, dialogTpl(dialogMessage), returnToHome, reloadPage, dialogConfig);
+        };
+
+        testRunner.on('error', processError);
+    }
+});

--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -33,13 +33,11 @@ const dialogConfig = {
         }
     }
 };
-const pauseMessage = __('You encountered an unexpected issue. The test has been suspended.');
 const pauseContext = {
     reasons: {
         category: 'technical',
         subCategory: 'error'
     },
-    message: pauseMessage,
     originalMessage: 'Due to an unexpected issue the test has been suspended.'
 };
 

--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -26,6 +26,7 @@ const dialogMessage = {
     message: __('Please try reloading the page or pause the test. If you pause, you will be able to resume the test from this page.')
 };
 const dialogConfig = {
+    focus: 'cancel',
     buttons: {
         labels: {
             ok: __('Pause the test'),

--- a/src/plugins/controls/connectivity/pauseOnError.tpl
+++ b/src/plugins/controls/connectivity/pauseOnError.tpl
@@ -1,0 +1,2 @@
+<b>{{title}}</b><br><br>
+{{message}}

--- a/test/plugins/controls/connectivity/pauseOnError/test.html
+++ b/test/plugins/controls/connectivity/pauseOnError/test.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner Plugin - pauseOnError</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    require(['taoQtiTest/test/runner/plugins/controls/connectivity/pauseOnError/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/plugins/controls/connectivity/pauseOnError/test.js
+++ b/test/plugins/controls/connectivity/pauseOnError/test.js
@@ -1,0 +1,173 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+define([
+    'lodash',
+    'taoTests/runner/runner',
+    'taoQtiTest/runner/plugins/controls/connectivity/pauseOnError'
+], function (_, runnerFactory, pluginFactory) {
+    'use strict';
+
+    const providerName = 'mock';
+    const getRunner = () => runnerFactory(providerName, [pluginFactory]);
+    runnerFactory.registerProvider(providerName, {
+        name: providerName,
+        loadAreaBroker() {
+        },
+        loadProxy() {
+        },
+        init() {
+        }
+    });
+
+    QUnit.module('pauseOnError plugin');
+
+    QUnit.test('module', assert => {
+        const runner = getRunner();
+
+        assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(
+            pluginFactory(runner),
+            pluginFactory(runner),
+            'The plugin factory provides a different instance on each call'
+        );
+    });
+
+    QUnit.cases
+        .init([
+            { title: 'init' },
+            { title: 'render' },
+            { title: 'finish' },
+            { title: 'destroy' },
+            { title: 'trigger' },
+            { title: 'getTestRunner' },
+            { title: 'getAreaBroker' },
+            { title: 'getConfig' },
+            { title: 'setConfig' },
+            { title: 'getState' },
+            { title: 'setState' },
+            { title: 'show' },
+            { title: 'hide' },
+            { title: 'enable' },
+            { title: 'disable' }
+        ])
+        .test('plugin API ', (data, assert) => {
+            const runner = getRunner();
+            const plugin = pluginFactory(runner);
+            assert.equal(
+                typeof plugin[data.title],
+                'function',
+                `The pluginFactory instance exposes a "${data.title}" function`
+            );
+        });
+
+    QUnit.test('error then reload', assert => {
+        const done = assert.async();
+        const runner = getRunner();
+        Promise.resolve()
+            .then(() => new Promise((resolve, reject) => {
+                const timeout = window.setTimeout(() => {
+                    reject(new Error('The plugin did not catch the error or did not complete properly!'));
+                }, 200);
+                runner
+                    .on('init', () => {
+                        assert.ok(true, 'Runner has been initialized');
+                        runner.trigger('error');
+                    })
+                    .on('confirm.*', (message, accept, cancel, options) => {
+                        assert.equal(typeof message, 'string', 'String message provided');
+                        assert.equal(typeof accept, 'function', 'Accept callback provided');
+                        assert.equal(typeof cancel, 'function', 'Cancel callback provided');
+                        assert.equal(typeof options, 'object', 'Options provided');
+                        cancel();
+                    })
+                    .before('pause', () => {
+                        assert.ok(false, 'The pause should not be triggered!');
+                        runner.destroy();
+                        return Promise.reject();
+                    })
+                    .before('reloadpage', () => {
+                        assert.ok(true, 'A page reload has been triggered');
+                        runner.destroy();
+                        return Promise.reject();
+                    })
+                    .on('destroy', () => {
+                        window.clearTimeout(timeout);
+                        resolve();
+                    })
+                    .init();
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(done);
+
+
+    });
+
+    QUnit.test('error then pause', assert => {
+        const done = assert.async();
+        const runner = getRunner();
+        Promise.resolve()
+            .then(() => new Promise((resolve, reject) => {
+                const timeout = window.setTimeout(() => {
+                    reject(new Error('The plugin did not catch the error or did not complete properly!'));
+                }, 200);
+                runner
+                    .on('init', () => {
+                        assert.ok(true, 'Runner has been initialized');
+                        runner.trigger('error');
+                    })
+                    .on('confirm.*', (message, accept, cancel, options) => {
+                        assert.equal(typeof message, 'string', 'String message provided');
+                        assert.equal(typeof accept, 'function', 'Accept callback provided');
+                        assert.equal(typeof cancel, 'function', 'Cancel callback provided');
+                        assert.equal(typeof options, 'object', 'Options provided');
+                        accept();
+                    })
+                    .before('pause', context => {
+                        assert.ok(true, 'The pause has been triggered');
+                        assert.equal(typeof context, 'object', 'A context is provided');
+                        runner.destroy();
+                        return Promise.reject();
+                    })
+                    .before('reloadpage', () => {
+                        assert.ok(false, 'A page reload should not be triggered!');
+                        runner.destroy();
+                        return Promise.reject();
+                    })
+                    .on('destroy', () => {
+                        window.clearTimeout(timeout);
+                        resolve();
+                    })
+                    .init();
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(done);
+
+
+    });
+});

--- a/test/plugins/controls/connectivity/pauseOnError/test.js
+++ b/test/plugins/controls/connectivity/pauseOnError/test.js
@@ -79,95 +79,62 @@ define([
     QUnit.test('error then reload', assert => {
         const done = assert.async();
         const runner = getRunner();
-        Promise.resolve()
-            .then(() => new Promise((resolve, reject) => {
-                const timeout = window.setTimeout(() => {
-                    reject(new Error('The plugin did not catch the error or did not complete properly!'));
-                }, 200);
-                runner
-                    .on('init', () => {
-                        assert.ok(true, 'Runner has been initialized');
-                        runner.trigger('error');
-                    })
-                    .on('confirm.*', (message, accept, cancel, options) => {
-                        assert.equal(typeof message, 'string', 'String message provided');
-                        assert.equal(typeof accept, 'function', 'Accept callback provided');
-                        assert.equal(typeof cancel, 'function', 'Cancel callback provided');
-                        assert.equal(typeof options, 'object', 'Options provided');
-                        cancel();
-                    })
-                    .before('pause', () => {
-                        assert.ok(false, 'The pause should not be triggered!');
-                        runner.destroy();
-                        return Promise.reject();
-                    })
-                    .before('reloadpage', () => {
-                        assert.ok(true, 'A page reload has been triggered');
-                        runner.destroy();
-                        return Promise.reject();
-                    })
-                    .on('destroy', () => {
-                        window.clearTimeout(timeout);
-                        resolve();
-                    })
-                    .init();
-            }))
-            .catch(err => {
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
+
+        assert.expect(6);
+        runner
+            .on('init', () => {
+                assert.ok(true, 'Runner has been initialized');
+                runner.trigger('error');
             })
-            .then(done);
-
-
+            .on('confirm.*', (message, accept, cancel, options) => {
+                assert.equal(typeof message, 'string', 'String message provided');
+                assert.equal(typeof accept, 'function', 'Accept callback provided');
+                assert.equal(typeof cancel, 'function', 'Cancel callback provided');
+                assert.equal(typeof options, 'object', 'Options provided');
+                cancel();
+            })
+            .before('pause', () => {
+                assert.ok(false, 'The pause should not be triggered!');
+                runner.destroy();
+                return Promise.reject();
+            })
+            .before('reloadpage', () => {
+                assert.ok(true, 'A page reload has been triggered');
+                runner.destroy();
+                return Promise.reject();
+            })
+            .on('destroy', done)
+            .init();
     });
 
     QUnit.test('error then pause', assert => {
         const done = assert.async();
         const runner = getRunner();
-        Promise.resolve()
-            .then(() => new Promise((resolve, reject) => {
-                const timeout = window.setTimeout(() => {
-                    reject(new Error('The plugin did not catch the error or did not complete properly!'));
-                }, 200);
-                runner
-                    .on('init', () => {
-                        assert.ok(true, 'Runner has been initialized');
-                        runner.trigger('error');
-                    })
-                    .on('confirm.*', (message, accept, cancel, options) => {
-                        assert.equal(typeof message, 'string', 'String message provided');
-                        assert.equal(typeof accept, 'function', 'Accept callback provided');
-                        assert.equal(typeof cancel, 'function', 'Cancel callback provided');
-                        assert.equal(typeof options, 'object', 'Options provided');
-                        accept();
-                    })
-                    .before('pause', context => {
-                        assert.ok(true, 'The pause has been triggered');
-                        assert.equal(typeof context, 'object', 'A context is provided');
-                        runner.destroy();
-                        return Promise.reject();
-                    })
-                    .before('reloadpage', () => {
-                        assert.ok(false, 'A page reload should not be triggered!');
-                        runner.destroy();
-                        return Promise.reject();
-                    })
-                    .on('destroy', () => {
-                        window.clearTimeout(timeout);
-                        resolve();
-                    })
-                    .init();
-            }))
-            .catch(err => {
-                assert.pushResult({
-                    result: false,
-                    message: err
-                });
+
+        assert.expect(6);
+        runner
+            .on('init', () => {
+                assert.ok(true, 'Runner has been initialized');
+                runner.trigger('error');
             })
-            .then(done);
-
-
+            .on('confirm.*', (message, accept, cancel, options) => {
+                assert.equal(typeof message, 'string', 'String message provided');
+                assert.equal(typeof accept, 'function', 'Accept callback provided');
+                assert.equal(typeof cancel, 'function', 'Cancel callback provided');
+                assert.equal(typeof options, 'object', 'Options provided');
+                accept();
+            })
+            .before('pause', context => {
+                assert.equal(typeof context, 'object', 'The pause has been triggered and a context is provided');
+                runner.destroy();
+                return Promise.reject();
+            })
+            .before('reloadpage', () => {
+                assert.ok(false, 'A page reload should not be triggered!');
+                runner.destroy();
+                return Promise.reject();
+            })
+            .on('destroy', done)
+            .init();
     });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-121

Add a plugin that displays a message upon error. It then allows either to pause the test or to reload the page.

How to test:
- run the unit test: `npm run test`
- install the plugin in TAO, pass a test and trigger an error (example: you may throw an exception in the getItem action)