### PR TITLE
Fix/TR-572/Too many popups displayed on test state error

### DIFF
--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -251,16 +251,7 @@ var qtiProvider = {
 
             //catch server errors
             var submitError = function submitError(err) {
-                if (err && err.unrecoverable){
-                    self.trigger(
-                        'alert.error',
-                        __(
-                            'An unrecoverable error occurred. Your test session will be paused.'
-                        )
-                    );
-
-                    self.trigger('pause', {message : err.message});
-                } else if (err.code === 200) {
+                if (err.code === 200) {
                     //some server errors are valid, so we don't fail (prevent empty responses)
                     self.trigger(
                         'alert.submitError',

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -251,7 +251,16 @@ var qtiProvider = {
 
             //catch server errors
             var submitError = function submitError(err) {
-                if (err.code === 200) {
+                if (err && err.unrecoverable){
+                    self.trigger(
+                        'alert.error',
+                        __(
+                            'An unrecoverable error occurred. Your test session will be paused.'
+                        )
+                    );
+
+                    self.trigger('pause', {message : err.message});
+                } else if (err.code === 200) {
                     //some server errors are valid, so we don't fail (prevent empty responses)
                     self.trigger(
                         'alert.submitError',

--- a/src/proxy/cache/proxy.js
+++ b/src/proxy/cache/proxy.js
@@ -214,7 +214,7 @@ export default _.defaults(
 
                                                 if (!actionResult.success && self.actionRejectPromises[actionId]) {
                                                     const error = new Error(actionResult.message);
-                                                    error.unrecoverable = true;
+                                                    error.unrecoverable = actionResult.type !== "TestState";
                                                     return reject(error);
                                                 }
 


### PR DESCRIPTION
Reopening of PR #366 as it was targeting the wrong branch but was merged too quickly

Related to: https://oat-sa.atlassian.net/browse/TR-572

Remove extra popups displayed when the test session has been halted outside of the test-taker scope.

How to check: 
 - Have a proctored test, a test taker and a proctor
 - Start the test on the test taker side
 - Enable the session on the proctor
 - Continue the test on the test taker side
 - Stop the session from the proctor side
 - From the test taker side, try to navigate to a next item
 - See the alert message showing up (only one should be displayed with the fix)
 