### PR TITLE
fix: TR-855 fix bottom toolbar behavior on shrink display

### DIFF
--- a/scss/inc/_test-action-bars.scss
+++ b/scss/inc/_test-action-bars.scss
@@ -130,6 +130,8 @@
             & > .control-box {
                 color: white(.9);
                 text-shadow: 1px 1px 0 black;
+                display: flex;
+                overflow-x: hidden;
                 .lft, .rgt {
                     padding-left: 20px;
                     &:first-child {
@@ -144,6 +146,12 @@
                 }
                 [class^="btn-"], [class*=" btn-"] {
                     white-space: nowrap;
+                }
+                .tools-box {
+                    margin-right: auto;
+                }
+                .lft UL.tools-box-list, .rgt UL.navi-box-list {
+                    display: flex;
                 }
             }
             .tools-box {


### PR DESCRIPTION
Related to:
- https://oat-sa.atlassian.net/browse/TR-855

Depencies:
- https://github.com/oat-sa/extension-tao-testqti/pull/1994

Fix disappers part of bottom toolbar on shrink display.

How to check: 
 - run test via LTI with nl-NL translation with some enabled test taker tools
 - try to shrink a browser window
 - ensure toolbar buttons not disappears