### PR TITLE
fix/TR-485-popup-message-fix-french-dutch-german

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.18.5",
+    "version": "2.18.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.18.5",
+    "version": "2.18.6",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -38,7 +38,7 @@ function getExitMessage(scope, runner, message = '', sync, submitButtonLabel) {
     if (messageEnabled) {
         itemsCountMessage = getUnansweredItemsWarning(scope, runner, sync);
 
-        if (itemsCountMessage) {
+        if (itemsCountMessage.length > 1) {
             itemsCountMessage += '.';
         }
     }
@@ -70,11 +70,16 @@ function getHeader(scope) {
  * @returns {String} Returns the message text
  */
 function getActionMessage(scope, submitButtonLabel = __('OK')) {
+    var msg;
     switch (scope) {
         case 'section':
         case 'testSection':
         case 'part':
-            return `${__('Click "%s" to continue', submitButtonLabel)}.`;
+            msg = __('Click "%s" to continue', submitButtonLabel);
+            if (msg.length > 1) {
+                msg += '.';
+            }
+            return msg;
         case 'test':
         case 'testWithoutInaccessibleItems':
             return `${__(

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -36,9 +36,9 @@ function getExitMessage(scope, runner, message = '', sync, submitButtonLabel) {
     const messageEnabled = testRunnerOptions.enableUnansweredItemsWarning;
 
     if (messageEnabled) {
-        itemsCountMessage = getUnansweredItemsWarning(scope, runner, sync);
+        itemsCountMessage = getUnansweredItemsWarning(scope, runner, sync).trim();
 
-        if (itemsCountMessage.length > 1) {
+        if (itemsCountMessage) {
             itemsCountMessage += '.';
         }
     }
@@ -75,8 +75,8 @@ function getActionMessage(scope, submitButtonLabel = __('OK')) {
         case 'section':
         case 'testSection':
         case 'part':
-            msg = __('Click "%s" to continue', submitButtonLabel);
-            if (msg.length > 1) {
+            msg = __('Click "%s" to continue', submitButtonLabel).trim();
+            if (msg) {
                 msg += '.';
             }
             return msg;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-485

- shrink test navigation warning popup messages for dutch, french and german. This PR removes exceed dot in popups messages.

Required:
 - https://github.com/oat-sa/extension-tao-bosa-selor/pull/84
 - https://github.com/oat-sa/extension-tao-testqti/pull/1969