### PR TITLE
Fix/tr 261 align on before test submission prompt copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.18.1",
+    "version": "2.18.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.18.1",
+    "version": "2.18.2",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/next.js
+++ b/src/plugins/navigation/next.js
@@ -86,7 +86,7 @@ const disableElement = $element => $element.prop('disabled', true).addClass('dis
 const updateElement = ($element, testRunner, isLast = false) => {
     const dataType = isLast ? 'end' : 'next';
     const testContext = testRunner.getTestContext();
-  
+
     if (dataType === 'next' && !testContext.isAdaptive && !testContext.isCatAdaptive) {
         const testMap = testRunner.getTestMap();
         const nextItem = navigationHelper.getNextItem(testMap, testContext.itemPosition);
@@ -223,7 +223,7 @@ export default pluginFactory({
                         {
                             buttons: {
                                 labels: {
-                                    ok: __('SUBMIT THE TEST'),
+                                    ok: __('SUBMIT TEST'),
                                     cancel: __('CANCEL')
                                 }
                             }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-261

Requires: translations files need to be updated due sprint release.

How to check:
- create a test with according warning dialog
- skip test to invoke mentioned dialog, ensure `ok button` label is changed