### PR TITLE
Feature/tr 736 improve pre caching behavior

### DIFF
--- a/src/plugins/controls/connectivity/connectivity.js
+++ b/src/plugins/controls/connectivity/connectivity.js
@@ -211,7 +211,7 @@ export default pluginFactory({
         });
 
         testRunner.before('loaditem.connectivity', function(e, itemRef, item) {
-            if (proxy.isOffline() && item.content.unresolvedAssets) {
+            if (proxy.isOffline() && item.flags && item.flags.containsNonPreloadedAssets) {
               self.displayWaitingDialog().then(function () {
                   testRunner.loadItem(itemRef);
               });

--- a/src/plugins/controls/connectivity/connectivity.js
+++ b/src/plugins/controls/connectivity/connectivity.js
@@ -209,6 +209,15 @@ export default pluginFactory({
                 return false;
             }
         });
+
+        testRunner.before('loaditem.connectivity', function(e, itemRef, item) {
+            if (proxy.isOffline() && item.content.unresolvedAssets) {
+              self.displayWaitingDialog().then(function () {
+                  testRunner.loadItem(itemRef);
+              });
+              return false;
+            }
+        });
     },
 
     /**

--- a/src/plugins/controls/connectivity/connectivity.js
+++ b/src/plugins/controls/connectivity/connectivity.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
  */
 
 /**

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
  */
 /**
  * Test Runner provider for QTI Tests.

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -665,15 +665,13 @@ var qtiProvider = {
     loadItem: function loadItem(itemIdentifier) {
         return this.getProxy()
             .getItem(itemIdentifier)
-            .then(function(data) {
-                //aggregate the results
-                return {
-                    content: data.itemData,
-                    baseUrl: data.baseUrl,
-                    state: data.itemState,
-                    portableElements: data.portableElements
-                };
-            });
+            .then(({itemData, baseUrl, itemState, portableElements, flags}) => ({
+                content: itemData,
+                baseUrl,
+                state: itemState,
+                portableElements,
+                flags
+            }));
     },
 
     /**

--- a/src/proxy/cache/itemPreloader.js
+++ b/src/proxy/cache/itemPreloader.js
@@ -311,7 +311,7 @@ var itemPreloaderFactory = function itemPreloaderFactory(options) {
                                 loaders[type](url, sourceUrl, item.itemIdentifier);
                             });
                         } else {
-                            item.itemData.unresolvedAssets = true;
+                            item.flags = Object.assign({}, item.flags, { containsNonPreloadedAssets: true });
                         }
                     });
                     return true;

--- a/src/proxy/cache/itemPreloader.js
+++ b/src/proxy/cache/itemPreloader.js
@@ -310,6 +310,8 @@ var itemPreloaderFactory = function itemPreloaderFactory(options) {
 
                                 loaders[type](url, sourceUrl, item.itemIdentifier);
                             });
+                        } else {
+                            item.itemData.unresolvedAssets = true;
                         }
                     });
                     return true;

--- a/src/proxy/cache/itemPreloader.js
+++ b/src/proxy/cache/itemPreloader.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 Open Assessment Technologies SA
+ * Copyright (c) 2017-2021 Open Assessment Technologies SA
  */
 
 /**

--- a/test/proxy/cache/itemPreloader/test.js
+++ b/test/proxy/cache/itemPreloader/test.js
@@ -231,4 +231,24 @@ define([
                 ready();
             });
     });
+
+    QUnit.test('preloader sets containsNonPreloadedAssets flag', function (assert) {
+        const ready = assert.async();
+        assert.expect(1);
+
+        const itemPreloader = itemPreloaderFactory(options);
+
+        const nonPreloadableItem = Object.assign({}, itemData, {
+            itemData: Object.assign({}, itemData.itemData, { assets: { video: { 'foo.mp4': 'foo.mp4' } } })
+        });
+
+        itemPreloader.preload(nonPreloadableItem).then(() => {
+            assert.deepEqual(
+                nonPreloadableItem.flags,
+                { containsNonPreloadedAssets: true },
+                'sets containsNonPreloadedAssets flag'
+            );
+            ready();
+        });
+    });
 });

--- a/test/proxy/cache/itemPreloader/test.js
+++ b/test/proxy/cache/itemPreloader/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 Open Assessment Technologies SA ;
  */
 
 /**


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-736

- Flag items that contains non preloaded assets
- Show waiting overlay when proxy is offline and test runner navigates to an item that contains non preloaded assets

Test:
- `npm run test`
- Integrate it to a BOSA environment and create a test that contains media interaction (both local and youtube).
- Go offline (for example on network tab) and navigate to the item that contains media interaction. You should see a waiting dialog until you will go back offline. After click to proceed, the navigation will happen.