### PR TITLE
Fix/tr 422/announce flagged items in the end test warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.18.2",
+    "version": "2.18.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.18.2",
+    "version": "2.18.3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -86,6 +86,26 @@ function getActionMessage(scope, submitButtonLabel = __('OK')) {
 }
 
 /**
+ * Build message for the flagged items if any.
+ * @param {Object} stats - The stats for the current context
+ * @param {String} [message] - The existing message to complete
+ * @returns {string|*}
+ */
+function getFlaggedItemsWarning(stats, message = '') {
+    const flaggedCount = stats && stats.flagged;
+    if (!flaggedCount) {
+        return message;
+    }
+    if (message) {
+        return `${message} ${__(
+            'and you flagged %s item(s) that you can review now',
+            flaggedCount.toString()
+        )}`;
+    }
+    return __('You flagged %s item(s) that you can review now', flaggedCount.toString());
+}
+
+/**
  * Build message if not all items have answers
  * @param {String} scope - scope to consider for calculating the stats
  * @param {Object} runner - testRunner instance
@@ -115,11 +135,8 @@ function getUnansweredItemsWarning(scope, runner, sync) {
             itemsCountMessage = __('There is %s unanswered question', unansweredCount.toString());
         }
 
-        if (unansweredCount && flaggedCount) {
-            itemsCountMessage += ` ${__(
-                'and you flagged %s item(s) that you can review now',
-                flaggedCount.toString()
-            )}`;
+        if (flaggedCount) {
+            itemsCountMessage = getFlaggedItemsWarning(stats, itemsCountMessage);
         }
     } else if (scope === 'part') {
         if (unansweredCount > 1) {
@@ -133,11 +150,8 @@ function getUnansweredItemsWarning(scope, runner, sync) {
                 unansweredCount.toString()
             );
         }
-        if (unansweredCount && flaggedCount) {
-            itemsCountMessage += ` ${__(
-                'and you flagged %s item(s) that you can review now',
-                flaggedCount.toString()
-            )}`;
+        if (flaggedCount) {
+            itemsCountMessage = getFlaggedItemsWarning(stats, itemsCountMessage);
         }
     }
     return itemsCountMessage;

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -15,9 +15,6 @@
  *
  * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
  */
-/**
- * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
- */
 
 import __ from 'i18n';
 import statsHelper from 'taoQtiTest/runner/helpers/stats';
@@ -28,7 +25,7 @@ import statsHelper from 'taoQtiTest/runner/helpers/stats';
  * @param {Object} runner - testRunner instance
  * @param {String} message - custom message that will be appended to the unanswered stats count
  * @param {Boolean} sync - flag for sync the unanswered stats in exit message and the unanswered stats in the toolbox
- * @param {String|undefined} - point the user to the submit button
+ * @param {String|undefined} submitButtonLabel - point the user to the submit button
  * @returns {String} Returns the message text
  */
 function getExitMessage(scope, runner, message = '', sync, submitButtonLabel) {
@@ -47,6 +44,7 @@ function getExitMessage(scope, runner, message = '', sync, submitButtonLabel) {
 
     return `${getHeader(scope)}${itemsCountMessage} ${getActionMessage(scope, submitButtonLabel)}${message}`.trim();
 }
+
 /**
  * Build message if not all items have answers
  * @param {String} scope - scope to consider for calculating the stats
@@ -82,10 +80,10 @@ function getActionMessage(scope, submitButtonLabel = __('OK')) {
                 'You will not be able to access this test once submitted. Click "%s" to continue and submit the test.',
                 submitButtonLabel
             )}`;
-        default:
-            '';
     }
+    return '';
 }
+
 /**
  * Build message if not all items have answers
  * @param {String} scope - scope to consider for calculating the stats

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -18,6 +18,7 @@
 
 import __ from 'i18n';
 import statsHelper from 'taoQtiTest/runner/helpers/stats';
+import messageHeaderTpl from 'taoQtiTest/runner/helpers/templates/messageHeader';
 
 /**
  * Completes an exit message
@@ -51,15 +52,15 @@ function getExitMessage(scope, runner, message = '', sync, submitButtonLabel) {
  * @returns {String} Returns the message text
  */
 function getHeader(scope) {
+    let header = '';
     if (scope === 'section' || scope === 'testSection') {
-        return `<b>${__('You are about to leave this section.')}</b><br><br>`;
+        header = __('You are about to leave this section.');
     } else if (scope === 'test' || scope === 'testWithoutInaccessibleItems') {
-        return `<b>${__('You are about to submit the test.')}</b><br><br>`;
+        header = __('You are about to submit the test.');
     } else if (scope === 'part') {
-        return `<b>${__('You are about to submit this test part.')}</b><br><br>`;
+        header = __('You are about to submit this test part.');
     }
-
-    return '';
+    return messageHeaderTpl({header});
 }
 
 /**

--- a/src/helpers/templates/messageHeader.tpl
+++ b/src/helpers/templates/messageHeader.tpl
@@ -1,0 +1,1 @@
+{{#if header}}<b>{{header}}</b><br><br>{{/if}}

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -120,8 +120,8 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
                 sectionStats: { answered: 3, flagged: 1 },
                 currentItemResponse: { string: 'test' },
                 currentItemAnswered: true,
-                testMessage: '<b>You are about to submit the test.</b><br><br>',
-                partMessage: '<b>You are about to submit this test part.</b><br><br>',
+                testMessage: '<b>You are about to submit the test.</b><br><br>You flagged 1 item(s) that you can review now.',
+                partMessage: '<b>You are about to submit this test part.</b><br><br>You flagged 1 item(s) that you can review now.',
                 sectionMessage: '<b>You are about to leave this section.</b><br><br>You answered 3 of 3 question(s) for this section of the test, and flagged 1 of them.'
             },
             {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-422

Make sure the flagged items are mentioned in the exit message, even if all items have been answered.

How to test:
- run the unit tests
- apply the [companion PR](https://github.com/oat-sa/extension-tao-testqti/pull/1964) and follow the instructions