### PR TITLE
Fix/tr 572/exceed popups

### DIFF
--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -251,16 +251,7 @@ var qtiProvider = {
 
             //catch server errors
             var submitError = function submitError(err) {
-                if (err && err.unrecoverable){
-                    self.trigger(
-                        'alert.error',
-                        __(
-                            'An unrecoverable error occurred. Your test session will be paused.'
-                        )
-                    );
-
-                    self.trigger('pause', {message : err.message});
-                } else if (err.code === 200) {
+                if (err.code === 200) {
                     //some server errors are valid, so we don't fail (prevent empty responses)
                     self.trigger(
                         'alert.submitError',

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -251,7 +251,16 @@ var qtiProvider = {
 
             //catch server errors
             var submitError = function submitError(err) {
-                if (err.code === 200) {
+                if (err && err.unrecoverable){
+                    self.trigger(
+                        'alert.error',
+                        __(
+                            'An unrecoverable error occurred. Your test session will be paused.'
+                        )
+                    );
+
+                    self.trigger('pause', {message : err.message});
+                } else if (err.code === 200) {
                     //some server errors are valid, so we don't fail (prevent empty responses)
                     self.trigger(
                         'alert.submitError',

--- a/src/proxy/cache/proxy.js
+++ b/src/proxy/cache/proxy.js
@@ -214,7 +214,7 @@ export default _.defaults(
 
                                                 if (!actionResult.success && self.actionRejectPromises[actionId]) {
                                                     const error = new Error(actionResult.message);
-                                                    error.unrecoverable = true;
+                                                    error.unrecoverable = actionResult.type !== "TestState";
                                                     return reject(error);
                                                 }
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-572

remove exceed popups on stop testtaker session by proctor

How to check: 
 - run test via LTI with enabled proctoring
 - enable session by proctor
 - start session as testaker
 - stop session as proctor
 - and try to navigate next item as testtaker
 - ensure only one alert message appears
 - 