### PR TITLE
Fix/TR-702/Fix failing unit tests

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
  */
 
 import path from 'path';
@@ -79,10 +79,12 @@ export default inputs.map(input => {
         external: [
             ...localExternals,
             'handlebars',
+            'interact',
             'jquery',
             'lodash',
             'moment',
             'module',
+            'nouislider',
             'i18n',
             'ckeditor',
             'layout/loading-bar'

--- a/environment/config.js
+++ b/environment/config.js
@@ -48,6 +48,7 @@ define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(
                 'taoQtiItem/qtiItem': '/node_modules/@oat-sa/tao-item-runner-qti/dist/qtiItem',
                 'taoQtiItem/qtiCommonRenderer': '/node_modules/@oat-sa/tao-item-runner-qti/dist/qtiCommonRenderer',
                 'taoQtiItem/qtiRunner': '/node_modules/@oat-sa/tao-item-runner-qti/dist/qtiRunner',
+                'taoQtiItem/reviewRenderer': '/node_modules/@oat-sa/tao-item-runner-qti/dist/reviewRenderer',
                 'taoTests/runner': '/node_modules/@oat-sa/tao-test-runner/dist',
 
                 /* LIBS */

--- a/environment/config.js
+++ b/environment/config.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
  */
 
 define(['/node_modules/@oat-sa/tao-core-libs/dist/pathdefinition.js'], function(libPathDefinition) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,9 +1050,9 @@
             }
         },
         "@oat-sa/tao-core-libs": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.3.tgz",
-            "integrity": "sha512-6H4B5ETIWK011gJIPNxOMP2xIdWLNcTpDRsQvLuHO/716KbGG5PCAFCgQwdhmyIBAx9ApUeTF2ee0Xn6Ds0FAA==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.4.4.tgz",
+            "integrity": "sha512-DvleNKX5Ljnnl5fxUp8ss1yFubFSyzO/V3uuTaBjw6EkBPfLuNmvMi915AQ3UgX7tV6ysMc6B0HlbLxcwZp86A==",
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,9 +1079,9 @@
             "dev": true
         },
         "@oat-sa/tao-item-runner-qti": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.17.2.tgz",
-            "integrity": "sha512-QXf/GPhoO3nMXUeWIlzT/6JCQkdMLrg5PHGSoDwYJpF2vOQfPqOX1nS3wiFSPlbCGjh7zgyu5sInTV+ZJ5/Ctg==",
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner-qti/-/tao-item-runner-qti-0.21.3.tgz",
+            "integrity": "sha512-Poumzu+wVSEk9RZy/1xUuBoXWgz/1abbuopDMdZFW9u9cEzNyAbBNDi9v73ylh1/896jgZG4cTGqCOxJwDpmFg==",
             "dev": true
         },
         "@oat-sa/tao-qunit-testrunner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1056,9 +1056,9 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.8.1.tgz",
-            "integrity": "sha512-SlfRorpBkNJPRN3S9wDTk5dPdfaCmEEr4gSvM1XaQYghJlYjsKrDFu63p4jfqwO8JHk9zSHWFg605de8DBRRCw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.12.0.tgz",
+            "integrity": "sha512-rWVPOI5q5E2+bDpNolDXy7el+hawGIrgwMzmjKcg2auhCC1Uo3SqqTX06ejphiZemAZhyGBMwPE1mDlwteVUpQ==",
             "dev": true,
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1085,25 +1085,25 @@
             "dev": true
         },
         "@oat-sa/tao-qunit-testrunner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-qunit-testrunner/-/tao-qunit-testrunner-0.1.3.tgz",
-            "integrity": "sha512-BgSzuFTyqAJRKoDdpNcWjWW37dwchfCllPRRqNaYEwyk40vsHQjIxlNMMvDesi/uBSzSDw6F+M2HB6t/uWdtKg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-qunit-testrunner/-/tao-qunit-testrunner-1.0.3.tgz",
+            "integrity": "sha512-1Zo+GxzEL777eaeJekIIY1lw30I9Zm2tb1pRT7j/IfFV1yR8tW05ni+O545MQm1mrxdOuP/HKB4+DuiaYB9GHg==",
             "dev": true,
             "requires": {
                 "body-parser": "^1.19.0",
                 "chalk": "^2.4.2",
                 "connect": "^3.7.0",
-                "fs-extra": "^8.0.1",
+                "fs-extra": "^8.1.0",
                 "get-port": "^5.0.0",
-                "glob": "^7.1.4",
+                "glob": "^7.1.6",
                 "glob-promise": "^3.4.0",
                 "istanbul-lib-instrument": "^3.3.0",
                 "minimatch": "^3.0.4",
-                "node-qunit-puppeteer": "^1.0.13",
+                "node-qunit-puppeteer": "^1.0.16",
                 "promise-limit": "^2.7.0",
                 "serve-index": "^1.9.1",
                 "serve-static": "^1.14.1",
-                "yargs": "^13.2.4"
+                "yargs": "^13.3.0"
             }
         },
         "@oat-sa/tao-test-runner": {
@@ -2940,9 +2940,9 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -3625,9 +3625,9 @@
             }
         },
         "mime": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-            "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+            "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
             "dev": true
         },
         "mime-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,9 +1067,9 @@
             }
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.2.tgz",
-            "integrity": "sha512-xfNWh0WyUN5yv2qTIDONXdTI6fOGbO0ZSoZIfx9diXDQfrnhIWG9DnWoB8KmoTrxckVzDbvNu8W57oMDFCvt/w==",
+            "version": "1.22.14",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.14.tgz",
+            "integrity": "sha512-AFfaJJuEVs/DBMa0dbYIG9JpnvTIeJkQ6+eQtnKEnVYlGiaoq5fQbbNeOH+nsm8NiKEeqNk6NpcNQGLzoNvWEw==",
             "dev": true
         },
         "@oat-sa/tao-item-runner": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.4.3",
         "@oat-sa/tao-core-sdk": "^1.8.1",
-        "@oat-sa/tao-core-ui": "^1.22.1",
+        "@oat-sa/tao-core-ui": "1.22.14",
         "@oat-sa/tao-item-runner": "^0.7.1",
         "@oat-sa/tao-item-runner-qti": "0.21.3",
         "@oat-sa/tao-qunit-testrunner": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@oat-sa/browserslist-config-tao": "^0.1.0",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
-        "@oat-sa/tao-core-libs": "^0.4.3",
+        "@oat-sa/tao-core-libs": "0.4.4",
         "@oat-sa/tao-core-sdk": "1.12.0",
         "@oat-sa/tao-core-ui": "1.22.14",
         "@oat-sa/tao-item-runner": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@oat-sa/tao-core-sdk": "^1.8.1",
         "@oat-sa/tao-core-ui": "^1.22.1",
         "@oat-sa/tao-item-runner": "^0.7.1",
-        "@oat-sa/tao-item-runner-qti": "^0.17.2",
+        "@oat-sa/tao-item-runner-qti": "0.21.3",
         "@oat-sa/tao-qunit-testrunner": "1.0.3",
         "@oat-sa/tao-test-runner": "^0.8.1",
         "async": "0.2.10",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@oat-sa/tao-core-ui": "^1.22.1",
         "@oat-sa/tao-item-runner": "^0.7.1",
         "@oat-sa/tao-item-runner-qti": "^0.17.2",
-        "@oat-sa/tao-qunit-testrunner": "^0.1.3",
+        "@oat-sa/tao-qunit-testrunner": "1.0.3",
         "@oat-sa/tao-test-runner": "^0.8.1",
         "async": "0.2.10",
         "autoprefixer": "^9.6.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "^0.4.3",
-        "@oat-sa/tao-core-sdk": "^1.8.1",
+        "@oat-sa/tao-core-sdk": "1.12.0",
         "@oat-sa/tao-core-ui": "1.22.14",
         "@oat-sa/tao-item-runner": "^0.7.1",
         "@oat-sa/tao-item-runner-qti": "0.21.3",

--- a/src/plugins/content/accessibility/keyNavigation/strategies/topToolbarNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/topToolbarNavigation.js
@@ -23,7 +23,6 @@ import {
     setupItemsNavigator,
     setupClickableNavigator
 } from 'taoQtiTest/runner/plugins/content/accessibility/keyNavigation/helpers';
-import isReviewPanelEnabled from 'taoQtiTest/runner/helpers/isReviewPanelEnabled';
 
 /**
  * The identifier the keyNavigator group

--- a/test/plugins/content/dialog/itemInlineMessage/test.js
+++ b/test/plugins/content/dialog/itemInlineMessage/test.js
@@ -29,25 +29,25 @@ define([
 ], function($, _, testRunnerFactory, providerMock, inlineMessage, qtiItemRunner, itemData) {
     'use strict';
 
-    var runner;
-    var containerId = 'item-container';
+    let runner;
+    const containerId = 'item-container';
 
     QUnit.module('Item init', {
-        afterEach: function() {
+        afterEach() {
             if (runner) {
                 runner.clear();
             }
         }
     });
 
-    QUnit.test('Item data loading', function(assert) {
-        var ready = assert.async();
+    QUnit.test('Item data loading', assert => {
+        const ready = assert.async();
         assert.expect(2);
 
         runner = qtiItemRunner('qti', itemData)
-            .on('init', function() {
-                assert.ok(typeof this._item === 'object', 'The item data is loaded and mapped to an object');
-                assert.ok(typeof this._item.bdy === 'object', 'The item contains a body object');
+            .on('init', () => {
+                assert.ok(typeof runner._item === 'object', 'The item data is loaded and mapped to an object');
+                assert.ok(typeof runner._item.bdy === 'object', 'The item contains a body object');
 
                 ready();
             })
@@ -55,15 +55,15 @@ define([
     });
 
     QUnit.module('Item render', {
-        afterEach: function() {
+        afterEach() {
             if (runner) {
                 runner.clear();
             }
         }
     });
 
-    QUnit.test('Item rendering', function(assert) {
-        var ready = assert.async();
+    QUnit.test('Item rendering', assert => {
+        const ready = assert.async();
         assert.expect(3);
 
         const container = document.getElementById(containerId);
@@ -72,7 +72,7 @@ define([
         assert.equal(container.children.length, 0, 'the container has no children');
 
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', () => {
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 ready();
@@ -82,40 +82,38 @@ define([
     });
 
     QUnit.module('API', {
-        beforeEach: function setup() {
+        beforeEach() {
             runner = qtiItemRunner('qti', itemData).init();
         },
-        afterEach: function() {
+        afterEach() {
             if (runner) {
                 runner.clear();
             }
         }
     });
 
-    const pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var feedback = inlineMessage(runner);
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const feedback = inlineMessage(runner);
         assert.equal(
-            typeof feedback[data.name],
+            typeof feedback[data.title],
             'function',
-            `The alertMessage instances expose a "${data.name}" function`
+            `The alertMessage instances expose a "${data.title}" function`
         );
     });
 
@@ -124,7 +122,7 @@ define([
     testRunnerFactory.registerProvider(providerName, providerMock());
 
     QUnit.module('alertMessage', {
-        afterEach: function setup() {
+        afterEach() {
             if (runner) {
                 runner.clear();
             }
@@ -174,10 +172,10 @@ define([
         itemPosition: 0
     };
 
-    QUnit.test('init', function(assert) {
-        var ready = assert.async();
+    QUnit.test('init', assert => {
+        const ready = assert.async();
 
-        var container = document.getElementById(containerId);
+        const container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement, 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
@@ -185,14 +183,14 @@ define([
             runner.clear();
         }
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', () => {
                 assert.equal(container.children.length, 1, 'the container has children');
 
                 const feedback = inlineMessage(testRunner, testRunner.getAreaBroker());
 
                 feedback
                     .init({ dom: '<div>text with message for user</div>' })
-                    .then(function() {
+                    .then(() => {
                         assert.equal(feedback.getState('init'), true, 'The feedback is initialised');
                         assert.equal(
                             feedback.$element.text(),
@@ -202,7 +200,7 @@ define([
                         assert.equal(feedback.$button.length, 1, 'The button was created');
                         ready();
                     })
-                    .catch(function() {
+                    .catch(() => {
                         assert.ok(false, 'The init method must not fail');
                         ready();
                     });
@@ -216,8 +214,8 @@ define([
         testRunner.itemRunner = { _item: runner };
     });
 
-    QUnit.test('render', function(assert) {
-        var ready = assert.async();
+    QUnit.test('render', assert => {
+        const ready = assert.async();
 
         assert.expect(10);
 
@@ -230,7 +228,7 @@ define([
             runner.clear();
         }
         runner = qtiItemRunner('qti', itemData)
-            .on('render', function() {
+            .on('render', () => {
                 assert.equal(container.children.length, 1, 'the container has children');
                 assert.equal(
                     $('li.action', testRunner.getAreaBroker().getNavigationArea()).length,
@@ -240,7 +238,7 @@ define([
 
                 mFeedback = inlineMessage(testRunner, testRunner.getAreaBroker());
                 mFeedback.init({ dom: '<div id="qUnitTestMessage">text with message for user</div>' });
-                mFeedback.render().catch(function() {
+                mFeedback.render().catch(() => {
                     assert.ok(false, 'The render method must not fail');
                     ready();
                 });
@@ -254,7 +252,7 @@ define([
         testRunner.itemRunner = { _item: runner };
 
         testRunner
-            .on('plugin-render.itemInlineMessage', function(feedback) {
+            .on('plugin-render.itemInlineMessage', feedback => {
                 assert.equal(feedback.getState('ready'), true, 'The feedback is rendered');
                 const $navContainer = testRunner.getAreaBroker().getNavigationArea();
                 assert.equal(
@@ -273,7 +271,7 @@ define([
 
                 feedback.$button.click();
             })
-            .on('plugin-resume.itemInlineMessage', function() {
+            .on('plugin-resume.itemInlineMessage', () => {
                 assert.equal(
                     $('#qUnitTestMessage', testRunner.itemRunner.container).length,
                     0,

--- a/test/plugins/content/dialog/itemInlineMessage/test.js
+++ b/test/plugins/content/dialog/itemInlineMessage/test.js
@@ -90,6 +90,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/content/dialog/itemInlineMessage/test.js
+++ b/test/plugins/content/dialog/itemInlineMessage/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016  (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2016-2021  (original work) Open Assessment Technologies SA;
  *
  * @author Alexander Zagovorichev <zagovorichev@1pt.com>
  */
@@ -26,111 +26,15 @@ define([
     'taoQtiTest/runner/plugins/content/dialog/itemInlineMessage',
     'taoQtiItem/runner/qtiItemRunner',
     'json!taoQtiItem/test/samples/json/inlineModalFeedback.json'
-], function($, _, testRunnerFactory, providerMock, inlineMessage, qtiItemRunner, itemData) {
+], function ($, _, testRunnerFactory, providerMock, inlineMessage, itemRunnerFactory, itemData) {
     'use strict';
 
-    let runner;
     const containerId = 'item-container';
-
-    QUnit.module('Item init', {
-        afterEach() {
-            if (runner) {
-                runner.clear();
-            }
-        }
-    });
-
-    QUnit.test('Item data loading', assert => {
-        const ready = assert.async();
-        assert.expect(2);
-
-        runner = qtiItemRunner('qti', itemData)
-            .on('init', () => {
-                assert.ok(typeof runner._item === 'object', 'The item data is loaded and mapped to an object');
-                assert.ok(typeof runner._item.bdy === 'object', 'The item contains a body object');
-
-                ready();
-            })
-            .init();
-    });
-
-    QUnit.module('Item render', {
-        afterEach() {
-            if (runner) {
-                runner.clear();
-            }
-        }
-    });
-
-    QUnit.test('Item rendering', assert => {
-        const ready = assert.async();
-        assert.expect(3);
-
-        const container = document.getElementById(containerId);
-
-        assert.ok(container instanceof HTMLElement, 'the item container exists');
-        assert.equal(container.children.length, 0, 'the container has no children');
-
-        runner = qtiItemRunner('qti', itemData)
-            .on('render', () => {
-                assert.equal(container.children.length, 1, 'the container has children');
-
-                ready();
-            })
-            .init()
-            .render(container);
-    });
-
-    QUnit.module('API', {
-        beforeEach() {
-            runner = qtiItemRunner('qti', itemData).init();
-        },
-        afterEach() {
-            if (runner) {
-                runner.clear();
-            }
-        }
-    });
-
-    QUnit.cases.init([
-        { title: 'init' },
-        { title: 'render' },
-        { title: 'finish' },
-        { title: 'destroy' },
-        { title: 'trigger' },
-        { title: 'getTestRunner' },
-        { title: 'getAreaBroker' },
-        { title: 'getConfig' },
-        { title: 'setConfig' },
-        { title: 'getState' },
-        { title: 'setState' },
-        { title: 'show' },
-        { title: 'hide' },
-        { title: 'enable' },
-        { title: 'disable' }
-    ]).test('plugin API ', (data, assert) => {
-        const feedback = inlineMessage(runner);
-        assert.equal(
-            typeof feedback[data.title],
-            'function',
-            `The alertMessage instances expose a "${data.title}" function`
-        );
-    });
-
     const providerName = 'mock';
-    let testRunner;
     testRunnerFactory.registerProvider(providerName, providerMock());
 
-    QUnit.module('alertMessage', {
-        afterEach() {
-            if (runner) {
-                runner.clear();
-            }
-        }
-    });
-
     const testMap = {
-        identifier: "Test",
+        identifier: 'Test',
         parts: {
             'Part1': {
                 id: 'Part1',
@@ -154,14 +58,14 @@ define([
             }
         },
         jumps: [{
-            identifier: "FirstItem",
-            section: "Section1",
-            part: "Part1",
+            identifier: 'FirstItem',
+            section: 'Section1',
+            part: 'Part1',
             position: 0
         }, {
-            identifier: "LastItem",
-            section: "Section1",
-            part: "Part1",
+            identifier: 'LastItem',
+            section: 'Section1',
+            part: 'Part1',
             position: 1
         }]
     };
@@ -172,112 +76,244 @@ define([
         itemPosition: 0
     };
 
-    QUnit.test('init', assert => {
+    /**
+     * Gets a configured instance of the Item Runner
+     * @returns {Promise<runner>}
+     */
+    function getItemRunner() {
+        return new Promise(resolve => {
+            const runner = itemRunnerFactory('qti', itemData)
+                .on('init', () => resolve(runner))
+                .init();
+        });
+    }
+
+    /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner(config) {
+        const runner = testRunnerFactory(providerName, [], config);
+        runner.getDataHolder();
+        runner.setTestContext(testContext);
+        runner.setTestMap(testMap);
+        return Promise.resolve(runner);
+    }
+
+    QUnit.module('Item init');
+
+    QUnit.test('Item data loading', assert => {
         const ready = assert.async();
+        getItemRunner()
+            .then(itemRunner => {
+                assert.expect(2);
+
+                assert.ok(typeof itemRunner._item === 'object', 'The item data is loaded and mapped to an object');
+                assert.ok(typeof itemRunner._item.bdy === 'object', 'The item contains a body object');
+
+                itemRunner.clear();
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+
+    QUnit.module('Item render');
+
+    QUnit.test('Item rendering', assert => {
+        const ready = assert.async();
+
+        assert.expect(3);
 
         const container = document.getElementById(containerId);
 
         assert.ok(container instanceof HTMLElement, 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
-        if (runner) {
-            runner.clear();
-        }
-        runner = qtiItemRunner('qti', itemData)
-            .on('render', () => {
-                assert.equal(container.children.length, 1, 'the container has children');
 
-                const feedback = inlineMessage(testRunner, testRunner.getAreaBroker());
+        getItemRunner()
+            .then(itemRunner => new Promise(resolve => {
+                itemRunner.on('render', () => {
+                    assert.equal(container.children.length, 1, 'the container has children');
 
-                feedback
-                    .init({ dom: '<div>text with message for user</div>' })
-                    .then(() => {
-                        assert.equal(feedback.getState('init'), true, 'The feedback is initialised');
-                        assert.equal(
-                            feedback.$element.text(),
-                            'text with message for user',
-                            'The message was appended'
-                        );
-                        assert.equal(feedback.$button.length, 1, 'The button was created');
-                        ready();
-                    })
-                    .catch(() => {
-                        assert.ok(false, 'The init method must not fail');
-                        ready();
-                    });
+                    itemRunner.clear();
+                    resolve();
+                })
+                    .init()
+                    .render(container);
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
-            .init()
-            .render(container);
+            .then(ready);
+    });
 
-        testRunner = testRunnerFactory(providerName);
-        testRunner.setTestMap(testMap);
-        testRunner.setTestContext(testContext);
-        testRunner.itemRunner = { _item: runner };
+    QUnit.module('API');
+
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const ready = assert.async();
+        getItemRunner()
+            .then(itemRunner => {
+                const feedback = inlineMessage(itemRunner);
+                assert.equal(
+                    typeof feedback[data.title],
+                    'function',
+                    `The alertMessage instances expose a "${data.title}" function`
+                );
+
+                itemRunner.clear();
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+
+    QUnit.module('alertMessage');
+
+    QUnit.test('init', assert => {
+        const ready = assert.async();
+        const container = document.getElementById(containerId);
+
+        assert.ok(container instanceof HTMLElement, 'the item container exists');
+        assert.equal(container.children.length, 0, 'the container has no children');
+
+        Promise.all([
+            getItemRunner(),
+            getTestRunner()
+        ])
+            .then(([itemRunner, testRunner]) => new Promise((resolve, reject) => {
+                itemRunner
+                    .on('render', () => {
+                        assert.equal(container.children.length, 1, 'the container has children');
+
+                        const feedback = inlineMessage(testRunner, testRunner.getAreaBroker());
+
+                        feedback
+                            .init({ dom: '<div>text with message for user</div>' })
+                            .then(() => {
+                                assert.equal(feedback.getState('init'), true, 'The feedback is initialised');
+                                assert.equal(
+                                    feedback.$element.text(),
+                                    'text with message for user',
+                                    'The message was appended'
+                                );
+                                assert.equal(feedback.$button.length, 1, 'The button was created');
+
+                                itemRunner.clear();
+                                resolve();
+                            })
+                            .catch(reject);
+                    })
+                    .render(container);
+
+                testRunner.itemRunner = { _item: itemRunner };
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('render', assert => {
         const ready = assert.async();
+        const container = document.getElementById(containerId);
 
         assert.expect(10);
 
-        let mFeedback;
-        const container = document.getElementById(containerId);
-
         assert.ok(container instanceof HTMLElement, 'the item container exists');
         assert.equal(container.children.length, 0, 'the container has no children');
-        if (runner) {
-            runner.clear();
-        }
-        runner = qtiItemRunner('qti', itemData)
-            .on('render', () => {
-                assert.equal(container.children.length, 1, 'the container has children');
-                assert.equal(
-                    $('li.action', testRunner.getAreaBroker().getNavigationArea()).length,
-                    0,
-                    'Navigation has no children'
-                );
 
-                mFeedback = inlineMessage(testRunner, testRunner.getAreaBroker());
-                mFeedback.init({ dom: '<div id="qUnitTestMessage">text with message for user</div>' });
-                mFeedback.render().catch(() => {
-                    assert.ok(false, 'The render method must not fail');
-                    ready();
+        Promise.all([
+            getItemRunner(),
+            getTestRunner()
+        ])
+            .then(([itemRunner, testRunner]) => new Promise((resolve, reject) => {
+                testRunner
+                    .on('plugin-render.itemInlineMessage', feedback => {
+                        assert.equal(feedback.getState('ready'), true, 'The feedback is rendered');
+                        const $navContainer = testRunner.getAreaBroker().getNavigationArea();
+                        assert.equal(
+                            $navContainer.find(feedback.$button).length,
+                            1,
+                            'The inline message plugin has changed navigation button'
+                        );
+                        assert.equal($('li.action', $navContainer).length, 1, 'Navigation has 1 children');
+
+                        assert.equal(feedback.$element.text(), 'text with message for user', 'The content was attached');
+                        assert.equal(
+                            $('#qUnitTestMessage', testRunner.itemRunner.container).length,
+                            1,
+                            'The message is created'
+                        );
+
+                        feedback.$button.click();
+                    })
+                    .on('plugin-resume.itemInlineMessage', () => {
+                        assert.equal(
+                            $('#qUnitTestMessage', testRunner.itemRunner.container).length,
+                            0,
+                            'The message is deleted'
+                        );
+
+                        itemRunner.clear();
+                        resolve();
+                    });
+
+                itemRunner
+                    .on('render', () => {
+                        assert.equal(container.children.length, 1, 'the container has children');
+                        assert.equal(
+                            $('li.action', testRunner.getAreaBroker().getNavigationArea()).length,
+                            0,
+                            'Navigation has no children'
+                        );
+
+                        const feedback = inlineMessage(testRunner, testRunner.getAreaBroker());
+
+                        feedback
+                            .init({ dom: '<div id="qUnitTestMessage">text with message for user</div>' })
+                            .then(() => feedback.render())
+                            .catch(reject);
+                    })
+                    .render(container);
+
+                testRunner.itemRunner = { _item: itemRunner };
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
                 });
             })
-            .init()
-            .render(container);
-
-        testRunner = testRunnerFactory(providerName);
-        testRunner.setTestMap(testMap);
-        testRunner.setTestContext(testContext);
-        testRunner.itemRunner = { _item: runner };
-
-        testRunner
-            .on('plugin-render.itemInlineMessage', feedback => {
-                assert.equal(feedback.getState('ready'), true, 'The feedback is rendered');
-                const $navContainer = testRunner.getAreaBroker().getNavigationArea();
-                assert.equal(
-                    $navContainer.find(feedback.$button).length,
-                    1,
-                    'The inline message plugin has changed navigation button'
-                );
-                assert.equal($('li.action', $navContainer).length, 1, 'Navigation has 1 children');
-
-                assert.equal(feedback.$element.text(), 'text with message for user', 'The content was attached');
-                assert.equal(
-                    $('#qUnitTestMessage', testRunner.itemRunner.container).length,
-                    1,
-                    'The message is created'
-                );
-
-                feedback.$button.click();
-            })
-            .on('plugin-resume.itemInlineMessage', () => {
-                assert.equal(
-                    $('#qUnitTestMessage', testRunner.itemRunner.container).length,
-                    0,
-                    'The message is deleted'
-                );
-                ready();
-            });
+            .then(ready);
     });
 });

--- a/test/plugins/content/responsiveness/collapser/test.html
+++ b/test/plugins/content/responsiveness/collapser/test.html
@@ -21,6 +21,15 @@
                 display: none;
             }
 
+            /*
+                fix: prevent the auto margin to impact the test
+                see: scss/inc/_test-action-bars.scss:151
+                regression added by: https://github.com/oat-sa/tao-test-runner-qti-fe/commit/a6a800bbf839149e70e33310a2a4de699acfdcb7
+            */
+            #qunit-fixture .tools-box {
+                margin: 0;
+            }
+
             [data-control] {
                 float: left;
                 margin-right: 10px;

--- a/test/plugins/content/responsiveness/collapser/test.js
+++ b/test/plugins/content/responsiveness/collapser/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA;
  */
 /**
  * @author Christophe Noël <christophe@taotesting.com>
@@ -484,114 +484,120 @@ define([
 
     //******************   Do not collapse in order   ******************//
 
-    QUnit
-        .cases.init([
-        { title: 'Tools and Nav', collapseTools: true, collapseNavigation: true },
-        { title: 'Tools', collapseTools: true, collapseNavigation: false },
-        { title: 'Nav', collapseTools: false, collapseNavigation: true }
-    ])
-        .test('collapse/expand all at once', (data, assert) => {
-            const ready = assert.async();
-            const $container = $(fixtureId);
+    QUnit.cases.init([{
+        title: 'Tools and Nav',
+        collapseTools: true,
+        collapseNavigation: true
+    }, {
+        title: 'Tools',
+        collapseTools: true,
+        collapseNavigation: false
+    }, {
+        title: 'Nav',
+        collapseTools: false,
+        collapseNavigation: true
+    }]).test('collapse/expand all at once', (data, assert) => {
+        const ready = assert.async();
+        const $container = $(fixtureId);
 
-            let $actionsBar;
-            let $nav;
-            let $toolbox;
-            let resizeCount = 0;
+        let $actionsBar;
+        let $nav;
+        let $toolbox;
+        let resizeCount = 0;
 
-            assert.expect(16);
+        assert.expect(16);
 
-            const areaBroker = areaBrokerMock({
-                $brokerContainer: $container,
-                mapping: {
-                    actionsBar: $container.find('.bottom-action-bar .control-box'),
-                    toolbox: $container.find('.tools-box'),
-                    navigation: $container.find('.navi-box')
-                }
-            });
-
-            runnerFactory.registerProvider(providerName, providerMock({ areaBroker: areaBroker }));
-            const runner = runnerFactory(providerName);
-            const plugin = pluginFactory(runner, areaBroker, {
-                collapseTools: data.collapseTools,
-                collapseNavigation: data.collapseNavigation
-            });
-
-            runner.after('collapseTools', () => {
-                resizeCount++;
-
-                switch (resizeCount) {
-
-                    // Original state
-                    case 1: {
-                        assert.ok(!$nav.hasClass(noLabelCls), 'nav is expanded');
-                        assert.ok(!$toolbox.hasClass(noLabelCls), 'toolbox is expanded');
-
-                        $actionsBar.width(ALL_EXPANDED - 1);
-                        runner.trigger('collapseTools');
-                        break;
-                    }
-                    case 2: {
-
-                        // Collapse all in the applicable containers (tools|navi)
-
-                        if (data.collapseNavigation) {
-                            assert.ok($container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been collapsed');
-                            assert.ok($container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been collapsed');
-                        } else {
-                            assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button remains expanded');
-                            assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button remains expanded');
-                        }
-
-                        if (data.collapseTools) {
-                            assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been collapsed');
-                            assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                            assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                            assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
-                            assert.ok($container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been collapsed');
-                        } else {
-                            assert.ok(!$container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 remains expanded');
-                            assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remains expanded');
-                            assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                            assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remains expanded');
-                            assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 remains expanded');
-                        }
-
-                        $actionsBar.width(ALL_EXPANDED + 1);
-                        runner.trigger('collapseTools');
-                        break;
-                    }
-                    case 3: {
-
-                        // Expand all
-                        assert.ok(!$container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been expanded');
-                        assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
-                        assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                        assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
-                        assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
-
-                        assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
-                        assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
-
-                        ready();
-                        break;
-                    }
-                }
-            });
-
-            plugin.init()
-                .then(() => {
-                    $actionsBar = areaBroker.getArea('actionsBar');
-                    $nav = areaBroker.getArea('navigation');
-                    $toolbox = areaBroker.getArea('toolbox');
-
-                    $actionsBar.width(ALL_EXPANDED);
-                    runner.trigger('loaditem');
-                })
-                .catch(err => {
-                    assert.ok(false, `Error in init method: ${err}`);
-                    ready();
-                });
+        const areaBroker = areaBrokerMock({
+            $brokerContainer: $container,
+            mapping: {
+                actionsBar: $container.find('.bottom-action-bar .control-box'),
+                toolbox: $container.find('.tools-box'),
+                navigation: $container.find('.navi-box')
+            }
         });
+
+        runnerFactory.registerProvider(providerName, providerMock({ areaBroker: areaBroker }));
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, areaBroker, {
+            collapseTools: data.collapseTools,
+            collapseNavigation: data.collapseNavigation
+        });
+
+        runner.after('collapseTools', () => {
+            resizeCount++;
+
+            switch (resizeCount) {
+
+                // Original state
+                case 1: {
+                    assert.ok(!$nav.hasClass(noLabelCls), 'nav is expanded');
+                    assert.ok(!$toolbox.hasClass(noLabelCls), 'toolbox is expanded');
+
+                    $actionsBar.width(ALL_EXPANDED - 1);
+                    runner.trigger('collapseTools');
+                    break;
+                }
+                case 2: {
+
+                    // Collapse all in the applicable containers (tools|navi)
+
+                    if (data.collapseNavigation) {
+                        assert.ok($container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been collapsed');
+                        assert.ok($container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been collapsed');
+                    } else {
+                        assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button remains expanded');
+                        assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button remains expanded');
+                    }
+
+                    if (data.collapseTools) {
+                        assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been collapsed');
+                        assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
+                        assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                        assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
+                        assert.ok($container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been collapsed');
+                    } else {
+                        assert.ok(!$container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 remains expanded');
+                        assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remains expanded');
+                        assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                        assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remains expanded');
+                        assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 remains expanded');
+                    }
+
+                    $actionsBar.width(ALL_EXPANDED + 1);
+                    runner.trigger('collapseTools');
+                    break;
+                }
+                case 3: {
+
+                    // Expand all
+                    assert.ok(!$container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been expanded');
+                    assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
+                    assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
+
+                    assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
+
+                    ready();
+                    break;
+                }
+            }
+        });
+
+        plugin.init()
+            .then(() => {
+                $actionsBar = areaBroker.getArea('actionsBar');
+                $nav = areaBroker.getArea('navigation');
+                $toolbox = areaBroker.getArea('toolbox');
+
+                $actionsBar.width(ALL_EXPANDED);
+                runner.trigger('loaditem');
+            })
+            .catch(err => {
+                assert.ok(false, `Error in init method: ${err}`);
+                ready();
+            });
+    });
 
 });

--- a/test/plugins/content/responsiveness/collapser/test.js
+++ b/test/plugins/content/responsiveness/collapser/test.js
@@ -26,8 +26,7 @@ define([
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/test/runner/mocks/areaBrokerMock',
     'taoQtiTest/runner/plugins/content/responsiveness/collapser'
-], function(
-
+], function (
     _,
     $,
     runnerFactory,
@@ -37,28 +36,29 @@ define([
 ) {
     'use strict';
 
-    var fixtureId = '#qunit-fixture';
+    const fixtureId = '#qunit-fixture';
 
-    var noLabelCls = 'tool-label-collapsed';
+    const noLabelCls = 'tool-label-collapsed';
+    const noLabelSelector = `.${noLabelCls}`;
 
-    var ICON_WIDTH = 20,
-        TEXT_WIDTH = 70,
-        BTN_MARGIN = 10,
-        NAV_PADDING = 20,
+    const ICON_WIDTH = 20;
+    const TEXT_WIDTH = 70;
+    const BTN_MARGIN = 10;
+    const NAV_PADDING = 20;
 
-        ALL_EXPANDED =
-            7 * ICON_WIDTH + // 5 toolbox buttons + 2 nav buttons
-            6 * TEXT_WIDTH + // 1 toolbox button is always collapsed, see test.html
-            7 * BTN_MARGIN +
-            NAV_PADDING +
-            20; //Scrollbar width
+    const ALL_EXPANDED =
+        7 * ICON_WIDTH + // 5 toolbox buttons + 2 nav buttons
+        6 * TEXT_WIDTH + // 1 toolbox button is always collapsed, see test.html
+        7 * BTN_MARGIN +
+        NAV_PADDING +
+        20; //Scrollbar width
 
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     QUnit.module('Module');
 
-    QUnit.test('Module export', function(assert) {
+    QUnit.test('Module export', assert => {
         assert.expect(1);
 
         assert.ok(typeof pluginFactory === 'function', 'The module expose a function');
@@ -68,29 +68,26 @@ define([
 
     //******************   With preconfigured order   ******************//
 
-    QUnit.test('collapse/expand with preconfigured order', function(assert) {
-        var ready = assert.async();
-        var $container = $(fixtureId),
-            areaBroker,
-            runner,
-            plugin;
+    QUnit.test('collapse/expand with preconfigured order', assert => {
+        const ready = assert.async();
+        const $container = $(fixtureId);
 
-        var collapseOrder = [
+        const collapseOrder = [
             '[data-control="prefixed-one"]',
             '[data-control="prefixed-two"],[data-control="three"],[data-control="four"]',
             '[data-control="five"]',
             '[data-control="navi-prev"],[data-control="navi-next"]'
         ];
 
-        var $actionsBar,
-            $collapsed,
-            newWidth,
-            collapsedBtns,
-            resizeCount = 0;
+        let $actionsBar;
+        let $collapsed;
+        let newWidth;
+        let collapsedBtns;
+        let resizeCount = 0;
 
         assert.expect(49);
 
-        areaBroker = areaBrokerMock({
+        const areaBroker = areaBrokerMock({
             $brokerContainer: $container,
             mapping: {
                 actionsBar: $container.find('.bottom-action-bar .control-box'),
@@ -99,23 +96,23 @@ define([
             }
         });
 
-        runnerFactory.registerProvider(providerName, providerMock({areaBroker: areaBroker}));
-        runner = runnerFactory(providerName);
-        plugin = pluginFactory(runner, areaBroker, {
+        runnerFactory.registerProvider(providerName, providerMock({ areaBroker: areaBroker }));
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, areaBroker, {
             collapseTools: false,
             collapseInOrder: true,
             collapseOrder: collapseOrder
         });
 
-        runner.after('collapseTools', function() {
+        runner.after('collapseTools', () => {
             resizeCount++;
 
             switch (resizeCount) {
                 case 1: {
                     collapsedBtns = 0;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     $actionsBar.width(ALL_EXPANDED - 1);
                     runner.trigger('collapseTools');
@@ -124,8 +121,8 @@ define([
                 case 2: {
                     collapsedBtns = 1;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 has been collapsed');
 
@@ -137,12 +134,12 @@ define([
                 case 3: {
                     collapsedBtns = 3;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 has been collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
 
                     newWidth = ALL_EXPANDED - (TEXT_WIDTH * collapsedBtns) - 1;
@@ -153,12 +150,12 @@ define([
                 case 4: {
                     collapsedBtns = 4;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 has been collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
                     assert.ok($container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been collapsed');
 
@@ -170,12 +167,12 @@ define([
                 case 5: {
                     collapsedBtns = 6;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 has been collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
                     assert.ok($container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been collapsed');
                     assert.ok($container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been collapsed');
@@ -189,15 +186,15 @@ define([
                 case 6: {
                     collapsedBtns = 4;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 remain collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remain collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remain collapsed');
                     assert.ok($container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 remain collapsed');
-                    assert.ok(! $container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
+                    assert.ok(!$container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
 
                     collapsedBtns = 3;
                     newWidth = ALL_EXPANDED - (TEXT_WIDTH * collapsedBtns) + 1;
@@ -208,15 +205,15 @@ define([
                 case 7: {
                     collapsedBtns = 3;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 remain collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remain collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remain collapsed');
-                    assert.ok(! $container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been expanded');
-                    assert.ok(! $container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
+                    assert.ok(!$container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been expanded');
+                    assert.ok(!$container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
 
                     collapsedBtns = 1;
                     newWidth = ALL_EXPANDED - (TEXT_WIDTH * collapsedBtns) + 1;
@@ -227,15 +224,15 @@ define([
                 case 8: {
                     collapsedBtns = 1;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 remain collapsed');
-                    assert.ok(! $container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                    assert.ok(! $container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
-                    assert.ok(! $container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been expanded');
-                    assert.ok(! $container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
+                    assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
+                    assert.ok(!$container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been expanded');
+                    assert.ok(!$container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
 
                     newWidth = ALL_EXPANDED + 1;
                     $actionsBar.width(newWidth);
@@ -245,15 +242,15 @@ define([
                 case 9: {
                     collapsedBtns = 0;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
-                    assert.ok(! $container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 has been expanded');
-                    assert.ok(! $container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                    assert.ok(! $container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
-                    assert.ok(! $container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been expanded');
-                    assert.ok(! $container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
+                    assert.ok(!$container.find(collapseOrder[0]).hasClass(noLabelCls), 'button1 has been expanded');
+                    assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
+                    assert.ok(!$container.find(collapseOrder[2]).hasClass(noLabelCls), 'button5 has been expanded');
+                    assert.ok(!$container.find(collapseOrder[3]).hasClass(noLabelCls), 'prev & next have been expanded');
 
                     ready();
                     break;
@@ -262,38 +259,35 @@ define([
         });
 
         plugin.init()
-            .then(function() {
+            .then(() => {
                 $actionsBar = areaBroker.getArea('actionsBar');
 
                 $actionsBar.width(ALL_EXPANDED);
                 runner.trigger('loaditem');
             })
-            .catch(function(err) {
-                assert.ok(false, `Error in init method: ${  err}`);
+            .catch(err => {
+                assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
     //******************   Without preconfigured order   ******************//
 
-    QUnit.test('collapse/expand without preconfigured order', function(assert) {
-        var ready = assert.async();
-        var $container = $(fixtureId),
-            areaBroker,
-            runner,
-            plugin;
+    QUnit.test('collapse/expand without preconfigured order', assert => {
+        const ready = assert.async();
+        const $container = $(fixtureId);
 
-        var collapseOrder = [];
+        const collapseOrder = [];
 
-        var $actionsBar,
-            $collapsed,
-            newWidth,
-            collapsedBtns,
-            resizeCount = 0;
+        let $actionsBar;
+        let $collapsed;
+        let newWidth;
+        let collapsedBtns;
+        let resizeCount = 0;
 
         assert.expect(57);
 
-        areaBroker = areaBrokerMock({
+        const areaBroker = areaBrokerMock({
             $brokerContainer: $container,
             mapping: {
                 actionsBar: $container.find('.bottom-action-bar .control-box'),
@@ -302,24 +296,24 @@ define([
             }
         });
 
-        runnerFactory.registerProvider(providerName, providerMock({areaBroker: areaBroker}));
-        runner = runnerFactory(providerName);
-        plugin = pluginFactory(runner, areaBroker, {
+        runnerFactory.registerProvider(providerName, providerMock({ areaBroker: areaBroker }));
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, areaBroker, {
             collapseTools: true,
             collapseNavigation: true,
             collapseInOrder: true,
             collapseOrder: collapseOrder
         });
 
-        runner.after('collapseTools', function() {
+        runner.after('collapseTools', () => {
             resizeCount++;
 
             switch (resizeCount) {
                 case 1: {
                     collapsedBtns = 0;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     $actionsBar.width(ALL_EXPANDED - 1);
                     runner.trigger('collapseTools');
@@ -328,8 +322,8 @@ define([
                 case 2: {
                     collapsedBtns = 2;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
                     assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
 
@@ -341,14 +335,14 @@ define([
                 case 3: {
                     collapsedBtns = 3;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
-                    assert.ok(! $container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has not been collapsed (because there is still space)');
+                    assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has not been collapsed (because there is still space)');
 
                     newWidth = ALL_EXPANDED - (TEXT_WIDTH * collapsedBtns) - 1;
                     $actionsBar.width(newWidth);
@@ -358,15 +352,15 @@ define([
                 case 4: {
                     collapsedBtns = 4;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
                     assert.ok($container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been collapsed');
-                    assert.ok(! $container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has not been collapsed (because there is still space)');
+                    assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has not been collapsed (because there is still space)');
 
                     newWidth = ALL_EXPANDED - (TEXT_WIDTH * collapsedBtns) - 1;
                     $actionsBar.width(newWidth);
@@ -376,12 +370,12 @@ define([
                 case 5: {
                     collapsedBtns = 6;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
                     assert.ok($container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been collapsed');
                     assert.ok($container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been collapsed');
@@ -396,16 +390,16 @@ define([
                 case 6: {
                     collapsedBtns = 4;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 remains collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remains collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remains collapsed');
                     assert.ok($container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 remains collapsed');
-                    assert.ok(! $container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
-                    assert.ok(! $container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
 
                     collapsedBtns = 3;
                     newWidth = ALL_EXPANDED - (TEXT_WIDTH * collapsedBtns) + 1;
@@ -416,16 +410,16 @@ define([
                 case 7: {
                     collapsedBtns = 3;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 remains collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remains collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                     assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remains collapsed');
-                    assert.ok(! $container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
-                    assert.ok(! $container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
-                    assert.ok(! $container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
+                    assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
 
                     collapsedBtns = 1;
                     newWidth = ALL_EXPANDED - (TEXT_WIDTH * collapsedBtns) + 1;
@@ -438,16 +432,16 @@ define([
                     //Two because the first two buttons are in a group
                     collapsedBtns = 2;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
                     assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 remains collapsed');
                     assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remains collapsed');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                    assert.ok(! $container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
-                    assert.ok(! $container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
-                    assert.ok(! $container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
-                    assert.ok(! $container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
+                    assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
 
 
                     newWidth = ALL_EXPANDED + 1;
@@ -458,16 +452,16 @@ define([
                 case 9: {
                     collapsedBtns = 0;
 
-                    $collapsed = $container.find(`.${  noLabelCls}`);
-                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns  } buttons are collapsed`);
+                    $collapsed = $container.find(noLabelSelector);
+                    assert.equal($collapsed.length, collapsedBtns, `${collapsedBtns} buttons are collapsed`);
 
-                    assert.ok(! $container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been expanded');
-                    assert.ok(! $container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
-                    assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                    assert.ok(! $container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
-                    assert.ok(! $container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
-                    assert.ok(! $container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
-                    assert.ok(! $container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
+                    assert.ok(!$container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been expanded');
+                    assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been expanded');
+                    assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                    assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been expanded');
+                    assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been expanded');
+                    assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been expanded');
 
                     ready();
                     break;
@@ -476,14 +470,14 @@ define([
         });
 
         plugin.init()
-            .then(function() {
+            .then(() => {
                 $actionsBar = areaBroker.getArea('actionsBar');
 
                 $actionsBar.width(ALL_EXPANDED);
                 runner.trigger('loaditem');
             })
-            .catch(function(err) {
-                assert.ok(false, `Error in init method: ${  err}`);
+            .catch(err => {
+                assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
@@ -492,25 +486,22 @@ define([
 
     QUnit
         .cases.init([
-            {title: 'Tools and Nav', collapseTools: true, collapseNavigation: true},
-            {title: 'Tools', collapseTools: true, collapseNavigation: false},
-            {title: 'Nav', collapseTools: false, collapseNavigation: true}
-        ])
-        .test('collapse/expand all at once', function(data, assert) {
-            var ready = assert.async();
-            var $container = $(fixtureId),
-                areaBroker,
-                runner,
-                plugin;
+        { title: 'Tools and Nav', collapseTools: true, collapseNavigation: true },
+        { title: 'Tools', collapseTools: true, collapseNavigation: false },
+        { title: 'Nav', collapseTools: false, collapseNavigation: true }
+    ])
+        .test('collapse/expand all at once', (data, assert) => {
+            const ready = assert.async();
+            const $container = $(fixtureId);
 
-            var $actionsBar,
-                $nav,
-                $toolbox,
-                resizeCount = 0;
+            let $actionsBar;
+            let $nav;
+            let $toolbox;
+            let resizeCount = 0;
 
             assert.expect(16);
 
-            areaBroker = areaBrokerMock({
+            const areaBroker = areaBrokerMock({
                 $brokerContainer: $container,
                 mapping: {
                     actionsBar: $container.find('.bottom-action-bar .control-box'),
@@ -519,14 +510,14 @@ define([
                 }
             });
 
-            runnerFactory.registerProvider(providerName, providerMock({areaBroker: areaBroker}));
-            runner = runnerFactory(providerName);
-            plugin = pluginFactory(runner, areaBroker, {
+            runnerFactory.registerProvider(providerName, providerMock({ areaBroker: areaBroker }));
+            const runner = runnerFactory(providerName);
+            const plugin = pluginFactory(runner, areaBroker, {
                 collapseTools: data.collapseTools,
                 collapseNavigation: data.collapseNavigation
             });
 
-            runner.after('collapseTools', function() {
+            runner.after('collapseTools', () => {
                 resizeCount++;
 
                 switch (resizeCount) {
@@ -544,26 +535,26 @@ define([
 
                         // Collapse all in the applicable containers (tools|navi)
 
-                        if(data.collapseNavigation) {
+                        if (data.collapseNavigation) {
                             assert.ok($container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button has been collapsed');
                             assert.ok($container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button has been collapsed');
                         } else {
-                            assert.ok(! $container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button remains expanded');
-                            assert.ok(! $container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button remains expanded');
+                            assert.ok(!$container.find('[data-control="navi-prev"]').hasClass(noLabelCls), 'navi-prev button remains expanded');
+                            assert.ok(!$container.find('[data-control="navi-next"]').hasClass(noLabelCls), 'navi-next button remains expanded');
                         }
 
-                        if(data.collapseTools) {
+                        if (data.collapseTools) {
                             assert.ok($container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 has been collapsed');
                             assert.ok($container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 has been collapsed');
-                            assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                            assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
                             assert.ok($container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 has been collapsed');
                             assert.ok($container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 has been collapsed');
                         } else {
-                            assert.ok(! $container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 remains expanded');
-                            assert.ok(! $container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remains expanded');
-                            assert.ok(! $container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
-                            assert.ok(! $container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remains expanded');
-                            assert.ok(! $container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 remains expanded');
+                            assert.ok(!$container.find('[data-control="prefixed-one"]').hasClass(noLabelCls), 'button1 remains expanded');
+                            assert.ok(!$container.find('[data-control="prefixed-two"]').hasClass(noLabelCls), 'button2 remains expanded');
+                            assert.ok(!$container.find('[data-control="three"]').hasClass(noLabelCls), 'button3 has NOT been collapsed (always collapsed, see markup in test.html)');
+                            assert.ok(!$container.find('[data-control="four"]').hasClass(noLabelCls), 'button4 remains expanded');
+                            assert.ok(!$container.find('[data-control="five"]').hasClass(noLabelCls), 'button5 remains expanded');
                         }
 
                         $actionsBar.width(ALL_EXPANDED + 1);
@@ -589,7 +580,7 @@ define([
             });
 
             plugin.init()
-                .then(function() {
+                .then(() => {
                     $actionsBar = areaBroker.getArea('actionsBar');
                     $nav = areaBroker.getArea('navigation');
                     $toolbox = areaBroker.getArea('toolbox');
@@ -597,8 +588,8 @@ define([
                     $actionsBar.width(ALL_EXPANDED);
                     runner.trigger('loaditem');
                 })
-                .catch(function(err) {
-                    assert.ok(false, `Error in init method: ${  err}`);
+                .catch(err => {
+                    assert.ok(false, `Error in init method: ${err}`);
                     ready();
                 });
         });

--- a/test/plugins/content/rubricBlock/test.js
+++ b/test/plugins/content/rubricBlock/test.js
@@ -27,11 +27,10 @@ define([
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/runner/plugins/content/rubricBlock/rubricBlock',
     'mathJax'
-], function($, runnerFactory, providerMock, pluginFactory, mathJaxMock) {
+], function ($, runnerFactory, providerMock, pluginFactory, mathJaxMock) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     /**
@@ -39,8 +38,8 @@ define([
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
         assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
@@ -51,49 +50,47 @@ define([
         );
     });
 
-    pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var runner = runnerFactory(providerName);
-        var timer = pluginFactory(runner);
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const timer = pluginFactory(runner);
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
     QUnit.module('load rubric blocks', {
-        beforeEach: function() {
+        beforeEach: () => {
             mathJaxMock.called = false;
         }
     });
 
-    QUnit.test('render a rubric block', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('render a rubric block', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(2);
 
-        runner.on('rubricblock', function() {
-            var $container = runner.getAreaBroker().getContainer();
+        runner.on('rubricblock', () => {
+            const $container = runner.getAreaBroker().getContainer();
 
             assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
             assert.equal($('#qti-rubrics', $container).html(), '<p>foo</p>', 'The rubric blocks content is loaded');
@@ -103,29 +100,29 @@ define([
         plugin
             .init()
             .then(plugin.render())
-            .then(function() {
+            .then(() => {
                 runner.setTestContext({
                     rubrics: '<p>foo</p>'
                 });
                 runner.trigger('loaditem', 'foo');
                 runner.trigger('renderitem');
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, err.message);
                 ready();
             });
     });
 
-    QUnit.test('load / unload a rubric block', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('load / unload a rubric block', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(4);
 
         runner
-            .after('renderitem', function() {
-                var $container = runner.getAreaBroker().getContainer();
+            .after('renderitem', () => {
+                const $container = runner.getAreaBroker().getContainer();
 
                 assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
                 assert.equal(
@@ -134,8 +131,8 @@ define([
                     'The rubric block element contains an child'
                 );
             })
-            .after('unloaditem', function() {
-                var $container = runner.getAreaBroker().getContainer();
+            .after('unloaditem', () => {
+                const $container = runner.getAreaBroker().getContainer();
 
                 assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
                 assert.equal($('#qti-rubrics', $container).children().length, 0, 'The rubric block element is empty');
@@ -146,32 +143,30 @@ define([
         plugin
             .init()
             .then(plugin.render())
-            .then(function() {
+            .then(() => {
                 runner.setTestContext({
                     rubrics: '<p>foo</p>'
                 });
                 runner.trigger('loaditem', 'foo');
                 runner.trigger('renderitem');
 
-                setTimeout(function() {
-                    runner.trigger('unloaditem');
-                }, 10);
+                setTimeout(() => runner.trigger('unloaditem'), 10);
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, err.message);
                 ready();
             });
     });
 
-    QUnit.test('render a rubric block with links', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('render a rubric block with links', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(3);
 
-        runner.on('rubricblock', function() {
-            var $container = runner.getAreaBroker().getContainer();
+        runner.on('rubricblock', () => {
+            const $container = runner.getAreaBroker().getContainer();
 
             assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
             assert.equal($('#qti-rubrics a', $container).length, 1, 'The link is in the rubric block');
@@ -182,28 +177,28 @@ define([
         plugin
             .init()
             .then(plugin.render())
-            .then(function() {
+            .then(() => {
                 runner.setTestContext({
-                    rubrics: '<p><a href="http//taotesting.com">foo</a></p>'
+                    rubrics: '<p><a href="http://taotesting.com">foo</a></p>'
                 });
                 runner.trigger('loaditem', 'foo');
                 runner.trigger('renderitem');
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, err.message);
                 ready();
             });
     });
 
-    QUnit.test('render a rubric block with math', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('render a rubric block with math', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(4);
 
-        runner.on('rubricblock', function() {
-            var $container = runner.getAreaBroker().getContainer();
+        runner.on('rubricblock', () => {
+            const $container = runner.getAreaBroker().getContainer();
 
             assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
 
@@ -223,7 +218,7 @@ define([
         plugin
             .init()
             .then(plugin.render())
-            .then(function() {
+            .then(() => {
                 runner.setTestContext({
                     rubrics:
                         '<div><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mi>Δ</mi><mo>=</mo><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mrow><mn>4</mn><mo>⁢</mo><mi>a</mi><mo>⁢</mo><mi>c</mi></mrow></mro</math></div>'
@@ -231,7 +226,7 @@ define([
                 runner.trigger('loaditem', 'foo');
                 runner.trigger('renderitem');
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, err.message);
                 ready();
             });

--- a/test/plugins/content/rubricBlock/test.js
+++ b/test/plugins/content/rubricBlock/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -87,7 +87,7 @@ define([
     });
 
     QUnit.module('load rubric blocks', {
-        beforeEach: () => {
+        beforeEach() {
             mathJaxMock.called = false;
         }
     });

--- a/test/plugins/content/rubricBlock/test.js
+++ b/test/plugins/content/rubricBlock/test.js
@@ -34,6 +34,16 @@ define([
     runnerFactory.registerProvider(providerName, providerMock());
 
     /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner() {
+        const runner = runnerFactory(providerName);
+        runner.getDataHolder();
+        return Promise.resolve(runner);
+    }
+
+    /**
      * The following tests applies to all plugins
      */
     QUnit.module('pluginFactory');
@@ -84,151 +94,175 @@ define([
 
     QUnit.test('render a rubric block', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        getTestRunner()
+            .then(runner => new Promise((resolve, reject) => {
+                const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-        assert.expect(2);
+                assert.expect(2);
 
-        runner.on('rubricblock', () => {
-            const $container = runner.getAreaBroker().getContainer();
+                runner.on('rubricblock', () => {
+                    const $container = runner.getAreaBroker().getContainer();
 
-            assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
-            assert.equal($('#qti-rubrics', $container).html(), '<p>foo</p>', 'The rubric blocks content is loaded');
-            ready();
-        });
-
-        plugin
-            .init()
-            .then(plugin.render())
-            .then(() => {
-                runner.setTestContext({
-                    rubrics: '<p>foo</p>'
+                    assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
+                    assert.equal($('#qti-rubrics', $container).html(), '<p>foo</p>', 'The rubric blocks content is loaded');
+                    resolve();
                 });
-                runner.trigger('loaditem', 'foo');
-                runner.trigger('renderitem');
-            })
+
+                plugin
+                    .init()
+                    .then(plugin.render())
+                    .then(() => {
+                        runner.setTestContext({
+                            rubrics: '<p>foo</p>'
+                        });
+                        runner.trigger('loaditem', 'foo');
+                        runner.trigger('renderitem');
+                    })
+                    .catch(reject);
+            }))
             .catch(err => {
-                assert.ok(false, err.message);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('load / unload a rubric block', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        getTestRunner()
+            .then(runner => new Promise((resolve, reject) => {
+                const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-        assert.expect(4);
+                assert.expect(4);
 
-        runner
-            .after('renderitem', () => {
-                const $container = runner.getAreaBroker().getContainer();
+                runner
+                    .after('renderitem', () => {
+                        const $container = runner.getAreaBroker().getContainer();
 
-                assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
-                assert.equal(
-                    $('#qti-rubrics', $container).children().length,
-                    1,
-                    'The rubric block element contains an child'
-                );
-            })
-            .after('unloaditem', () => {
-                const $container = runner.getAreaBroker().getContainer();
+                        assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
+                        assert.equal(
+                            $('#qti-rubrics', $container).children().length,
+                            1,
+                            'The rubric block element contains an child'
+                        );
+                    })
+                    .after('unloaditem', () => {
+                        const $container = runner.getAreaBroker().getContainer();
 
-                assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
-                assert.equal($('#qti-rubrics', $container).children().length, 0, 'The rubric block element is empty');
+                        assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric block element is created');
+                        assert.equal($('#qti-rubrics', $container).children().length, 0, 'The rubric block element is empty');
 
-                ready();
-            });
+                        resolve();
+                    });
 
-        plugin
-            .init()
-            .then(plugin.render())
-            .then(() => {
-                runner.setTestContext({
-                    rubrics: '<p>foo</p>'
-                });
-                runner.trigger('loaditem', 'foo');
-                runner.trigger('renderitem');
+                plugin
+                    .init()
+                    .then(plugin.render())
+                    .then(() => {
+                        runner.setTestContext({
+                            rubrics: '<p>foo</p>'
+                        });
+                        runner.trigger('loaditem', 'foo');
+                        runner.trigger('renderitem');
 
-                setTimeout(() => runner.trigger('unloaditem'), 10);
-            })
+                        setTimeout(() => runner.trigger('unloaditem'), 10);
+                    })
+                    .catch(reject);
+            }))
             .catch(err => {
-                assert.ok(false, err.message);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('render a rubric block with links', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        getTestRunner()
+            .then(runner => new Promise((resolve, reject) => {
+                const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-        assert.expect(3);
+                assert.expect(3);
 
-        runner.on('rubricblock', () => {
-            const $container = runner.getAreaBroker().getContainer();
+                runner.on('rubricblock', () => {
+                    const $container = runner.getAreaBroker().getContainer();
 
-            assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
-            assert.equal($('#qti-rubrics a', $container).length, 1, 'The link is in the rubric block');
-            assert.equal($('#qti-rubrics a', $container).attr('target'), '_blank', 'The link has now a _blank target');
-            ready();
-        });
-
-        plugin
-            .init()
-            .then(plugin.render())
-            .then(() => {
-                runner.setTestContext({
-                    rubrics: '<p><a href="http://taotesting.com">foo</a></p>'
+                    assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
+                    assert.equal($('#qti-rubrics a', $container).length, 1, 'The link is in the rubric block');
+                    assert.equal($('#qti-rubrics a', $container).attr('target'), '_blank', 'The link has now a _blank target');
+                    resolve();
                 });
-                runner.trigger('loaditem', 'foo');
-                runner.trigger('renderitem');
-            })
+
+                plugin
+                    .init()
+                    .then(plugin.render())
+                    .then(() => {
+                        runner.setTestContext({
+                            rubrics: '<p><a href="http://taotesting.com">foo</a></p>'
+                        });
+                        runner.trigger('loaditem', 'foo');
+                        runner.trigger('renderitem');
+                    })
+                    .catch(reject);
+            }))
             .catch(err => {
-                assert.ok(false, err.message);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('render a rubric block with math', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        getTestRunner()
+            .then(runner => new Promise((resolve, reject) => {
+                const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-        assert.expect(4);
+                assert.expect(4);
 
-        runner.on('rubricblock', () => {
-            const $container = runner.getAreaBroker().getContainer();
+                runner.on('rubricblock', () => {
+                    const $container = runner.getAreaBroker().getContainer();
 
-            assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
+                    assert.equal($('#qti-rubrics', $container).length, 1, 'The rubric blocks element is created');
 
-            //Mathjax is mocked, so we don\'t assert the transformation
-            assert.equal(
-                $('#qti-rubrics', $container).find('math').length,
-                1,
-                'The rubric blocks element contains a math element'
-            );
-            assert.ok(mathJaxMock.called, 'The mathJax mock has been called');
+                    //Mathjax is mocked, so we don\'t assert the transformation
+                    assert.equal(
+                        $('#qti-rubrics', $container).find('math').length,
+                        1,
+                        'The rubric blocks element contains a math element'
+                    );
+                    assert.ok(mathJaxMock.called, 'The mathJax mock has been called');
 
-            ready();
-        });
-
-        assert.ok(mathJaxMock.called === false, 'The mathJax mock has not been called');
-
-        plugin
-            .init()
-            .then(plugin.render())
-            .then(() => {
-                runner.setTestContext({
-                    rubrics:
-                        '<div><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mi>Δ</mi><mo>=</mo><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mrow><mn>4</mn><mo>⁢</mo><mi>a</mi><mo>⁢</mo><mi>c</mi></mrow></mro</math></div>'
+                    resolve();
                 });
-                runner.trigger('loaditem', 'foo');
-                runner.trigger('renderitem');
-            })
+
+                assert.ok(mathJaxMock.called === false, 'The mathJax mock has not been called');
+
+                plugin
+                    .init()
+                    .then(plugin.render())
+                    .then(() => {
+                        runner.setTestContext({
+                            rubrics:
+                                '<div><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mi>Δ</mi><mo>=</mo><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mrow><mn>4</mn><mo>⁢</mo><mi>a</mi><mo>⁢</mo><mi>c</mi></mrow></mro</math></div>'
+                        });
+                        runner.trigger('loaditem', 'foo');
+                        runner.trigger('renderitem');
+                    })
+                    .catch(reject);
+            }))
             .catch(err => {
-                assert.ok(false, err.message);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 });

--- a/test/plugins/controls/duration/test.js
+++ b/test/plugins/controls/duration/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA
  */
 
 define([
@@ -59,6 +59,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/controls/duration/test.js
+++ b/test/plugins/controls/duration/test.js
@@ -22,7 +22,7 @@ define([
     'taoQtiTest/runner/plugins/controls/duration/duration',
     'core/polling',
     'taoTests/runner/proxy',
-    'taoQtiTest/test/runner/mocks/proxyMock',
+    'taoQtiTest/test/runner/mocks/proxyMock'
 ], function (runnerFactory, providerMock, pluginFactory, pollingFactory, proxyFactory, providerProxyMock) {
     'use strict';
 
@@ -32,7 +32,7 @@ define([
 
     const sampleTestContext = {
         itemIdentifier: 'item-1',
-        attempt: 1,
+        attempt: 1
     };
 
     const sampleTestMap = {
@@ -56,6 +56,18 @@ define([
             position: 0
         }]
     };
+
+    /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner(config) {
+        const runner = runnerFactory(providerName, [], config);
+        runner.getDataHolder();
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+        return Promise.resolve(runner);
+    }
 
     /**
      * Generic tests
@@ -111,84 +123,83 @@ define([
 
     QUnit.module('Plugin init');
 
-    QUnit.test('tick', function (assert) {
+    QUnit.test('tick', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner);
-        const itemAttemptId = `${sampleTestContext.itemIdentifier}#${sampleTestContext.attempt}`;
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
+                const itemAttemptId = `${sampleTestContext.itemIdentifier}#${sampleTestContext.attempt}`;
 
-        assert.expect(1);
+                assert.expect(1);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                return plugin
+                    .init()
+                    .then(() => {
+                        runner.trigger('renderitem');
 
-        plugin
-            .init()
-            .then(() => {
-                runner.trigger('renderitem');
+                        return runner.getPluginStore('duration');
+                    })
+                    .then(durationStore => new Promise(resolve => {
+                        runner.trigger('tick', 10000);
 
-                runner.getPluginStore('duration').then((durationStore) => {
-                    runner.trigger('tick', 10000);
-
-                    // add timeout to make sure that store has been updated
-                    setTimeout(
-                        () => {
+                        // add timeout to make sure that store has been updated
+                        setTimeout(() => {
                             durationStore.getItem(itemAttemptId).then((duration) => {
                                 assert.equal(duration, 10, 'the plugin updates duration every tick');
 
-                                ready();
+                                resolve();
                             });
-                        },
-                        1000
-                    );
+                        }, 100);
+                    }));
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
                 });
             })
-            .catch((err) => {
-                assert.ok(false, `Unexpected error: ${err}`);
-                ready();
-            });
+            .then(ready);
     });
 
-    QUnit.test('plugin-get.duration', function (assert) {
+    QUnit.test('plugin-get.duration', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner);
-        const itemAttemptId = `${sampleTestContext.itemIdentifier}#${sampleTestContext.attempt}`;
+        getTestRunner()
+            .then(runner => new Promise(resolve => {
+                const plugin = pluginFactory(runner);
+                const itemAttemptId = `${sampleTestContext.itemIdentifier}#${sampleTestContext.attempt}`;
 
-        assert.expect(1);
+                assert.expect(1);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                const getDuration = durationPromise => {
+                    durationPromise.then((duration) => {
+                        assert.equal(duration, 10, 'the plugin handles plugin-get.duration event');
 
-        const getDuration = (durationPromise) => {
-            durationPromise.then((duration) => {
-                assert.equal(duration, 10, 'the plugin handles plugin-get.duration event');
+                        resolve();
+                    });
+                };
 
-                ready();
-            });
-        };
+                plugin
+                    .init()
+                    .then(() => {
+                        runner.trigger('renderitem');
 
-        plugin
-            .init()
-            .then(() => {
-                runner.trigger('renderitem');
+                        // add timeout to make sure that store has been updated
 
-                // add timeout to make sure that store has been updated
+                        runner.getPluginStore('duration').then(() => {
+                            runner.trigger('tick', 10000);
+                            setTimeout(() => {
+                                runner.trigger('plugin-get.duration', itemAttemptId, getDuration);
+                            }, 100);
+                        });
 
-                runner.getPluginStore('duration').then(() => {
-                    runner.trigger('tick', 10000);
-                    setTimeout(
-                        () => {
-                            runner.trigger('plugin-get.duration', itemAttemptId, getDuration);
-                        },
-                        100
-                    );
+                    });
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
                 });
-
             })
-            .catch((err) => {
-                assert.ok(false, `Unexpected error: ${err}`);
-                ready();
-            });
+            .then(ready);
     });
 });

--- a/test/plugins/controls/progressbar/plugin/test.js
+++ b/test/plugins/controls/progressbar/plugin/test.js
@@ -24,7 +24,7 @@ define([
 ], function(runnerFactory, providerMock, pluginFactory, testMap) {
     'use strict';
 
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     /**
@@ -32,8 +32,8 @@ define([
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.expect(3);
 
@@ -66,9 +66,9 @@ define([
             { title: 'enable' },
             { title: 'disable' }
         ])
-        .test('plugin API ', function(data, assert) {
-            var runner = runnerFactory(providerName);
-            var plugin = pluginFactory(runner);
+        .test('plugin API ', (data, assert) => {
+            const runner = runnerFactory(providerName);
+            const plugin = pluginFactory(runner);
             assert.expect(1);
             assert.equal(
                 typeof plugin[data.title],
@@ -82,9 +82,9 @@ define([
      */
     QUnit.module('Lifecycle');
 
-    QUnit.test('render/destroy', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
+    QUnit.test('render/destroy', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName),
             areaBroker = runner.getAreaBroker(),
             plugin = pluginFactory(runner, areaBroker, {}),
             $container = areaBroker.getControlArea();
@@ -101,13 +101,13 @@ define([
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
 
                 assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
 
                 // Plugin rendering
-                return plugin.render().then(function() {
+                return plugin.render().then(() => {
                     assert.equal(
                         $container.find('.progress-box').length,
                         1,
@@ -115,22 +115,22 @@ define([
                     );
 
                     // Plugin destroying
-                    return plugin.destroy().then(function() {
+                    return plugin.destroy().then(() => {
                         assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
 
                         ready();
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('show/hide', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
+    QUnit.test('show/hide', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName),
             areaBroker = runner.getAreaBroker(),
             plugin = pluginFactory(runner, areaBroker),
             $container = areaBroker.getControlArea();
@@ -147,13 +147,13 @@ define([
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
 
                 assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
 
                 // Plugin rendering
-                return plugin.render().then(function() {
+                return plugin.render().then(() => {
                     assert.equal(
                         $container.find('.progress-box').length,
                         1,
@@ -161,10 +161,10 @@ define([
                     );
                     assert.equal($container.find('.progress-box:visible').length, 1, 'The plugin is visible');
 
-                    return plugin.hide().then(function() {
+                    return plugin.hide().then(() => {
                         assert.equal($container.find('.progress-box:visible').length, 0, 'The plugin is now hidden');
 
-                        return plugin.show().then(function() {
+                        return plugin.show().then(() => {
                             assert.equal(
                                 $container.find('.progress-box:visible').length,
                                 1,
@@ -172,7 +172,7 @@ define([
                             );
 
                             // Plugin destroying
-                            return plugin.destroy().then(function() {
+                            return plugin.destroy().then(() => {
                                 assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
 
                                 ready();
@@ -181,7 +181,7 @@ define([
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${err.message}`);
                 ready();
             });
@@ -189,9 +189,9 @@ define([
 
     QUnit.module('Options');
 
-    QUnit.test('hide on informational', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName, {}, {
+    QUnit.test('hide on informational', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName, {}, {
                 options : {
                     progressIndicator: {
                         type: 'questions'
@@ -214,13 +214,13 @@ define([
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
 
                 assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
 
                 // Plugin rendering
-                return plugin.render().then(function() {
+                return plugin.render().then(() => {
                     assert.equal(
                         $container.find('.progress-box').length,
                         1,
@@ -229,14 +229,14 @@ define([
                     assert.equal($container.find('.progress-box:visible').length, 0, 'The plugin is not visible');
 
                     // Plugin destroying
-                    return plugin.destroy().then(function() {
+                    return plugin.destroy().then(() => {
                         assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
 
                         ready();
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${err.message}`);
                 ready();
             });

--- a/test/plugins/controls/progressbar/plugin/test.js
+++ b/test/plugins/controls/progressbar/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2018-2021 (original work) Open Assessment Technologies SA
  */
 
 define([
@@ -29,6 +29,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/controls/progressbar/plugin/test.js
+++ b/test/plugins/controls/progressbar/plugin/test.js
@@ -28,6 +28,16 @@ define([
     runnerFactory.registerProvider(providerName, providerMock());
 
     /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner(config) {
+        const runner = runnerFactory(providerName, [], config);
+        runner.getDataHolder();
+        return Promise.resolve(runner);
+    }
+
+    /**
      * Generic tests
      */
     QUnit.module('pluginFactory');
@@ -84,161 +94,178 @@ define([
 
     QUnit.test('render/destroy', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            plugin = pluginFactory(runner, areaBroker, {}),
-            $container = areaBroker.getControlArea();
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const plugin = pluginFactory(runner, areaBroker, {});
+                const $container = areaBroker.getControlArea();
 
-        assert.expect(4);
+                assert.expect(4);
 
-        runner.setTestContext({
-            itemPosition: 3,
-            testPartId: 'testPart-1',
-            sectionId: 'assessmentSection-1'
-        });
-
-        runner.setTestMap(testMap);
-
-        plugin
-            .init()
-            .then(() => {
-                assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
-
-                assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
-
-                // Plugin rendering
-                return plugin.render().then(() => {
-                    assert.equal(
-                        $container.find('.progress-box').length,
-                        1,
-                        'The plugin has been inserted in the right place'
-                    );
-
-                    // Plugin destroying
-                    return plugin.destroy().then(() => {
-                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
-
-                        ready();
-                    });
+                runner.setTestContext({
+                    itemPosition: 3,
+                    testPartId: 'testPart-1',
+                    sectionId: 'assessmentSection-1'
                 });
+
+                runner.setTestMap(testMap);
+
+                return plugin
+                    .init()
+                    .then(() => {
+                        assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
+
+                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
+
+                        // Plugin rendering
+                        return plugin.render();
+                    })
+                    .then(() => {
+                        assert.equal(
+                            $container.find('.progress-box').length,
+                            1,
+                            'The plugin has been inserted in the right place'
+                        );
+
+                        // Plugin destroying
+                        return plugin.destroy();
+                    })
+                    .then(() => {
+                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
+                    });
             })
             .catch(err => {
-                assert.ok(false, `Unexpected failure : ${err.message}`);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('show/hide', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            plugin = pluginFactory(runner, areaBroker),
-            $container = areaBroker.getControlArea();
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const plugin = pluginFactory(runner, areaBroker, {});
+                const $container = areaBroker.getControlArea();
 
-        assert.expect(7);
+                assert.expect(7);
 
-        runner.setTestContext({
-            itemPosition: 3,
-            testPartId: 'testPart-1',
-            sectionId: 'assessmentSection-1'
-        });
+                runner.setTestContext({
+                    itemPosition: 3,
+                    testPartId: 'testPart-1',
+                    sectionId: 'assessmentSection-1'
+                });
 
-        runner.setTestMap(testMap);
+                runner.setTestMap(testMap);
 
-        plugin
-            .init()
-            .then(() => {
-                assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
+                return plugin
+                    .init()
+                    .then(() => {
+                        assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
 
-                assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
+                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
 
-                // Plugin rendering
-                return plugin.render().then(() => {
-                    assert.equal(
-                        $container.find('.progress-box').length,
-                        1,
-                        'The plugin has been inserted in the right place'
-                    );
-                    assert.equal($container.find('.progress-box:visible').length, 1, 'The plugin is visible');
+                        // Plugin rendering
+                        return plugin.render();
+                    })
+                    .then(() => {
+                        assert.equal(
+                            $container.find('.progress-box').length,
+                            1,
+                            'The plugin has been inserted in the right place'
+                        );
+                        assert.equal($container.find('.progress-box:visible').length, 1, 'The plugin is visible');
 
-                    return plugin.hide().then(() => {
+                        return plugin.hide();
+                    })
+                    .then(() => {
                         assert.equal($container.find('.progress-box:visible').length, 0, 'The plugin is now hidden');
 
-                        return plugin.show().then(() => {
-                            assert.equal(
-                                $container.find('.progress-box:visible').length,
-                                1,
-                                'The plugin is now visible'
-                            );
+                        return plugin.show();
+                    })
+                    .then(() => {
+                        assert.equal(
+                            $container.find('.progress-box:visible').length,
+                            1,
+                            'The plugin is now visible'
+                        );
 
-                            // Plugin destroying
-                            return plugin.destroy().then(() => {
-                                assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
-
-                                ready();
-                            });
-                        });
+                        // Plugin destroying
+                        return plugin.destroy();
+                    })
+                    .then(() => {
+                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
                     });
-                });
             })
             .catch(err => {
-                assert.ok(false, `Unexpected failure : ${err.message}`);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.module('Options');
 
     QUnit.test('hide on informational', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName, {}, {
-                options : {
-                    progressIndicator: {
-                        type: 'questions'
-                    }
+        getTestRunner({
+            options : {
+                progressIndicator: {
+                    type: 'questions'
                 }
-            }),
-            areaBroker = runner.getAreaBroker(),
-            plugin = pluginFactory(runner, areaBroker),
-            $container = areaBroker.getControlArea();
+            }
+        })
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const plugin = pluginFactory(runner, areaBroker);
+                const $container = areaBroker.getControlArea();
 
-        assert.expect(5);
+                assert.expect(5);
 
-        runner.setTestContext({
-            itemPosition: 1,
-            testPartId: 'testPart-intro',
-            sectionId: 'assessmentSection-intro'
-        });
-
-        runner.setTestMap(testMap);
-
-        plugin
-            .init()
-            .then(() => {
-                assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
-
-                assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
-
-                // Plugin rendering
-                return plugin.render().then(() => {
-                    assert.equal(
-                        $container.find('.progress-box').length,
-                        1,
-                        'The plugin has been inserted in the right place'
-                    );
-                    assert.equal($container.find('.progress-box:visible').length, 0, 'The plugin is not visible');
-
-                    // Plugin destroying
-                    return plugin.destroy().then(() => {
-                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
-
-                        ready();
-                    });
+                runner.setTestContext({
+                    itemPosition: 1,
+                    testPartId: 'testPart-intro',
+                    sectionId: 'assessmentSection-intro'
                 });
+
+                runner.setTestMap(testMap);
+
+                return plugin
+                    .init()
+                    .then(() => {
+                        assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
+
+                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has not been inserted yet');
+
+                        // Plugin rendering
+                        return plugin.render();
+                    })
+                    .then(() => {
+                        assert.equal(
+                            $container.find('.progress-box').length,
+                            1,
+                            'The plugin has been inserted in the right place'
+                        );
+                        assert.equal($container.find('.progress-box:visible').length, 0, 'The plugin is not visible');
+
+                        // Plugin destroying
+                        return plugin.destroy();
+                    })
+                    .then(() => {
+                        assert.equal($container.find('.progress-box').length, 0, 'The plugin has been removed');
+                    });
             })
             .catch(err => {
-                assert.ok(false, `Unexpected failure : ${err.message}`);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 });

--- a/test/plugins/controls/timer/plugin/test.js
+++ b/test/plugins/controls/timer/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Anton Tsymuk <anton@taotesting.com>
@@ -54,6 +54,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {
@@ -326,7 +327,7 @@ define([
                                     resolve();
                                 })
                                 .catch(reject);
-                        }, 50)
+                        }, 50);
                     }));
             })
             .catch(err => {

--- a/test/plugins/controls/title/test.js
+++ b/test/plugins/controls/title/test.js
@@ -33,26 +33,26 @@ define([
     const titles = {
         test: {
             attribute: 'qti-test-title',
-            className: '',
+            className: ''
         },
         testPart: {
             attribute: 'qti-test-part-title',
-            className: 'visible-hidden',
+            className: 'visible-hidden'
         },
         section: {
             attribute: 'qti-test-position',
-            className: '',
+            className: ''
         },
         item: {
             attribute: 'qti-test-item-title',
-            className: 'visible-hidden',
-        },
+            className: 'visible-hidden'
+        }
     };
 
     const sampleTestContext = {
         itemIdentifier: 'item-1',
         itemPosition: 0,
-        isDeepestSectionVisible: true,
+        isDeepestSectionVisible: true
     };
     const sampleTestMap = {
         parts: {
@@ -68,14 +68,14 @@ define([
                         },
                         stats: {
                             questions: 1,
-                            answered: 0,
-                        },
+                            answered: 0
+                        }
                     }
                 },
                 stats: {
                     questions: 1,
-                    answered: 0,
-                },
+                    answered: 0
+                }
             }
         },
         jumps: [{
@@ -87,16 +87,28 @@ define([
         title: 'test-title',
         stats: {
             questions: 1,
-            answered: 0,
-        },
+            answered: 0
+        }
     };
+
+    /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner() {
+        const runner = runnerFactory(providerName);
+        runner.getDataHolder();
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+        return Promise.resolve(runner);
+    }
 
     /**
      * The following tests applies to all plugins
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', (assert) => {
+    QUnit.test('module', assert => {
         const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
@@ -109,21 +121,21 @@ define([
     });
 
     const pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
     ];
 
     QUnit.cases.init(pluginApi).test('plugin API ', (data, assert) => {
@@ -131,248 +143,276 @@ define([
         const plugin = pluginFactory(runner);
 
         assert.equal(
-            typeof plugin[data.name],
+            typeof plugin[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
-    QUnit.test('pluginFactory.init', (assert) => {
+    QUnit.test('pluginFactory.init', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner);
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
 
-        plugin
-            .init()
-            .then(() => {
-                assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
+                return plugin
+                    .init()
+                    .then(() => {
+                        assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
+                    });
             })
-            .catch((err) => {
-                assert.ok(false, `The init failed: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('pluginFactory.render', (assert) => {
+    QUnit.test('pluginFactory.render', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getControlArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getControlArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(9);
+                assert.expect(9);
 
-        plugin
-            .init()
-            .then(() => {
-                plugin.render();
+                return plugin
+                    .init()
+                    .then(() => {
+                        plugin.render();
 
-                _.forEach(_.values(titles), ({ attribute, className }) => {
-                    $container.find();
+                        _.forEach(_.values(titles), ({ attribute, className }) => {
+                            $container.find();
 
-                    assert.equal(
-                        $container.find(`${className ? `.${className}` : ''}[data-control="${attribute}"]`).length,
-                        1,
-                        'Add the title with the given css class to the container'
-                    );
-                    assert.equal(
-                        $container.find(`.visible-hidden[data-control="${attribute}-timer"]`).length,
-                        1,
-                        'Add the visible hidden title timer to the container'
-                    );
+                            assert.equal(
+                                $container.find(`${className ? `.${className}` : ''}[data-control="${attribute}"]`).length,
+                                1,
+                                'Add the title with the given css class to the container'
+                            );
+                            assert.equal(
+                                $container.find(`.visible-hidden[data-control="${attribute}-timer"]`).length,
+                                1,
+                                'Add the visible hidden title timer to the container'
+                            );
+                        });
+
+                        assert.equal(
+                            $container.find('.qti-controls').css('display'),
+                            'none',
+                            'Hide the titles by default'
+                        );
+                    });
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
                 });
-
-                assert.equal(
-                    $container.find('.qti-controls').css('display'),
-                    'none',
-                    'Hide the titles by default'
-                );
-
-                ready();
-            });
+            })
+            .then(ready);
     });
 
-    QUnit.test('test runner events: renderitem', (assert) => {
+    QUnit.test('test runner events: renderitem', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getControlArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getControlArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(4);
+                assert.expect(4);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                runner.getCurrentItem = () => ({});
+                runner.getCurrentPart = () => ({ label: 'part-title' });
 
-        runner.getCurrentItem = () => ({});
-        runner.getCurrentPart = () => ({ label: 'part-title' });
+                return plugin
+                    .init()
+                    .then(() => {
+                        plugin.render();
 
-        plugin
-            .init()
-            .then(() => {
-                plugin.render();
+                        return runner.trigger('renderitem');
+                    })
+                    .then(() => {
+                        assert.equal(
+                            $container.find('[data-control="qti-test-title"]').text(),
+                            'test-title',
+                            'Add test title'
+                        );
 
-                return runner.trigger('renderitem');
+                        assert.equal(
+                            $container.find('[data-control="qti-test-part-title"]').text(),
+                            ' - part-title',
+                            'Add part title'
+                        );
+
+                        assert.equal(
+                            $container.find('[data-control="qti-test-position"]').text(),
+                            ' - section-title',
+                            'Add section title'
+                        );
+
+                        assert.equal(
+                            $container.find('[data-control="qti-test-item-title"]').text(),
+                            ' - item-title',
+                            'Add item title'
+                        );
+                    });
             })
-            .then(() => {
-                assert.equal(
-                    $container.find('[data-control="qti-test-title"]').text(),
-                    'test-title',
-                    'Add test title'
-                );
-
-                assert.equal(
-                    $container.find('[data-control="qti-test-part-title"]').text(),
-                    ' - part-title',
-                    'Add part title'
-                );
-
-                assert.equal(
-                    $container.find('[data-control="qti-test-position"]').text(),
-                    ' - section-title',
-                    'Add section title'
-                );
-
-                assert.equal(
-                    $container.find('[data-control="qti-test-item-title"]').text(),
-                    ' - item-title',
-                    'Add item title'
-                );
-
-                ready();
-            });
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
-    QUnit.test('test runner events: unloaditem', (assert) => {
+    QUnit.test('test runner events: unloaditem', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getControlArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getControlArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(1);
+                assert.expect(1);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                runner.getCurrentItem = () => ({});
+                runner.getCurrentPart = () => ({ label: 'part-title' });
 
-        runner.getCurrentItem = () => ({});
-        runner.getCurrentPart = () => ({ label: 'part-title' });
+                return plugin
+                    .init()
+                    .then(() => {
+                        plugin.render();
 
-        plugin
-            .init()
-            .then(() => {
-                plugin.render();
-
-                return runner.trigger('renderitem');
+                        return runner.trigger('renderitem');
+                    })
+                    .then(() => runner.trigger('unloaditem'))
+                    .then(() => {
+                        assert.equal(
+                            $container.find('.qti-controls').css('display'),
+                            'none',
+                            'Hide the titles after unloaditem'
+                        );
+                    });
             })
-            .then(() => runner.trigger('unloaditem'))
-            .then(() => {
-                assert.equal(
-                    $container.find('.qti-controls').css('display'),
-                    'none',
-                    'Hide the titles after unloaditem'
-                );
-
-                ready();
-            });
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
-    QUnit.test('test runner events: timertick', (assert) => {
+    QUnit.test('test runner events: timertick', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getControlArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getControlArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(5);
+                assert.expect(5);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                runner.getCurrentItem = () => ({});
+                runner.getCurrentPart = () => ({ label: 'part-title' });
 
-        runner.getCurrentItem = () => ({});
-        runner.getCurrentPart = () => ({ label: 'part-title' });
+                return plugin
+                    .init()
+                    .then(() => {
+                        plugin.render();
 
-        plugin
-            .init()
-            .then(() => {
-                plugin.render();
+                        return runner.trigger('renderitem');
+                    })
+                    .then(() => {
+                        runner.trigger('timertick', 60000, 'test');
+                        assert.equal(
+                            $container.find('[data-control="qti-test-title-timer"]').text(),
+                            '1 minutes to answer remaining 1 question',
+                            'Update test timer'
+                        );
 
-                return runner.trigger('renderitem');
+                        runner.trigger('timertick', 60000, 'testPart');
+                        assert.equal(
+                            $container.find('[data-control="qti-test-part-title-timer"]').text(),
+                            '1 minutes to answer remaining 1 question',
+                            'Update part timer'
+                        );
+
+                        runner.trigger('timertick', 60000, 'section');
+                        assert.equal(
+                            $container.find('[data-control="qti-test-position-timer"]').text(),
+                            '1 minutes to answer remaining 1 question',
+                            'Update section timer'
+                        );
+
+                        runner.trigger('timertick', 60000, 'item');
+                        assert.equal(
+                            $container.find('[data-control="qti-test-item-title-timer"]').text(),
+                            '1 minutes to answer the current question',
+                            'Update item timer'
+                        );
+
+                        const headingBeforeTimertick = $container.find('.title-box').text();
+                        runner.trigger('timertick', 60000, 'wrongscope');
+                        assert.equal(
+                            $container.find('.title-box').text(),
+                            headingBeforeTimertick,
+                            'Heading is not update if scope unknown'
+                        );
+                    });
             })
-            .then(() => {
-                runner.trigger('timertick', 60000, 'test');
-                assert.equal(
-                    $container.find('[data-control="qti-test-title-timer"]').text(),
-                    '1 minutes to answer remaining 1 question',
-                    'Update test timer'
-                );
-
-                runner.trigger('timertick', 60000, 'testPart');
-                assert.equal(
-                    $container.find('[data-control="qti-test-part-title-timer"]').text(),
-                    '1 minutes to answer remaining 1 question',
-                    'Update part timer'
-                );
-
-                runner.trigger('timertick', 60000, 'section');
-                assert.equal(
-                    $container.find('[data-control="qti-test-position-timer"]').text(),
-                    '1 minutes to answer remaining 1 question',
-                    'Update section timer'
-                );
-
-                runner.trigger('timertick', 60000, 'item');
-                assert.equal(
-                    $container.find('[data-control="qti-test-item-title-timer"]').text(),
-                    '1 minutes to answer the current question',
-                    'Update item timer'
-                );
-
-                const headingBeforeTimertick = $container.find('.title-box').text();
-                runner.trigger('timertick', 60000, 'wrongscope');
-                assert.equal(
-                    $container.find('.title-box').text(),
-                    headingBeforeTimertick,
-                    'Heading is not update if scope unknown'
-                );
-
-                ready();
-            });
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
-    QUnit.test('test runner events: timertick', (assert) => {
+    QUnit.test('test runner events: timertick', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getControlArea();
-        const plugin = pluginFactory(runner, areaBroker);
-        const $playground = $('#title-playground-container');
-        $playground.append($container);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getControlArea();
+                const plugin = pluginFactory(runner, areaBroker);
+                const $playground = $('#title-playground-container');
+                $playground.append($container);
 
-        assert.expect(1);
+                assert.expect(1);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                runner.getCurrentItem = () => ({});
+                runner.getCurrentPart = () => ({ label: 'part-title' });
 
-        runner.getCurrentItem = () => ({});
-        runner.getCurrentPart = () => ({ label: 'part-title' });
+                return plugin
+                    .init()
+                    .then(() => {
+                        plugin.render();
 
-        plugin
-            .init()
-            .then(() => {
-                plugin.render();
+                        return runner.trigger('renderitem');
+                    })
+                    .then(() => {
+                        runner.trigger('timertick', 60000, 'test');
+                        runner.trigger('timertick', 60000, 'testPart');
+                        runner.trigger('timertick', 60000, 'section');
+                        runner.trigger('timertick', 60000, 'item');
 
-                return runner.trigger('renderitem');
+                        assert.ok('Playground ready');
+                    });
             })
-            .then(() => {
-                runner.trigger('timertick', 60000, 'test');
-                runner.trigger('timertick', 60000, 'testPart');
-                runner.trigger('timertick', 60000, 'section');
-                runner.trigger('timertick', 60000, 'item');
-
-                assert.ok('Playground ready');
-
-                ready();
-            });
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 });

--- a/test/plugins/controls/title/test.js
+++ b/test/plugins/controls/title/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Anton Tsymuk <anton@taotesting.com>

--- a/test/plugins/navigation/allowSkipping/test.js
+++ b/test/plugins/navigation/allowSkipping/test.js
@@ -61,73 +61,28 @@ define([
     });
 
     QUnit.cases.init([
-        {
-            name: 'init',
-            title: 'init'
-        },
-        {
-            name: 'render',
-            title: 'render'
-        },
-        {
-            name: 'finish',
-            title: 'finish'
-        },
-        {
-            name: 'destroy',
-            title: 'destroy'
-        },
-        {
-            name: 'trigger',
-            title: 'trigger'
-        },
-        {
-            name: 'getTestRunner',
-            title: 'getTestRunner'
-        },
-        {
-            name: 'getAreaBroker',
-            title: 'getAreaBroker'
-        },
-        {
-            name: 'getConfig',
-            title: 'getConfig'
-        },
-        {
-            name: 'setConfig',
-            title: 'setConfig'
-        },
-        {
-            name: 'getState',
-            title: 'getState'
-        },
-        {
-            name: 'setState',
-            title: 'setState'
-        },
-        {
-            name: 'show',
-            title: 'show'
-        },
-        {
-            name: 'hide',
-            title: 'hide'
-        },
-        {
-            name: 'enable',
-            title: 'enable'
-        },
-        {
-            name: 'disable',
-            title: 'disable'
-        }
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
     ]).test('plugin API ', (data, assert) => {
         const runner = runnerFactory(providerName);
         const timer = pluginFactory(runner);
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 

--- a/test/plugins/navigation/allowSkipping/test.js
+++ b/test/plugins/navigation/allowSkipping/test.js
@@ -34,6 +34,16 @@ define([
     currentItemHelper.getDeclarations = testRunner => testRunner.responses;
 
     /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner(config) {
+        const runner = runnerFactory(providerName, [], config);
+        runner.getDataHolder();
+        return Promise.resolve(runner);
+    }
+
+    /**
      * The following tests applies to all plugins
      */
     QUnit.module('pluginFactory');
@@ -177,33 +187,38 @@ define([
         ])
         .test('Moving is allowed ', (data, assert) => {
             const ready = assert.async();
-            const runner = runnerFactory(providerName, {
+            getTestRunner({
                 options: data.options
-            });
-            const plugin = pluginFactory(runner, runner.getAreaBroker());
+            })
+                .then(runner => {
+                    const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-            runner.getCurrentItem = () => ({ allowSkipping: data.allowSkipping });
+                    runner.getCurrentItem = () => ({ allowSkipping: data.allowSkipping });
 
-            assert.expect(1);
+                    assert.expect(1);
 
-            plugin
-                .init()
-                .then(() => {
-                    runner.setTestContext(data.context);
-                    runner.answered = data.answered;
-                    runner.responses = data.responses;
+                    return plugin
+                        .init()
+                        .then(() => new Promise(resolve => {
+                            runner.setTestContext(data.context);
+                            runner.answered = data.answered;
+                            runner.responses = data.responses;
 
-                    runner.on('move', () => {
-                        assert.ok(true, 'Move is allowed');
-                        ready();
-                        return Promise.reject();
-                    });
-                    runner.trigger('move');
+                            runner.on('move', () => {
+                                assert.ok(true, 'Move is allowed');
+                                resolve();
+                                return Promise.reject();
+                            });
+                            runner.trigger('move');
+                        }));
                 })
                 .catch(err => {
-                    assert.ok(false, err.message);
-                    ready();
-                });
+                    assert.pushResult({
+                        result: false,
+                        message: err
+                    });
+                })
+                .then(ready);
         });
 
     QUnit.cases
@@ -223,47 +238,51 @@ define([
         ])
         .test('Moving is prevented ', (data, assert) => {
             const ready = assert.async();
-
-            const runner = runnerFactory(providerName, {}, {
+            getTestRunner({
                 options: data.options
-            });
-            const plugin = pluginFactory(runner, runner.getAreaBroker());
+            })
+                .then(runner => {
+                    const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-            runner.getCurrentItem = () => ({
-                allowSkipping: data.allowSkipping,
-                answered: data.answered
-            });
-
-            assert.expect(2);
-
-            plugin
-                .init()
-                .then(() => {
-                    runner.setTestContext(data.context);
-                    runner.answered = data.answered;
-                    runner.responses = data.responses;
-
-                    runner.on('move', () => {
-                        assert.ok(false, 'Move is denied');
-                        ready();
+                    runner.getCurrentItem = () => ({
+                        allowSkipping: data.allowSkipping,
+                        answered: data.answered
                     });
-                    runner.off('alert.notallowed').on('alert.notallowed', (message, cb) => {
-                        assert.equal(
-                            message,
-                            'A response to this item is required.',
-                            'The user receive the correct message'
-                        );
-                        cb();
-                    });
-                    runner.on('resumeitem', () => {
-                        assert.ok(true, 'Move has been prevented');
-                        ready();
-                    });
-                    runner.trigger('move');
+
+                    assert.expect(2);
+
+                    return plugin
+                        .init()
+                        .then(() => new Promise((resolve, reject) => {
+                            runner.setTestContext(data.context);
+                            runner.answered = data.answered;
+                            runner.responses = data.responses;
+
+                            runner.on('move', () => {
+                                assert.ok(false, 'Move is denied');
+                                reject();
+                            });
+                            runner.off('alert.notallowed').on('alert.notallowed', (message, cb) => {
+                                assert.equal(
+                                    message,
+                                    'A response to this item is required.',
+                                    'The user receive the correct message'
+                                );
+                                cb();
+                            });
+                            runner.on('resumeitem', () => {
+                                assert.ok(true, 'Move has been prevented');
+                                resolve();
+                            });
+                            runner.trigger('move');
+                        }));
                 })
                 .catch(err => {
-                    assert.ok(false, err.message);
-                    ready();
-                });
+                    assert.pushResult({
+                        result: false,
+                        message: err
+                    });
+                })
+                .then(ready);
         });
 });

--- a/test/plugins/navigation/allowSkipping/test.js
+++ b/test/plugins/navigation/allowSkipping/test.js
@@ -21,30 +21,25 @@ define([
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/runner/plugins/navigation/allowSkipping',
     'taoQtiTest/runner/helpers/currentItem'
-], function(runnerFactory, providerMock, pluginFactory, currentItemHelper) {
+], function (runnerFactory, providerMock, pluginFactory, currentItemHelper) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     //Mock the isAnswered helper, using testRunner property
-    currentItemHelper.isAnswered = function(testRunner) {
-        return testRunner.answered;
-    };
+    currentItemHelper.isAnswered = testRunner => testRunner.answered;
 
     //Mock the getDeclarations helper, using testRunner property
-    currentItemHelper.getDeclarations = function(testRunner) {
-        return testRunner.responses;
-    };
+    currentItemHelper.getDeclarations = testRunner => testRunner.responses;
 
     /**
      * The following tests applies to all plugins
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
         assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
@@ -55,7 +50,7 @@ define([
         );
     });
 
-    pluginApi = [
+    QUnit.cases.init([
         {
             name: 'init',
             title: 'init'
@@ -116,15 +111,13 @@ define([
             name: 'disable',
             title: 'disable'
         }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var runner = runnerFactory(providerName);
-        var timer = pluginFactory(runner);
+    ]).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const timer = pluginFactory(runner);
         assert.equal(
             typeof timer[data.name],
             'function',
-            `The pluginFactory instances expose a "${  data.name  }" function`
+            `The pluginFactory instances expose a "${data.name}" function`
         );
     });
 
@@ -137,7 +130,7 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableAllowSkipping: false
                 },
                 allowSkipping: false,
@@ -149,7 +142,7 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableAllowSkipping: true
                 },
                 allowSkipping: false,
@@ -162,7 +155,7 @@ define([
                     itemIdentifier: 'item-1',
                     allowSkipping: true
                 },
-                options : {
+                options: {
                     enableAllowSkipping: true
                 },
                 allowSkipping: true,
@@ -172,9 +165,9 @@ define([
             {
                 title: 'when the item is answered',
                 context: {
-                    itemIdentifier: 'item-1',
+                    itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableAllowSkipping: true
                 },
                 allowSkipping: false,
@@ -182,32 +175,32 @@ define([
                 responses: ['foo']
             }
         ])
-        .test('Moving is allowed ', function(data, assert) {
+        .test('Moving is allowed ', (data, assert) => {
             const ready = assert.async();
             const runner = runnerFactory(providerName, {
-                options : data.options
+                options: data.options
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-            runner.getCurrentItem = () => ({ allowSkipping : data.allowSkipping });
+            runner.getCurrentItem = () => ({ allowSkipping: data.allowSkipping });
 
             assert.expect(1);
 
             plugin
                 .init()
-                .then(function() {
+                .then(() => {
                     runner.setTestContext(data.context);
                     runner.answered = data.answered;
                     runner.responses = data.responses;
 
-                    runner.on('move', function() {
+                    runner.on('move', () => {
                         assert.ok(true, 'Move is allowed');
                         ready();
                         return Promise.reject();
                     });
                     runner.trigger('move');
                 })
-                .catch(function(err) {
+                .catch(err => {
                     assert.ok(false, err.message);
                     ready();
                 });
@@ -218,9 +211,9 @@ define([
             {
                 title: 'when the item not answered',
                 context: {
-                    itemIdentifier: 'item-1',
+                    itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableAllowSkipping: true
                 },
                 allowSkipping: false,
@@ -237,24 +230,24 @@ define([
             const plugin = pluginFactory(runner, runner.getAreaBroker());
 
             runner.getCurrentItem = () => ({
-                allowSkipping : data.allowSkipping,
-                answered : data.answered
+                allowSkipping: data.allowSkipping,
+                answered: data.answered
             });
 
             assert.expect(2);
 
             plugin
                 .init()
-                .then(function() {
+                .then(() => {
                     runner.setTestContext(data.context);
                     runner.answered = data.answered;
                     runner.responses = data.responses;
 
-                    runner.on('move', function() {
+                    runner.on('move', () => {
                         assert.ok(false, 'Move is denied');
                         ready();
                     });
-                    runner.off('alert.notallowed').on('alert.notallowed', function(message, cb) {
+                    runner.off('alert.notallowed').on('alert.notallowed', (message, cb) => {
                         assert.equal(
                             message,
                             'A response to this item is required.',
@@ -262,13 +255,13 @@ define([
                         );
                         cb();
                     });
-                    runner.on('resumeitem', function() {
+                    runner.on('resumeitem', () => {
                         assert.ok(true, 'Move has been prevented');
                         ready();
                     });
                     runner.trigger('move');
                 })
-                .catch(function(err) {
+                .catch(err => {
                     assert.ok(false, err.message);
                     ready();
                 });

--- a/test/plugins/navigation/allowSkipping/test.js
+++ b/test/plugins/navigation/allowSkipping/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 
 define([
@@ -35,6 +35,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/navigation/next/linearNextItemWarning/test.js
+++ b/test/plugins/navigation/next/linearNextItemWarning/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2019-2021 (original work) Open Assessment Technologies SA ;
  */
 
 define([
@@ -28,6 +28,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {
@@ -68,7 +69,8 @@ define([
         { title: 'show' },
         { title: 'hide' },
         { title: 'enable' },
-        { title: 'disable' }]).test('plugin API ', (data, assert) => {
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
         assert.expect(1);
         const runner = runnerFactory(providerName);
         const timer = pluginFactory(runner);
@@ -236,9 +238,9 @@ define([
                 const plugin = pluginFactory(runner, runner.getAreaBroker());
 
                 // mock test store init
-                runner.getTestStore = () => {
+                runner.getTestStore = function getTestStore() {
                     return {
-                        setVolatile: () => {
+                        setVolatile() {
                         }
                     };
                 };
@@ -324,12 +326,12 @@ define([
                 const plugin = pluginFactory(runner, runner.getAreaBroker());
 
                 // mock test store init
-                runner.getTestStore = () => {
+                runner.getTestStore = function getTestStore() {
                     return {
-                        getStore: () => {
+                        getStore() {
                             return Promise.reject();
                         },
-                        setVolatile: () => {
+                        setVolatile() {
                         }
                     };
                 };

--- a/test/plugins/navigation/next/linearNextItemWarning/test.js
+++ b/test/plugins/navigation/next/linearNextItemWarning/test.js
@@ -19,12 +19,11 @@
 define([
     'taoTests/runner/runner',
     'taoQtiTest/test/runner/mocks/providerMock',
-    'taoQtiTest/runner/plugins/navigation/next/linearNextItemWarning',
-], function(runnerFactory, providerMock, pluginFactory) {
+    'taoQtiTest/runner/plugins/navigation/next/linearNextItemWarning'
+], function (runnerFactory, providerMock, pluginFactory) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     /**
@@ -32,7 +31,7 @@ define([
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', assert => {
         assert.expect(3);
         const runner = runnerFactory(providerName);
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
@@ -44,61 +43,29 @@ define([
         );
     });
 
-    pluginApi = [{
-        name: 'init',
-        title: 'init'
-    }, {
-        name: 'render',
-        title: 'render'
-    }, {
-        name: 'finish',
-        title: 'finish'
-    }, {
-        name: 'destroy',
-        title: 'destroy'
-    }, {
-        name: 'trigger',
-        title: 'trigger'
-    }, {
-        name: 'getTestRunner',
-        title: 'getTestRunner'
-    }, {
-        name: 'getAreaBroker',
-        title: 'getAreaBroker'
-    }, {
-        name: 'getConfig',
-        title: 'getConfig'
-    }, {
-        name: 'setConfig',
-        title: 'setConfig'
-    }, {
-        name: 'getState',
-        title: 'getState'
-    }, {
-        name: 'setState',
-        title: 'setState'
-    }, {
-        name: 'show',
-        title: 'show'
-    }, {
-        name: 'hide',
-        title: 'hide'
-    }, {
-        name: 'enable',
-        title: 'enable'
-    }, {
-        name: 'disable',
-        title: 'disable'
-    }];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }]).test('plugin API ', (data, assert) => {
         assert.expect(1);
         const runner = runnerFactory(providerName);
         const timer = pluginFactory(runner);
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
@@ -108,7 +75,7 @@ define([
     QUnit.module('Behavior');
 
     const testMap = {
-        identifier: "Test",
+        identifier: 'Test',
         parts: {
             'Part1': {
                 id: 'Part1',
@@ -133,14 +100,14 @@ define([
             }
         },
         jumps: [{
-            identifier: "FirstItem",
-            section: "Section1",
-            part: "Part1",
+            identifier: 'FirstItem',
+            section: 'Section1',
+            part: 'Part1',
             position: 0
         }, {
-            identifier: "LastItem",
-            section: "Section1",
-            part: "Part1",
+            identifier: 'LastItem',
+            section: 'Section1',
+            part: 'Part1',
             position: 1
         }]
     };
@@ -160,7 +127,7 @@ define([
         item: {
             informational: false
         },
-        isLinear : true,
+        isLinear: true
 
     }, {
         title: 'when the next section warning is set',
@@ -176,7 +143,7 @@ define([
         item: {
             informational: false
         },
-        isLinear : true
+        isLinear: true
     }, {
         title: 'when the item is informational',
         testContext: {
@@ -190,7 +157,7 @@ define([
         item: {
             informational: true
         },
-        isLinear : true
+        isLinear: true
     }, {
         title: 'when the item is the last item',
         testContext: {
@@ -204,7 +171,7 @@ define([
         item: {
             informational: false
         },
-        isLinear : true
+        isLinear: true
     }, {
         title: 'when the config setting is undefined',
         testContext: {
@@ -218,7 +185,7 @@ define([
         item: {
             informational: false
         },
-        isLinear : true
+        isLinear: true
     }, {
         title: 'when the config setting is explicitly false',
         testContext: {
@@ -235,7 +202,7 @@ define([
         item: {
             informational: false
         },
-        isLinear : true
+        isLinear: true
     }, {
         title: 'when the test is not linear',
         testContext: {
@@ -249,43 +216,44 @@ define([
         item: {
             informational: false
         },
-        isLinear : false
-    }]).test('No dialog is triggered ', function(caseData, assert) {
+        isLinear: false
+    }]).test('No dialog is triggered ', (data, assert) => {
         const ready = assert.async();
         const runner = runnerFactory(providerName, {}, {
-            options : caseData.testConfig
+            options: data.testConfig
         });
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         // mock test store init
-        runner.getTestStore = function() {
+        runner.getTestStore = () => {
             return {
-                setVolatile: function() {}
+                setVolatile: () => {
+                }
             };
         };
-        runner.getCurrentItem = () => caseData.item;
+        runner.getCurrentItem = () => data.item;
         runner.getCurrentPart = () => Object.assign({
-            isLinear : caseData.isLinear
+            isLinear: data.isLinear
         }, testMap.part);
 
         assert.expect(1);
 
         plugin
             .init()
-            .then(function() {
-                runner.setTestContext(caseData.testContext);
+            .then(() => {
+                runner.setTestContext(data.testContext);
                 runner.setTestMap(testMap);
 
                 // dialog would be instantiated *before* move occurs
-                runner.on('move', function() {
+                runner.on('move', () => {
                     assert.ok(true, 'The move took place without interruption');
                     runner.destroy();
                     ready();
                     return Promise.reject();
                 });
-                runner.trigger('move', 'next', caseData.scope);
+                runner.trigger('move', 'next', data.scope);
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, err.message);
                 ready();
             });
@@ -309,7 +277,7 @@ define([
         item: {
             informational: false
         },
-        isLinear : true
+        isLinear: true
     }, {
         title: 'when a skip warning is needed',
         event: 'skip',
@@ -327,45 +295,46 @@ define([
         item: {
             informational: false
         },
-        isLinear : true
-    }]).test('Dialog will be triggered ', function(caseData, assert) {
+        isLinear: true
+    }]).test('Dialog will be triggered ', (data, assert) => {
         const ready = assert.async();
 
         const runner = runnerFactory(providerName, {}, {
-            options : caseData.testConfig
+            options: data.testConfig
         });
         const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         // mock test store init
-        runner.getTestStore = function() {
+        runner.getTestStore = () => {
             return {
-                getStore: function() {
+                getStore: () => {
                     return Promise.reject();
                 },
-                setVolatile: function() {}
+                setVolatile: () => {
+                }
             };
         };
-        runner.getCurrentItem = () => caseData.item;
+        runner.getCurrentItem = () => data.item;
         runner.getCurrentPart = () => Object.assign({
-            isLinear : caseData.isLinear
+            isLinear: data.isLinear
         }, testMap.part);
 
         assert.expect(1);
 
         plugin
             .init()
-            .then(function() {
-                runner.setTestContext(caseData.testContext);
+            .then(() => {
+                runner.setTestContext(data.testContext);
                 runner.setTestMap(testMap);
 
-                runner.on('disablenav', function() {
+                runner.on('disablenav', () => {
                     assert.ok(true, 'The dialog interrupted the move');
                     runner.destroy();
                     ready();
                 });
-                runner.trigger('move', caseData.event);
+                runner.trigger('move', data.event);
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, err.message);
                 ready();
             });

--- a/test/plugins/navigation/validateResponses/test.js
+++ b/test/plugins/navigation/validateResponses/test.js
@@ -22,30 +22,25 @@ define([
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/runner/plugins/navigation/validateResponses',
     'taoQtiTest/runner/helpers/currentItem'
-], function(_, runnerFactory, providerMock, pluginFactory, currentItemHelper) {
+], function (_, runnerFactory, providerMock, pluginFactory, currentItemHelper) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     //Mock the isAnswered helper, using testRunner property
-    currentItemHelper.isAnswered = function(testRunner) {
-        return testRunner.answered;
-    };
+    currentItemHelper.isAnswered = testRunner => testRunner.answered;
 
     //Mock the getDeclarations helper, using testRunner property
-    currentItemHelper.getDeclarations = function(testRunner) {
-        return testRunner.responses;
-    };
+    currentItemHelper.getDeclarations = testRunner => testRunner.responses;
 
     /**
      * The following tests applies to all plugins
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
         assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
@@ -56,31 +51,29 @@ define([
         );
     });
 
-    pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var runner = runnerFactory(providerName);
-        var timer = pluginFactory(runner);
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const timer = pluginFactory(runner);
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
@@ -93,8 +86,8 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options : {
-                    enableValidateResponses: false,
+                options: {
+                    enableValidateResponses: false
                 },
                 validateResponses: true,
                 answered: false,
@@ -105,7 +98,7 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableValidateResponses: true
                 },
                 validateResponses: true,
@@ -117,7 +110,7 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableValidateResponses: true
                 },
                 answered: false,
@@ -129,7 +122,7 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableValidateResponses: true
                 },
                 validateResponses: true,
@@ -144,24 +137,24 @@ define([
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-            runner.getCurrentItem = () => ({ validateResponses : data.validateResponses });
+            runner.getCurrentItem = () => ({ validateResponses: data.validateResponses });
 
             assert.expect(1);
 
             plugin
                 .init()
-                .then(function() {
+                .then(() => {
                     runner.setTestContext(data.context);
                     runner.answered = data.answered;
                     runner.responses = data.responses;
 
-                    runner.on('move', function() {
+                    runner.on('move', () => {
                         assert.ok(true, 'Move is allowed');
                         ready();
                     });
                     runner.trigger('move');
                 })
-                .catch(function(err) {
+                .catch(err => {
                     assert.ok(false, err.message);
                     ready();
                 });
@@ -174,7 +167,7 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options : {
+                options: {
                     enableValidateResponses: true
                 },
                 validateResponses: true,
@@ -182,33 +175,33 @@ define([
                 responses: ['foo']
             }
         ])
-        .test('Moving is prevented ', function(data, assert) {
+        .test('Moving is prevented ', (data, assert) => {
             const ready = assert.async();
 
             const runner = runnerFactory(providerName, {}, {
-                options : data.options
+                options: data.options
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker());
 
             runner.getCurrentItem = () => ({
-                validateResponses : data.validateResponses,
-                answered : data.answered
+                validateResponses: data.validateResponses,
+                answered: data.answered
             });
 
             assert.expect(2);
 
             plugin
                 .init()
-                .then(function() {
+                .then(() => {
                     runner.setTestContext(data.context);
                     runner.answered = data.answered;
                     runner.responses = data.responses;
 
-                    runner.on('move', function() {
+                    runner.on('move', () => {
                         assert.ok(false, 'Move is denied');
                         ready();
                     });
-                    runner.off('alert.notallowed').on('alert.notallowed', function(message, cb) {
+                    runner.off('alert.notallowed').on('alert.notallowed', (message, cb) => {
                         assert.equal(
                             message,
                             'A valid response to this item is required.',
@@ -216,13 +209,13 @@ define([
                         );
                         cb();
                     });
-                    runner.on('resumeitem', function() {
+                    runner.on('resumeitem', () => {
                         assert.ok(true, 'Move has been prevented');
                         ready();
                     });
                     runner.trigger('move');
                 })
-                .catch(function(err) {
+                .catch(err => {
                     assert.ok(false, err.message);
                     ready();
                 });
@@ -235,10 +228,10 @@ define([
                 context: {
                     itemIdentifier: 'item-1'
                 },
-                options :  {
-                    enableValidateResponses: true,
+                options: {
+                    enableValidateResponses: true
                 },
-                pluginConfig : {
+                pluginConfig: {
                     validateOnPreviousMove: false
                 },
                 validateResponses: true,
@@ -246,31 +239,31 @@ define([
                 responses: ['foo']
             }
         ])
-        .test('Moving backwards is also allowed ', (data, assert)  => {
+        .test('Moving backwards is also allowed ', (data, assert) => {
             const ready = assert.async();
             const runner = runnerFactory(providerName, {}, {
                 options: data.options
             });
             const plugin = pluginFactory(runner, runner.getAreaBroker(), data.pluginConfig);
 
-            runner.getCurrentItem = () => ({ validateResponses : data.validateResponses });
+            runner.getCurrentItem = () => ({ validateResponses: data.validateResponses });
 
             assert.expect(1);
 
             plugin
                 .init()
-                .then(function() {
+                .then(() => {
                     runner.setTestContext(data.context);
                     runner.answered = data.answered;
                     runner.responses = data.responses;
 
-                    runner.on('move', function() {
+                    runner.on('move', () => {
                         assert.ok(true, 'Moving is allowed');
                         ready();
                     });
                     runner.previous();
                 })
-                .catch(function(err) {
+                .catch(err => {
                     assert.ok(false, err.message);
                     ready();
                 });

--- a/test/plugins/navigation/validateResponses/test.js
+++ b/test/plugins/navigation/validateResponses/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 
 define([
@@ -36,6 +36,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/answerElimination/eliminator/test.js
+++ b/test/plugins/tools/answerElimination/eliminator/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA
  */
 /**
  * @author Dieter Raber <dieter@taotesting.com>
@@ -55,6 +55,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/answerElimination/eliminator/test.js
+++ b/test/plugins/tools/answerElimination/eliminator/test.js
@@ -25,7 +25,7 @@ define([
 ], function(runnerFactory, providerMock, eliminatorFactory) {
     'use strict';
 
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     const sampleTestContext = {
@@ -55,24 +55,24 @@ define([
 
     QUnit.module('eliminatorFactory');
 
-    QUnit.test('module', function(assert) {
+    QUnit.test('module', assert => {
         assert.ok(typeof eliminatorFactory === 'function', 'Module exposes a function');
     });
 
     QUnit.module('Eliminator Mode');
 
-    QUnit.test('Toggle eliminator mode on/off', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var eliminator = eliminatorFactory(runner, areaBroker);
-        var interaction = document.querySelector('.qti-choiceInteraction');
+    QUnit.test('Toggle eliminator mode on/off', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const eliminator = eliminatorFactory(runner, areaBroker);
+        const interaction = document.querySelector('.qti-choiceInteraction');
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
 
         areaBroker.getContentArea().append(interaction);
-        eliminator.init().then(function() {
+        eliminator.init().then(() => {
             runner.trigger('renderitem');
             runner.trigger('tool-eliminator-toggle');
             assert.ok(interaction.classList.contains('eliminable'), 'Class "eliminable" has been added');

--- a/test/plugins/tools/answerElimination/plugin/test.js
+++ b/test/plugins/tools/answerElimination/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA
  */
 
 define([
@@ -53,6 +53,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/answerElimination/plugin/test.js
+++ b/test/plugins/tools/answerElimination/plugin/test.js
@@ -23,8 +23,7 @@ define([
 ], function(runnerFactory, providerMock, pluginFactory) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     const sampleTestContext = {
@@ -57,8 +56,8 @@ define([
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.expect(3);
 
@@ -71,34 +70,32 @@ define([
         );
     });
 
-    pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
     QUnit.module('Plugin API');
 
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner);
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner);
         assert.expect(1);
         assert.equal(
-            typeof plugin[data.name],
+            typeof plugin[data.title],
             'function',
-            `The pluginFactory instances expose a "${  data.name  }" function`
+            `The pluginFactory instances expose a "${  data.title  }" function`
         );
     });
 
@@ -107,53 +104,52 @@ define([
      */
     QUnit.module('Button');
 
-    QUnit.test('render/enable/disable/destroy', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            plugin = pluginFactory(runner, areaBroker),
-            toolbox = areaBroker.getToolbox(),
-            $container = areaBroker.getToolboxArea(),
-            buttonSelector = '[data-control="eliminator"]',
-            $button;
+    QUnit.test('render/enable/disable/destroy', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, areaBroker);
+        const toolbox = areaBroker.getToolbox();
+        const $container = areaBroker.getToolboxArea();
+        const buttonSelector = '[data-control="eliminator"]';
 
         assert.expect(12);
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
 
                 // Toolbox rendering
                 toolbox.render($container);
 
-                $button = $container.find(buttonSelector);
+                const $button = $container.find(buttonSelector);
 
                 assert.equal($button.length, 1, 'The plugin button has been inserted in the right place');
                 assert.equal($button.hasClass('disabled'), true, 'The button has been rendered disabled');
 
                 // Plugin rendering
-                return plugin.render().then(function() {
+                return plugin.render().then(() => {
                     assert.equal(plugin.getState('ready'), true, 'The plugin is ready');
 
                     // Enabling
-                    return plugin.enable().then(function() {
+                    return plugin.enable().then(() => {
                         assert.equal(plugin.getState('enabled'), true, 'The plugin is enabled');
                         assert.equal($button.hasClass('disabled'), false, 'The button is not disabled');
 
                         // Disabling
-                        return plugin.disable().then(function() {
+                        return plugin.disable().then(() => {
                             assert.equal(plugin.getState('enabled'), false, 'The plugin is disabled');
                             assert.equal($button.hasClass('disabled'), true, 'The button is disabled');
                             assert.equal($button.hasClass('active'), false, 'The button is turned off');
 
                             // Plugin destroying
-                            return plugin.destroy().then(function() {
-                                $button = $container.find(buttonSelector);
+                            return plugin.destroy().then(() => {
+                                const $buttonBefore = $container.find(buttonSelector);
 
                                 assert.equal(plugin.getState('init'), false, 'The plugin is destroyed');
                                 assert.equal(
-                                    $button.length,
+                                    $buttonBefore.length,
                                     1,
                                     'The plugin button has not been destroyed by the plugin'
                                 );
@@ -161,42 +157,41 @@ define([
                                 // Toolbox destroying
                                 toolbox.destroy();
 
-                                $button = $container.find(buttonSelector);
+                                const $buttonAfter = $container.find(buttonSelector);
 
-                                assert.equal($button.length, 0, 'The button has been removed');
+                                assert.equal($buttonAfter.length, 0, 'The button has been removed');
                                 ready();
                             });
                         });
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('show/hide', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            plugin = pluginFactory(runner, areaBroker),
-            toolbox = areaBroker.getToolbox(),
-            $container = areaBroker.getToolboxArea(),
-            buttonSelector = '[data-control="eliminator"]',
-            $button;
+    QUnit.test('show/hide', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, areaBroker);
+        const toolbox = areaBroker.getToolbox();
+        const $container = areaBroker.getToolboxArea();
+        const buttonSelector = '[data-control="eliminator"]';
 
         assert.expect(7);
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin has been initialized');
 
                 // Toolbox rendering
                 toolbox.render($container);
 
-                $button = $container.find(buttonSelector);
+                const $button = $container.find(buttonSelector);
 
                 plugin.setState('visible', true);
 
@@ -204,12 +199,12 @@ define([
                 assert.equal(plugin.getState('visible'), true, 'The plugin is visible');
 
                 // Hiding
-                return plugin.hide().then(function() {
+                return plugin.hide().then(() => {
                     assert.equal(plugin.getState('visible'), false, 'The plugin is not visible');
                     assert.equal($button.css('display'), 'none', 'The plugin element is hidden');
 
                     // Showing
-                    return plugin.show().then(function() {
+                    return plugin.show().then(() => {
                         assert.equal(plugin.getState('visible'), true, 'The plugin is visible');
                         assert.notEqual($button.css('display'), 'none', 'The plugin element is visible');
 
@@ -217,21 +212,20 @@ define([
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('runner events: loaditem / unloaditem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            plugin = pluginFactory(runner, runner.getAreaBroker()),
-            toolbox = areaBroker.getToolbox(),
-            $container = areaBroker.getToolboxArea(),
-            buttonSelector = '[data-control="eliminator"]',
-            $button;
+    QUnit.test('runner events: loaditem / unloaditem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const toolbox = areaBroker.getToolbox();
+        const $container = areaBroker.getToolboxArea();
+        const buttonSelector = '[data-control="eliminator"]';
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
@@ -240,10 +234,10 @@ define([
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 toolbox.render($container);
 
-                $button = $container.find(buttonSelector);
+                const $button = $container.find(buttonSelector);
 
                 assert.equal($button.length, 1, 'The plugin button has been inserted in the right place');
 
@@ -258,21 +252,20 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${  err}`);
             });
     });
 
-    QUnit.test('runner events: renderitem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker()),
-            areaBroker = runner.getAreaBroker(),
-            toolbox = areaBroker.getToolbox(),
-            $container = areaBroker.getToolboxArea(),
-            buttonSelector = '[data-control="eliminator"]',
-            $button,
-            interaction = document.querySelector('.qti-choiceInteraction');
+    QUnit.test('runner events: renderitem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const areaBroker = runner.getAreaBroker();
+        const toolbox = areaBroker.getToolbox();
+        const $container = areaBroker.getToolboxArea();
+        const buttonSelector = '[data-control="eliminator"]';
+        const interaction = document.querySelector('.qti-choiceInteraction');
 
         areaBroker.getContentArea().append(interaction);
 
@@ -283,10 +276,10 @@ define([
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 toolbox.render($container);
 
-                $button = $container.find(buttonSelector);
+                const $button = $container.find(buttonSelector);
 
                 assert.equal($button.length, 1, 'The plugin button has been inserted in the right place');
 
@@ -297,7 +290,7 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `An error has occurred: ${  err}`);
                 ready();
             });

--- a/test/plugins/tools/answerMasking/plugin/test.js
+++ b/test/plugins/tools/answerMasking/plugin/test.js
@@ -29,8 +29,7 @@ define([
 ], function($, _, hider, runnerFactory, providerMock, pluginFactory) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     const sampleTestContext = {
@@ -63,8 +62,8 @@ define([
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
         assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
@@ -75,47 +74,45 @@ define([
         );
     });
 
-    pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var runner = runnerFactory(providerName);
-        var timer = pluginFactory(runner);
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const timer = pluginFactory(runner);
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
-    QUnit.test('pluginFactory.init', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('pluginFactory.init', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `The init failed: ${err}`);
                 ready();
             });
@@ -126,23 +123,22 @@ define([
      */
     QUnit.module('plugin button');
 
-    QUnit.test('render/destroy button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('render/destroy button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(3);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="answer-masking"]');
+                let $button = $container.find('[data-control="answer-masking"]');
 
                 assert.equal($button.length, 1, 'The button has been inserted');
                 assert.equal($button.hasClass('disabled'), true, 'The button has been rendered disabled');
@@ -154,71 +150,69 @@ define([
                 assert.equal($button.length, 0, 'The button has been removed');
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('enable/disable button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('enable/disable button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(2);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                return plugin.enable().then(function() {
-                    $button = $container.find('[data-control="answer-masking"]');
+                return plugin.enable().then(() => {
+                    const $button = $container.find('[data-control="answer-masking"]');
 
                     assert.equal($button.hasClass('disabled'), false, 'The button has been enabled');
 
-                    return plugin.disable().then(function() {
+                    return plugin.disable().then(() => {
                         assert.equal($button.hasClass('disabled'), true, 'The button has been disabled');
 
                         ready();
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('show/hide button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('show/hide button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(3);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                return plugin.hide().then(function() {
-                    $button = $container.find('[data-control="answer-masking"]');
+                return plugin.hide().then(() => {
+                    const $button = $container.find('[data-control="answer-masking"]');
 
                     assert.ok(hider.isHidden($button), 'The button has been hidden');
 
-                    return plugin.show().then(function() {
+                    return plugin.show().then(() => {
                         assert.ok(!hider.isHidden($button), 'The button is visible');
 
-                        return plugin.hide().then(function() {
+                        return plugin.hide().then(() => {
                             assert.ok(hider.isHidden($button), 'The button has been hidden again');
 
                             ready();
@@ -226,17 +220,17 @@ define([
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('runner events: loaditem / unloaditem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('runner events: loaditem / unloaditem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(3);
 
@@ -251,13 +245,12 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="answer-masking"]');
+                const $button = $container.find('[data-control="answer-masking"]');
 
                 runner.trigger('loaditem');
 
@@ -271,17 +264,17 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('runner events: renderitem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('runner events: renderitem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(2);
 
@@ -296,15 +289,14 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
                 runner.trigger('renderitem');
 
-                $button = $container.find('[data-control="answer-masking"]');
+                const $button = $container.find('[data-control="answer-masking"]');
 
                 assert.ok(!hider.isHidden($button), 'The button is visible');
 
@@ -312,7 +304,7 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
@@ -323,7 +315,7 @@ define([
      */
     QUnit.module('plugin UI');
 
-    QUnit.test('Toggle on keyboard shortcut', function(assert) {
+    QUnit.test('Toggle on keyboard shortcut', assert => {
         const ready = assert.async();
         const runner = runnerFactory(providerName, {}, {
             options : {
@@ -352,7 +344,7 @@ define([
             })
         );
 
-        runner.after('tool-answer-masking-toggle', function() {
+        runner.after('tool-answer-masking-toggle', () => {
             toggleCounter++;
 
             if (toggleCounter === 1) {
@@ -379,8 +371,8 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $toolboxContainer = areaBroker.getToolboxArea();
+            .then(() => {
+                const $toolboxContainer = areaBroker.getToolboxArea();
 
                 areaBroker.getToolbox().render($toolboxContainer);
                 $button = areaBroker.getToolboxArea().find('[data-control="answer-masking"]');
@@ -401,19 +393,18 @@ define([
                     metaKey: false
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('Toggle on click', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
-        var toggleCounter = 0;
-        var $button;
+    QUnit.test('Toggle on click', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const toggleCounter = 0;
 
         assert.expect(5);
 
@@ -426,7 +417,7 @@ define([
             })
         );
 
-        runner.after('tool-answer-masking-toggle', function() {
+        runner.after('tool-answer-masking-toggle', () => {
             toggleCounter++;
 
             if (toggleCounter === 1) {
@@ -442,11 +433,11 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $toolboxContainer = areaBroker.getToolboxArea();
+            .then(() => {
+                const $toolboxContainer = areaBroker.getToolboxArea();
 
                 areaBroker.getToolbox().render($toolboxContainer);
-                $button = areaBroker.getToolboxArea().find('[data-control="answer-masking"]');
+                const $button = areaBroker.getToolboxArea().find('[data-control="answer-masking"]');
 
                 runner.trigger('renderitem');
 
@@ -454,7 +445,7 @@ define([
 
                 $button.click();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });

--- a/test/plugins/tools/answerMasking/plugin/test.js
+++ b/test/plugins/tools/answerMasking/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Christophe Noël <christophe@taotesting.com>
@@ -59,6 +59,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/apipTextToSpeech/plugin/test.js
+++ b/test/plugins/tools/apipTextToSpeech/plugin/test.js
@@ -94,6 +94,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/apipTextToSpeech/plugin/test.js
+++ b/test/plugins/tools/apipTextToSpeech/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Anton Tsymuk <anton@taotesting.com>
@@ -93,11 +93,23 @@ define([
     };
 
     /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner(config) {
+        const runner = runnerFactory(providerName, [], config);
+        runner.getDataHolder();
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+        return Promise.resolve(runner);
+    }
+
+    /**
      * The following tests applies to all plugins
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', (assert) => {
+    QUnit.test('module', assert => {
         const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
@@ -109,47 +121,50 @@ define([
         );
     });
 
-    const pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', (data, assert) => {
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
         const runner = runnerFactory(providerName);
         const timer = pluginFactory(runner);
 
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
-    QUnit.test('pluginFactory.init', (assert) => {
+    QUnit.test('pluginFactory.init', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner, runner.getAreaBroker());
 
-        plugin
-            .init()
-            .then(() => {
-                assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
+                return plugin
+                    .init()
+                    .then(() => {
+                        assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
+                    });
             })
-            .catch((err) => {
-                assert.ok(false, `The init failed: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
@@ -159,356 +174,385 @@ define([
      */
     QUnit.module('plugin button');
 
-    QUnit.test('render/destroy button', (assert) => {
+    QUnit.test('render/destroy button', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(3);
+                assert.expect(3);
 
-        plugin
-            .init()
-            .then(() => {
-                let $button;
+                return plugin
+                    .init()
+                    .then(() => {
+                        let $button;
 
-                areaBroker.getToolbox().render($container);
+                        areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="apiptts"]');
+                        $button = $container.find('[data-control="apiptts"]');
 
-                assert.equal($button.length, 1, 'The trigger button has been inserted');
-                assert.equal($button.hasClass('disabled'), true, 'The trigger button has been rendered disabled');
+                        assert.equal($button.length, 1, 'The trigger button has been inserted');
+                        assert.equal($button.hasClass('disabled'), true, 'The trigger button has been rendered disabled');
 
-                areaBroker.getToolbox().destroy();
+                        areaBroker.getToolbox().destroy();
 
-                $button = $container.find('[data-control="apiptts"]');
+                        $button = $container.find('[data-control="apiptts"]');
 
-                assert.equal($button.length, 0, 'The trigger button has been removed');
+                        assert.equal($button.length, 0, 'The trigger button has been removed');
+                    });
             })
-            .catch((err) => {
-                assert.ok(false, `Error in init method: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('enable/disable button', (assert) => {
+    QUnit.test('enable/disable button', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(2);
+                assert.expect(2);
 
-        plugin
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                return plugin
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                return plugin.enable();
+                        return plugin.enable();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        assert.equal($button.hasClass('disabled'), false, 'The trigger button has been enabled');
+
+                        return plugin.disable();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
+                    });
             })
-            .then(() => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                assert.equal($button.hasClass('disabled'), false, 'The trigger button has been enabled');
-
-                return plugin.disable();
-            })
-            .then(() => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
-            })
-            .catch((err) => {
-                assert.ok(false, `Unexpected error: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('show/hide button', (assert) => {
+    QUnit.test('show/hide button', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(3);
+                assert.expect(3);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
-        runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
+                runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
 
-        plugin
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                plugin
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                return plugin.hide();
+                        return plugin.hide();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden');
+
+                        return plugin.show();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
+
+                        return plugin.hide();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden again');
+                    });
             })
-            .then(() => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden');
-
-                return plugin.show();
-            })
-            .then(() => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
-
-                return plugin.hide();
-            })
-            .then(() => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                assert.equal(hider.isHidden($button), true, 'The trigger button has been hidden again');
-            })
-            .catch((err) => {
-                assert.ok(false, `Unexpected error: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('runner events: loaditem / unloaditem', (assert) => {
+    QUnit.test('runner events: loaditem / unloaditem', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(3);
+                assert.expect(3);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
-        runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
+                runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
 
-        plugin
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                return plugin
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                const $button = $container.find('[data-control="apiptts"]');
+                        const $button = $container.find('[data-control="apiptts"]');
 
-                runner.trigger('loaditem');
+                        runner.trigger('loaditem');
 
-                assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
+                        assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
 
-                runner.trigger('unloaditem');
+                        runner.trigger('unloaditem');
 
-                assert.equal(hider.isHidden($button), false, 'The trigger button is still visible');
+                        assert.equal(hider.isHidden($button), false, 'The trigger button is still visible');
 
-                assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
+                        assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
+                    });
             })
-            .catch((err) => {
-                assert.ok(false, `Error in init method: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('runner events: renderitem', (assert) => {
+    QUnit.test('runner events: renderitem', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
-        runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
+                runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
 
-        assert.expect(2);
+                assert.expect(2);
 
-        plugin
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                return plugin
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                const $button = $container.find('[data-control="apiptts"]');
+                        const $button = $container.find('[data-control="apiptts"]');
 
-                runner.trigger('renderitem');
+                        runner.trigger('renderitem');
 
-                assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
+                        assert.equal(hider.isHidden($button), false, 'The trigger button is visible');
 
-                assert.equal($button.hasClass('disabled'), false, 'The trigger button is not disabled');
+                        assert.equal($button.hasClass('disabled'), false, 'The trigger button is not disabled');
+                    });
             })
-            .catch((err) => {
-                assert.ok(false, `Error in init method: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('runner events: renderitem with disabled plugin', (assert) => {
+    QUnit.test('runner events: renderitem with disabled plugin', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const testPartWithApipCategory = {
-            parts: {
-                p1: {
-                    sections: {
-                        s1: {
-                            items: {
-                                'item-1': {
-                                    categories: []
+        getTestRunner()
+            .then(runner => {
+                const testPartWithApipCategory = {
+                    parts: {
+                        p1: {
+                            sections: {
+                                s1: {
+                                    items: {
+                                        'item-1': {
+                                            categories: []
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
-                }
-            }
-        };
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(Object.assign({}, sampleTestMap, testPartWithApipCategory));
+                };
+                runner.setTestMap(Object.assign({}, sampleTestMap, testPartWithApipCategory));
 
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
+                runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
 
-        assert.expect(1);
+                assert.expect(1);
 
-        plugin
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                return plugin
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                const $button = $container.find('[data-control="apiptts"]');
+                        const $button = $container.find('[data-control="apiptts"]');
 
-                plugin.hide();
-                runner.trigger('renderitem');
+                        plugin.hide();
+                        runner.trigger('renderitem');
 
-                assert.equal(hider.isHidden($button), true, 'the button is not visible');
+                        assert.equal(hider.isHidden($button), true, 'the button is not visible');
+                    });
             })
-            .catch((err) => {
-                assert.ok(false, `Error in init method: ${err}`);
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('Toggle on click', (assert) => {
+    QUnit.test('Toggle on click', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
 
-        assert.expect(3);
+                assert.expect(3);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
-        runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
+                runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
 
-        plugin
-            .init()
-            .then(() => {
-                runner.trigger('renderitem');
+                return plugin
+                    .init()
+                    .then(() => {
+                        runner.trigger('renderitem');
 
-                areaBroker.getToolbox().render($container);
+                        areaBroker.getToolbox().render($container);
 
-                return plugin.enable();
-            })
-            .then(() => {
-                const $button = $container.find('[data-control="apiptts"]');
+                        return plugin.enable();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="apiptts"]');
 
-                assert.equal(plugin.getState('active'), true, 'The plugin should be active by default');
+                        assert.equal(plugin.getState('active'), true, 'The plugin should be active by default');
 
-                $button.click();
+                        $button.click();
 
-                assert.equal(plugin.getState('active'), false, 'If the plugin is active, the button should toggle the plugin to non active state');
+                        assert.equal(plugin.getState('active'), false, 'If the plugin is active, the button should toggle the plugin to non active state');
 
-                $button.click();
+                        $button.click();
 
-                assert.equal(plugin.getState('active'), true, 'The button should toggle the plugin to active state');
+                        assert.equal(plugin.getState('active'), true, 'The button should toggle the plugin to active state');
+                    });
             })
             .catch(err => {
-                assert.ok(false, `Unexpected error: ${err}`);
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });
 
-    QUnit.test('Add navigation group', (assert) => {
+    QUnit.test('Add navigation group', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const $testContainer = areaBroker.getContainer();
-        const $container = areaBroker.getToolboxArea();
-        const plugin = pluginFactory(runner, areaBroker);
-        const pluginName = plugin.getName();
-        const actionPrefix = `tool-${pluginName}-`;
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const $testContainer = areaBroker.getContainer();
+                const $container = areaBroker.getToolboxArea();
+                const plugin = pluginFactory(runner, areaBroker);
+                const pluginName = plugin.getName();
+                const actionPrefix = `tool-${pluginName}-`;
 
-        assert.expect(8);
+                assert.expect(8);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
-        runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
+                runner.itemRunner = { assetManager: { resolve: () => { } }, getData: () => ({ apipAccessibility: apipData }) };
 
-        plugin
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                return plugin
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                runner.trigger('renderitem');
-                runner.trigger(`${actionPrefix}toggle`);
+                        runner.trigger('renderitem');
+                        runner.trigger(`${actionPrefix}toggle`);
 
-                return plugin.enable();
+                        return plugin.enable();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="apiptts"]');
+                        const $sfhButton = $testContainer.find('.tts-control-mode');
+
+                        assert.equal($button.is(document.activeElement), false, 'The focus group is not focused by default');
+
+                        $button.click();
+
+                        assert.equal(typeof plugin.navigationGroup, 'object', 'The plugin create navigation group after render');
+
+                        assert.equal($button.is(document.activeElement), true, 'The focus group is focused after plugin activation');
+
+                        $button.click();
+                        $sfhButton.click();
+
+                        assert.equal($button.is(document.activeElement), false, 'The focus group lose focus after plugin disabling');
+
+                        $button.click();
+
+                        assert.equal($button.is(document.activeElement), true, 'The focus group is focused again');
+                    })
+                    .then(() => new Promise(resolve => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        runner.on(`${actionPrefix}next`, () => {
+                            assert.ok(true, 'The next event triggered after tab navigation');
+
+                            resolve();
+                        });
+
+                        $button.simulate('keydown', {keyCode: 9}); //Tab -> navigate next
+                    }))
+                    .then(() => new Promise(resolve => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        runner.on(`${actionPrefix}previous`, () => {
+                            assert.ok(true, 'The previous event triggered after tab+shift navigation');
+
+                            resolve();
+                        });
+
+                        $button.simulate('keydown', {keyCode: 9, shiftKey: true}); //Shift+Tab -> navigate back
+                    }))
+                    .then(() => new Promise(resolve => {
+                        const $button = $container.find('[data-control="apiptts"]');
+
+                        runner.on(`${actionPrefix}togglePlayback`, () => {
+                            assert.ok(true, 'The togglePlayback event triggered on activate navigation event');
+
+                            resolve();
+                        });
+
+                        $button.simulate('keydown', {keyCode: 13}); //Enter -> activate
+                    }));
             })
-            .then(() => {
-                const $button = $container.find('[data-control="apiptts"]');
-                const $sfhButton = $testContainer.find('.tts-control-mode');
-
-                assert.equal($button.is(document.activeElement), false, 'The focus group is not focused by default');
-
-                $button.click();
-
-                assert.equal(typeof plugin.navigationGroup, 'object', 'The plugin create navigation group after render');
-
-                assert.equal($button.is(document.activeElement), true, 'The focus group is focused after plugin activation');
-
-                $button.click();
-                $sfhButton.click();
-
-                assert.equal($button.is(document.activeElement), false, 'The focus group lose focus after plugin disabling');
-
-                $button.click();
-
-                assert.equal($button.is(document.activeElement), true, 'The focus group is focused again');
-            })
-            .then(() => new Promise(resolve => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                runner.on(`${actionPrefix}next`, () => {
-                    assert.ok(true, 'The next event triggered after tab navigation');
-
-                    resolve();
-                });
-
-                $button.simulate('keydown', {keyCode: 9}); //Tab -> navigate next
-            }))
-            .then(() => new Promise(resolve => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                runner.on(`${actionPrefix}previous`, () => {
-                    assert.ok(true, 'The previous event triggered after tab+shift navigation');
-
-                    resolve();
-                });
-
-                $button.simulate('keydown', {keyCode: 9, shiftKey: true}); //Shift+Tab -> navigate back
-            }))
-            .then(() => new Promise(resolve => {
-                const $button = $container.find('[data-control="apiptts"]');
-
-                runner.on(`${actionPrefix}togglePlayback`, () => {
-                    assert.ok(true, 'The togglePlayback event triggered on activate navigation event');
-
-                    resolve();
-                });
-
-                $button.simulate('keydown', {keyCode: 13}); //Enter -> activate
-            }))
             .catch(err => {
-                assert.ok(false, `Unexpected error: ${err}`);
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
             })
             .then(ready);
     });

--- a/test/plugins/tools/areaMasking/plugin/test.js
+++ b/test/plugins/tools/areaMasking/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
  */
 
 define([
@@ -54,6 +54,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/areaMasking/plugin/test.js
+++ b/test/plugins/tools/areaMasking/plugin/test.js
@@ -24,7 +24,7 @@ define([
 ], function($, runnerFactory, providerMock, areaMaskingFactory) {
     'use strict';
 
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     const sampleTestContext = {
@@ -54,8 +54,8 @@ define([
 
     QUnit.module('API');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.expect(3);
 
@@ -70,62 +70,61 @@ define([
 
     QUnit.cases
         .init([
-            { name: 'init', title: 'init' },
-            { name: 'render', title: 'render' },
-            { name: 'finish', title: 'finish' },
-            { name: 'destroy', title: 'destroy' },
-            { name: 'trigger', title: 'trigger' },
-            { name: 'getTestRunner', title: 'getTestRunner' },
-            { name: 'getAreaBroker', title: 'getAreaBroker' },
-            { name: 'getConfig', title: 'getConfig' },
-            { name: 'setConfig', title: 'setConfig' },
-            { name: 'getState', title: 'getState' },
-            { name: 'setState', title: 'setState' },
-            { name: 'show', title: 'show' },
-            { name: 'hide', title: 'hide' },
-            { name: 'enable', title: 'enable' },
-            { name: 'disable', title: 'disable' }
+            { title: 'init' },
+            { title: 'render' },
+            { title: 'finish' },
+            { title: 'destroy' },
+            { title: 'trigger' },
+            { title: 'getTestRunner' },
+            { title: 'getAreaBroker' },
+            { title: 'getConfig' },
+            { title: 'setConfig' },
+            { title: 'getState' },
+            { title: 'setState' },
+            { title: 'show' },
+            { title: 'hide' },
+            { title: 'enable' },
+            { title: 'disable' }
         ])
-        .test('plugin ', function(data, assert) {
-            var runner = runnerFactory(providerName);
-            var areaMasking = areaMaskingFactory(runner);
+        .test('plugin ', (data, assert) => {
+            const runner = runnerFactory(providerName);
+            const areaMasking = areaMaskingFactory(runner);
             assert.expect(1);
 
-            assert.equal(typeof areaMasking[data.name], 'function', `The plugin exposes a ${  data.name  } method`);
+            assert.equal(typeof areaMasking[data.title], 'function', `The plugin exposes a ${data.title} method`);
         });
 
     QUnit.module('plugin lifecycle');
 
-    QUnit.test('render/destroy button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = areaMaskingFactory(runner, areaBroker);
+    QUnit.test('render/destroy button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = areaMaskingFactory(runner, areaBroker);
 
         assert.expect(3);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="area-masking"]');
+                const $buttonBefore = $container.find('[data-control="area-masking"]');
 
-                assert.equal($button.length, 1, 'The button has been inserted');
-                assert.equal($button.hasClass('disabled'), true, 'The button has been rendered disabled');
+                assert.equal($buttonBefore.length, 1, 'The button has been inserted');
+                assert.equal($buttonBefore.hasClass('disabled'), true, 'The button has been rendered disabled');
 
                 areaBroker.getToolbox().destroy();
 
-                $button = $container.find('[data-control="area-masking"]');
+                const $buttonAfter = $container.find('[data-control="area-masking"]');
 
-                assert.equal($button.length, 0, 'The button has been removed');
+                assert.equal($buttonAfter.length, 0, 'The button has been removed');
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${  err}`);
                 ready();
             });
@@ -133,20 +132,19 @@ define([
 
     QUnit.module('mask');
 
-    QUnit.test('create', function(assert) {
-        var ready = assert.async();
-        var $container = $('#qunit-fixture');
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var areaMasking = areaMaskingFactory(runner, areaBroker);
-        var $button;
+    QUnit.test('create', assert => {
+        const ready = assert.async();
+        const $container = $('#qunit-fixture');
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const areaMasking = areaMaskingFactory(runner, areaBroker);
 
         assert.expect(9);
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
 
-        runner.on('plugin-maskadd.area-masking', function() {
+        runner.on('plugin-maskadd.area-masking', () => {
             assert.equal($('.mask', $container).length, 1, 'A mask has been created');
             assert.equal(areaMasking.masks.length, 1, 'The mask is bound');
             assert.ok($button.hasClass('active'), 'The mask button is active');
@@ -156,7 +154,7 @@ define([
 
         areaMasking
             .init()
-            .then(function() {
+            .then(() => {
                 assert.ok(!areaMasking.getState('enabled'), 'The areaMasking starts disabled');
 
                 areaMasking.enable();
@@ -164,8 +162,8 @@ define([
                 areaBroker.getToolbox().render($container);
                 runner.trigger('renderitem');
 
-                return areaMasking.render().then(function() {
-                    $button = $container.find('[data-control="area-masking"]');
+                return areaMasking.render().then(() => {
+                    const $button = $container.find('[data-control="area-masking"]');
 
                     assert.ok(areaMasking.getState('enabled'), 'The areaMasking is not disabled anymore');
                     assert.equal($button.length, 1, 'The plugin button has been appended');
@@ -177,19 +175,18 @@ define([
                     $button.trigger('click');
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('remove', function(assert) {
-        var ready = assert.async();
-        var $container = $('#qunit-fixture');
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var areaMasking = areaMaskingFactory(runner, areaBroker);
-        var $button;
+    QUnit.test('remove', assert => {
+        const ready = assert.async();
+        const $container = $('#qunit-fixture');
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const areaMasking = areaMaskingFactory(runner, areaBroker);
 
         assert.expect(12);
 
@@ -197,15 +194,15 @@ define([
         runner.setTestMap(sampleTestMap);
 
         runner
-            .on('plugin-maskadd.area-masking', function() {
+            .on('plugin-maskadd.area-masking', () => {
                 assert.equal($('.mask', $container).length, 1, 'A mask has been created');
                 assert.equal(areaMasking.masks.length, 1, 'The mask is bound');
                 assert.ok($button.hasClass('active'), 'The mask button is active');
 
                 $('.mask .close', $container).click();
             })
-            .on('plugin-maskclose.area-masking', function() {
-                setTimeout(function() {
+            .on('plugin-maskclose.area-masking', () => {
+                setTimeout(() => {
                     assert.equal($('.mask', $container).length, 0, 'A mask has been removed');
                     assert.equal(areaMasking.masks.length, 0, 'The mask is unbound');
                     assert.ok(!$button.hasClass('active'), 'The mask button is not active anymore');
@@ -216,7 +213,7 @@ define([
 
         areaMasking
             .init()
-            .then(function() {
+            .then(() => {
                 assert.ok(!areaMasking.getState('enabled'), 'The areaMasking starts disabled');
 
                 areaMasking.enable();
@@ -224,8 +221,8 @@ define([
                 areaBroker.getToolbox().render($container);
                 runner.trigger('renderitem');
 
-                return areaMasking.render().then(function() {
-                    $button = $container.find('[data-control="area-masking"]');
+                return areaMasking.render().then(() => {
+                    const $button = $container.find('[data-control="area-masking"]');
 
                     assert.ok(areaMasking.getState('enabled'), 'The areaMasking is not disbaled anymore');
                     assert.equal($button.length, 1, 'The plugin button has been appended');
@@ -237,18 +234,18 @@ define([
                     $button.trigger('click');
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('multiple', function(assert) {
-        var ready = assert.async();
-        var $container = $('#qunit-fixture');
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var areaMasking = areaMaskingFactory(runner, areaBroker);
+    QUnit.test('multiple', assert => {
+        const ready = assert.async();
+        const $container = $('#qunit-fixture');
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const areaMasking = areaMaskingFactory(runner, areaBroker);
 
         assert.expect(17);
 
@@ -257,7 +254,7 @@ define([
 
         areaMasking
             .init()
-            .then(function() {
+            .then(() => {
                 assert.ok(!areaMasking.getState('enabled'), 'The areaMasking starts disabled');
 
                 areaMasking.enable();
@@ -265,8 +262,8 @@ define([
                 areaBroker.getToolbox().render($container);
                 runner.trigger('renderitem');
 
-                return areaMasking.render().then(function() {
-                    var $button = $container.find('[data-control="area-masking"]');
+                return areaMasking.render().then(() => {
+                    const $button = $container.find('[data-control="area-masking"]');
 
                     assert.ok(areaMasking.getState('enabled'), 'The areaMasking is not disbaled anymore');
                     assert.equal($button.length, 1, 'The plugin button has been appended');
@@ -280,7 +277,7 @@ define([
                     $button.trigger('click');
                     $button.trigger('click');
 
-                    setTimeout(function() {
+                    setTimeout(() => {
                         assert.equal($('.mask', $container).length, 3, '3 masks have been created');
                         assert.equal(areaMasking.masks.length, 3, '3 masks are bound');
                         assert.ok(areaMasking.getState('enabled'), 'The areaMasking is enabled');
@@ -289,14 +286,14 @@ define([
                         $button.trigger('click');
                         $button.trigger('click');
 
-                        setTimeout(function() {
+                        setTimeout(() => {
                             assert.equal($('.mask', $container).length, 5, '5 masks have been created');
                             assert.equal(areaMasking.masks.length, 5, '5 masks are bound');
                             assert.ok($button.hasClass('active'), 'The mask button is active');
 
                             $button.trigger('click');
 
-                            setTimeout(function() {
+                            setTimeout(() => {
                                 assert.equal($('.mask', $container).length, 5, 'There is still 5 masks');
                                 assert.equal(areaMasking.masks.length, 5, 'There is still 5 masks');
                                 assert.ok($button.hasClass('active'), 'The mask button is still active');
@@ -307,7 +304,7 @@ define([
                     }, 10);
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });

--- a/test/plugins/tools/highlighter/plugin/test.js
+++ b/test/plugins/tools/highlighter/plugin/test.js
@@ -26,7 +26,7 @@ define([
     'taoQtiTest/runner/helpers/currentItem',
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/runner/plugins/tools/highlighter/plugin'
-], function($, _, hider, runnerFactory, itemHelper, providerMock, pluginFactory) {
+], function ($, _, hider, runnerFactory, itemHelper, providerMock, pluginFactory) {
     'use strict';
 
     const providerName = 'mock';
@@ -46,15 +46,15 @@ define([
     }
 
     const sampleTestContext = {
-        itemIdentifier : 'item-1'
+        itemIdentifier: 'item-1'
     };
     const sampleTestMap = {
         parts: {
-            p1 : {
-                sections : {
-                    s1 : {
-                        items : {
-                            'item-1' : {
+            p1: {
+                sections: {
+                    s1: {
+                        items: {
+                            'item-1': {
                                 categories: ['x-tao-option-highlighter']
                             }
                         }
@@ -62,7 +62,7 @@ define([
                 }
             }
         },
-        jumps : [{
+        jumps: [{
             identifier: 'item-1',
             section: 's1',
             part: 'p1',

--- a/test/plugins/tools/highlighter/plugin/test.js
+++ b/test/plugins/tools/highlighter/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Christophe Noël <christophe@taotesting.com>
@@ -32,9 +32,7 @@ define([
     const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
-    itemHelper.getStimuliHrefs = () => {
-        return ['http://include1.xml', 'http://include2.xml'];
-    };
+    itemHelper.getStimuliHrefs = () => ['http://include1.xml', 'http://include2.xml'];
 
     function selectText(id) {
         const el = document.getElementById(id); //get element id
@@ -72,6 +70,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/highlighter/plugin/test.js
+++ b/test/plugins/tools/highlighter/plugin/test.js
@@ -29,15 +29,13 @@ define([
 ], function($, _, hider, runnerFactory, itemHelper, providerMock, pluginFactory) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     function selectText(id) {
-        var sel, range;
-        var el = document.getElementById(id); //get element id
-        sel = window.getSelection();
-        range = document.createRange(); //range object
+        const el = document.getElementById(id); //get element id
+        const sel = window.getSelection();
+        const range = document.createRange(); //range object
         range.selectNodeContents(el); //sets Range
         sel.removeAllRanges(); //remove all ranges from selection
         sel.addRange(range); //add Range to a Selection.
@@ -73,8 +71,8 @@ define([
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
         assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
@@ -85,47 +83,45 @@ define([
         );
     });
 
-    pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var runner = runnerFactory(providerName);
-        var timer = pluginFactory(runner);
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const timer = pluginFactory(runner);
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
-    QUnit.test('pluginFactory.init', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('pluginFactory.init', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `The init failed: ${err}`);
                 ready();
             });
@@ -136,79 +132,69 @@ define([
      */
     QUnit.module('plugin button');
 
-    function getButtonContainer(runner) {
-        return runner.getAreaBroker().getToolboxArea();
-    }
-
-    QUnit.test('render/destroy button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('render/destroy button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(6);
 
         plugin
             .init()
-            .then(function() {
-                var $container = getButtonContainer(runner),
-                    $buttonMain,
-                    $buttonRemove;
-
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
-                $buttonMain = $container.find('[data-control="highlight-trigger"]');
-                $buttonRemove = $container.find('[data-control="highlight-clear"]');
+                const $buttonMainBefore = $container.find('[data-control="highlight-trigger"]');
+                const $buttonRemoveBefore = $container.find('[data-control="highlight-clear"]');
 
-                assert.equal($buttonMain.length, 1, 'The trigger button has been inserted');
-                assert.equal($buttonMain.hasClass('disabled'), true, 'The trigger button has been rendered disabled');
-                assert.equal($buttonRemove.length, 1, 'The remove button has been inserted');
-                assert.equal($buttonMain.hasClass('disabled'), true, 'The remove button has been rendered disabled');
+                assert.equal($buttonMainBefore.length, 1, 'The trigger button has been inserted');
+                assert.equal($buttonMainBefore.hasClass('disabled'), true, 'The trigger button has been rendered disabled');
+                assert.equal($buttonRemoveBefore.length, 1, 'The remove button has been inserted');
+                assert.equal($buttonMainBefore.hasClass('disabled'), true, 'The remove button has been rendered disabled');
 
                 areaBroker.getToolbox().destroy();
 
-                $buttonMain = $container.find('[data-control="highlight-trigger"]');
-                $buttonRemove = $container.find('[data-control="highlight-clear"]');
+                const $buttonMainAfter = $container.find('[data-control="highlight-trigger"]');
+                const $buttonRemoveAfter = $container.find('[data-control="highlight-clear"]');
 
-                assert.equal($buttonMain.length, 0, 'The trigger button has been removed');
-                assert.equal($buttonRemove.length, 0, 'The remove button has been removed');
+                assert.equal($buttonMainAfter.length, 0, 'The trigger button has been removed');
+                assert.equal($buttonRemoveAfter.length, 0, 'The remove button has been removed');
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('enable/disable button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('enable/disable button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(4);
 
         plugin
             .init()
-            .then(function() {
-                var $container = getButtonContainer(runner),
-                    $buttonMain,
-                    $buttonRemove;
-
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
                 plugin
                     .enable()
-                    .then(function() {
-                        $buttonMain = $container.find('[data-control="highlight-trigger"]');
-                        $buttonRemove = $container.find('[data-control="highlight-clear"]');
+                    .then(() => {
+                        const $buttonMain = $container.find('[data-control="highlight-trigger"]');
+                        const $buttonRemove = $container.find('[data-control="highlight-clear"]');
 
                         assert.equal($buttonMain.hasClass('disabled'), false, 'The trigger button has been enabled');
                         assert.equal($buttonRemove.hasClass('disabled'), false, 'The remove button has been enabled');
 
                         plugin
                             .disable()
-                            .then(function() {
+                            .then(() => {
                                 assert.equal(
                                     $buttonMain.hasClass('disabled'),
                                     true,
@@ -222,67 +208,64 @@ define([
 
                                 ready();
                             })
-                            .catch(function(err) {
+                            .catch(err => {
                                 assert.ok(false, `error in disable method: ${err}`);
                                 ready();
                             });
                     })
-                    .catch(function(err) {
+                    .catch(err => {
                         assert.ok(false, `error in enable method: ${err}`);
                         ready();
                     });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('show/hide button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('show/hide button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(4);
 
         plugin
             .init()
-            .then(function() {
-                var $container = getButtonContainer(runner),
-                    $buttonMain,
-                    $buttonRemove;
-
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
                 plugin
                     .hide()
-                    .then(function() {
-                        $buttonMain = $container.find('[data-control="highlight-trigger"]');
-                        $buttonRemove = $container.find('[data-control="highlight-clear"]');
+                    .then(() => {
+                        const $buttonMain = $container.find('[data-control="highlight-trigger"]');
+                        const $buttonRemove = $container.find('[data-control="highlight-clear"]');
 
                         assert.ok(hider.isHidden($buttonMain), 'The trigger button has been hidden');
                         assert.ok(hider.isHidden($buttonRemove), 'The remove button has been hidden');
 
                         plugin
                             .show()
-                            .then(function() {
+                            .then(() => {
                                 assert.ok(!hider.isHidden($buttonMain), 'The trigger button is visible');
                                 assert.ok(!hider.isHidden($buttonRemove), 'The remove button is visible');
 
                                 ready();
                             })
-                            .catch(function(err) {
+                            .catch(err => {
                                 assert.ok(false, `error in disable method: ${err}`);
                                 ready();
                             });
                     })
-                    .catch(function(err) {
+                    .catch(err => {
                         assert.ok(false, `error in enable method: ${err}`);
                         ready();
                     });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
@@ -291,11 +274,12 @@ define([
     /**
      * The following tests applies to this plugin specfically
      */
-    QUnit.test('runner events: loaditem / unloaditem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('runner events: loaditem / unloaditem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(6);
 
@@ -304,15 +288,11 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $container = getButtonContainer(runner),
-                    $buttonMain,
-                    $buttonRemove;
-
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
-                $buttonMain = $container.find('[data-control="highlight-trigger"]');
-                $buttonRemove = $container.find('[data-control="highlight-clear"]');
+                const $buttonMain = $container.find('[data-control="highlight-trigger"]');
+                const $buttonRemove = $container.find('[data-control="highlight-clear"]');
 
                 runner.trigger('loaditem');
 
@@ -329,31 +309,28 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('runner events: renderitem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('runner events: renderitem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(4);
 
         plugin
             .init()
-            .then(function() {
-                var $container = getButtonContainer(runner),
-                    $buttonMain,
-                    $buttonRemove;
-
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
-                $buttonMain = $container.find('[data-control="highlight-trigger"]');
-                $buttonRemove = $container.find('[data-control="highlight-clear"]');
+                const $buttonMain = $container.find('[data-control="highlight-trigger"]');
+                const $buttonRemove = $container.find('[data-control="highlight-clear"]');
 
                 runner.trigger('renderitem');
 
@@ -365,25 +342,25 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('actions: select item & stimulus texts, unload, reload', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
-        var $container, $buttonMain, $buttonRemove;
-        var cleanItemHtml = $('#qunit-item').html();
+    QUnit.test('actions: select item & stimulus texts, unload, reload', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const $container = areaBroker.getToolboxArea();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
+        const cleanItemHtml = $('#qunit-item').html();
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
 
         // mock stimulus helper
-        itemHelper.getStimuliHrefs = function() {
+        itemHelper.getStimuliHrefs = () => {
             return ['http://include1.xml', 'http://include2.xml'];
         };
 
@@ -391,11 +368,8 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                $container = getButtonContainer(runner);
+            .then(() => {
                 areaBroker.getToolbox().render($container);
-                $buttonMain = $container.find('[data-control="highlight-trigger"]');
-                $buttonRemove = $container.find('[data-control="highlight-clear"]');
 
                 runner.trigger('loaditem');
                 runner.trigger('renderitem');
@@ -405,7 +379,9 @@ define([
                     setTimeout(resolve, 1000);
                 });
             })
-            .then(function() {
+            .then(() => {
+                const $buttonMain = $container.find('[data-control="highlight-trigger"]');
+
                 // do some highlighting
                 selectText('para1');
                 $buttonMain.trigger('mousedown');
@@ -434,7 +410,7 @@ define([
                     setTimeout(resolve, 1000);
                 });
             })
-            .then(function() {
+            .then(() => {
                 $('#qunit-item').html(cleanItemHtml);
 
                 // load item again
@@ -446,7 +422,9 @@ define([
                     setTimeout(resolve, 1000);
                 });
             })
-            .then(function() {
+            .then(() => {
+                const $buttonRemove = $container.find('[data-control="highlight-clear"]');
+
                 // test loaded highlights
                 assert.equal($('#para1 span').length, 1, 'Para 1 was highlighted');
                 assert.equal($('#para2 span').length, 1, 'Para 2 was highlighted');
@@ -458,7 +436,7 @@ define([
                 assert.equal($('.qti-itemBody').find('span').length, 0, 'No highlights remain after clear');
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });

--- a/test/plugins/tools/lineReader/plugin/test.js
+++ b/test/plugins/tools/lineReader/plugin/test.js
@@ -28,8 +28,7 @@ define([
 ], function(_, hider, runnerFactory, providerMock, pluginFactory) {
     'use strict';
 
-    var pluginApi;
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     const sampleTestContext = {
@@ -62,8 +61,8 @@ define([
      */
     QUnit.module('pluginFactory');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
         assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
@@ -74,47 +73,45 @@ define([
         );
     });
 
-    pluginApi = [
-        { name: 'init', title: 'init' },
-        { name: 'render', title: 'render' },
-        { name: 'finish', title: 'finish' },
-        { name: 'destroy', title: 'destroy' },
-        { name: 'trigger', title: 'trigger' },
-        { name: 'getTestRunner', title: 'getTestRunner' },
-        { name: 'getAreaBroker', title: 'getAreaBroker' },
-        { name: 'getConfig', title: 'getConfig' },
-        { name: 'setConfig', title: 'setConfig' },
-        { name: 'getState', title: 'getState' },
-        { name: 'setState', title: 'setState' },
-        { name: 'show', title: 'show' },
-        { name: 'hide', title: 'hide' },
-        { name: 'enable', title: 'enable' },
-        { name: 'disable', title: 'disable' }
-    ];
-
-    QUnit.cases.init(pluginApi).test('plugin API ', function(data, assert) {
-        var runner = runnerFactory(providerName);
-        var timer = pluginFactory(runner);
+    QUnit.cases.init([
+        { title: 'init' },
+        { title: 'render' },
+        { title: 'finish' },
+        { title: 'destroy' },
+        { title: 'trigger' },
+        { title: 'getTestRunner' },
+        { title: 'getAreaBroker' },
+        { title: 'getConfig' },
+        { title: 'setConfig' },
+        { title: 'getState' },
+        { title: 'setState' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' }
+    ]).test('plugin API ', (data, assert) => {
+        const runner = runnerFactory(providerName);
+        const timer = pluginFactory(runner);
         assert.equal(
-            typeof timer[data.name],
+            typeof timer[data.title],
             'function',
-            `The pluginFactory instances expose a "${data.name}" function`
+            `The pluginFactory instances expose a "${data.title}" function`
         );
     });
 
-    QUnit.test('pluginFactory.init', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('pluginFactory.init', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         plugin
             .init()
-            .then(function() {
+            .then(() => {
                 assert.equal(plugin.getState('init'), true, 'The plugin is initialised');
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `The init failed: ${err}`);
                 ready();
             });
@@ -125,100 +122,97 @@ define([
      */
     QUnit.module('plugin button');
 
-    QUnit.test('render/destroy button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('render/destroy button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(4);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="line-reader"]');
+                const $buttonBefore = $container.find('[data-control="line-reader"]');
 
-                assert.equal($button.length, 1, 'The trigger button has been inserted');
-                assert.equal($button.hasClass('disabled'), true, 'The trigger button has been rendered disabled');
-                assert.equal($button.hasClass('disabled'), true, 'The remove button has been rendered disabled');
+                assert.equal($buttonBefore.length, 1, 'The trigger button has been inserted');
+                assert.equal($buttonBefore.hasClass('disabled'), true, 'The trigger button has been rendered disabled');
+                assert.equal($buttonBefore.hasClass('disabled'), true, 'The remove button has been rendered disabled');
 
                 areaBroker.getToolbox().destroy();
 
-                $button = $container.find('[data-control="line-reader"]');
+                const $buttonAfter = $container.find('[data-control="line-reader"]');
 
-                assert.equal($button.length, 0, 'The trigger button has been removed');
+                assert.equal($buttonAfter.length, 0, 'The trigger button has been removed');
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('enable/disable button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('enable/disable button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(2);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                return plugin.enable().then(function() {
-                    $button = $container.find('[data-control="line-reader"]');
+                return plugin.enable().then(() => {
+                    const $button = $container.find('[data-control="line-reader"]');
 
                     assert.equal($button.hasClass('disabled'), false, 'The trigger button has been enabled');
 
-                    return plugin.disable().then(function() {
+                    return plugin.disable().then(() => {
                         assert.equal($button.hasClass('disabled'), true, 'The trigger button has been disabled');
 
                         ready();
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('show/hide button', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('show/hide button', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(3);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                return plugin.hide().then(function() {
-                    $button = $container.find('[data-control="line-reader"]');
+                return plugin.hide().then(() => {
+                    const $button = $container.find('[data-control="line-reader"]');
 
                     assert.ok(hider.isHidden($button), 'The trigger button has been hidden');
 
-                    return plugin.show().then(function() {
+                    return plugin.show().then(() => {
                         assert.ok(!hider.isHidden($button), 'The trigger button is visible');
 
-                        return plugin.hide().then(function() {
+                        return plugin.hide().then(() => {
                             assert.ok(hider.isHidden($button), 'The trigger button has been hidden again');
 
                             ready();
@@ -226,17 +220,17 @@ define([
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('runner events: loaditem / unloaditem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('runner events: loaditem / unloaditem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(3);
 
@@ -245,13 +239,12 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="line-reader"]');
+                const $button = $container.find('[data-control="line-reader"]');
 
                 runner.trigger('loaditem');
 
@@ -265,29 +258,28 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('runner events: renderitem', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('runner events: renderitem', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(2);
 
         plugin
             .init()
-            .then(function() {
-                var $container = runner.getAreaBroker().getToolboxArea(),
-                    $button;
+            .then(() => {
+                const $container = runner.getAreaBroker().getToolboxArea();
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="line-reader"]');
+                const $button = $container.find('[data-control="line-reader"]');
 
                 runner.trigger('renderitem');
 
@@ -297,7 +289,7 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Error in init method: ${err}`);
                 ready();
             });
@@ -308,11 +300,11 @@ define([
      */
     QUnit.module('line reader');
 
-    QUnit.test('Render compound mask', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('Render compound mask', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(4);
 
@@ -321,8 +313,8 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $contentContainer = areaBroker.getContentArea().parent(),
+            .then(() => {
+                const $contentContainer = areaBroker.getContentArea().parent(),
                     $masks = $contentContainer.find('.line-reader-mask'),
                     $overlays = $contentContainer.find('.line-reader-overlay');
 
@@ -336,17 +328,17 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('Toggle on click', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName);
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+    QUnit.test('Toggle on click', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(8);
 
@@ -355,17 +347,16 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $contentContainer = areaBroker.getContentArea().parent(),
+            .then(() => {
+                const $contentContainer = areaBroker.getContentArea().parent(),
                     $toolboxContainer = areaBroker.getToolboxArea(),
                     $masks = $contentContainer.find('.line-reader-mask'),
-                    $overlays = $contentContainer.find('.line-reader-overlay'),
-                    $button;
+                    $overlays = $contentContainer.find('.line-reader-overlay');
 
                 runner.trigger('renderitem');
 
                 areaBroker.getToolbox().render($toolboxContainer);
-                $button = areaBroker.getToolboxArea().find('[data-control="line-reader"]');
+                const $button = areaBroker.getToolboxArea().find('[data-control="line-reader"]');
 
                 assert.equal($masks.length, 8, '8 masks have been rendered');
                 assert.equal($overlays.length, 1, '1 overlay has been rendered');
@@ -385,15 +376,15 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });
     });
 
-    QUnit.test('Toggle on keyboard shortcut', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName, {}, {
+    QUnit.test('Toggle on keyboard shortcut', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName, {}, {
             options: {
                 allowShortcuts: true,
                 shortcuts: {
@@ -403,8 +394,8 @@ define([
                 }
             }
         });
-        var areaBroker = runner.getAreaBroker();
-        var plugin = pluginFactory(runner, runner.getAreaBroker());
+        const areaBroker = runner.getAreaBroker();
+        const plugin = pluginFactory(runner, runner.getAreaBroker());
 
         assert.expect(6);
 
@@ -413,8 +404,8 @@ define([
 
         plugin
             .init()
-            .then(function() {
-                var $contentContainer = areaBroker.getContentArea().parent(),
+            .then(() => {
+                const $contentContainer = areaBroker.getContentArea().parent(),
                     $masks = $contentContainer.find('.line-reader-mask'),
                     $overlays = $contentContainer.find('.line-reader-overlay');
 
@@ -455,7 +446,7 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected error: ${err}`);
                 ready();
             });

--- a/test/plugins/tools/lineReader/plugin/test.js
+++ b/test/plugins/tools/lineReader/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA ;
  */
 /**
  * @author Christophe Noël <christophe@taotesting.com>
@@ -58,6 +58,7 @@ define([
 
     /**
      * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
      * @returns {Promise<runner>}
      */
     function getTestRunner(config) {

--- a/test/plugins/tools/magnifier/plugin/test.js
+++ b/test/plugins/tools/magnifier/plugin/test.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2016-2021 (original work) Open Assessment Technologies SA ;
  */
 
 define([

--- a/test/plugins/tools/magnifier/plugin/test.js
+++ b/test/plugins/tools/magnifier/plugin/test.js
@@ -22,22 +22,24 @@ define([
     'taoTests/runner/runner',
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/runner/plugins/tools/magnifier/magnifier'
-], function($, _, runnerFactory, providerMock, magnifierFactory) {
+], function ($, _, runnerFactory, providerMock, magnifierFactory) {
     'use strict';
+
+    const uiDelay = 50;
 
     const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     const sampleTestContext = {
-        itemIdentifier : 'item-1'
+        itemIdentifier: 'item-1'
     };
     const sampleTestMap = {
         parts: {
-            p1 : {
-                sections : {
-                    s1 : {
-                        items : {
-                            'item-1' : {
+            p1: {
+                sections: {
+                    s1: {
+                        items: {
+                            'item-1': {
                                 categories: ['x-tao-option-magnifier']
                             }
                         }
@@ -45,13 +47,25 @@ define([
                 }
             }
         },
-        jumps : [{
+        jumps: [{
             identifier: 'item-1',
             section: 's1',
             part: 'p1',
             position: 0
         }]
     };
+
+    /**
+     * Gets a configured instance of the Test Runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner() {
+        const runner = runnerFactory(providerName);
+        runner.getDataHolder();
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+        return Promise.resolve(runner);
+    }
 
     QUnit.module('API');
 
@@ -88,278 +102,317 @@ define([
             const magnifier = magnifierFactory(runner);
             assert.expect(1);
 
-            assert.equal(typeof magnifier[data.title], 'function', `The plugin exposes a ${  data.title  } method`);
+            assert.equal(typeof magnifier[data.title], 'function', `The plugin exposes a ${data.title} method`);
         });
 
     QUnit.module('plugin lifecycle');
 
     QUnit.test('init', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const magnifier = magnifierFactory(runner, areaBroker);
-        const $container = runner.getAreaBroker().getToolboxArea();
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const magnifier = magnifierFactory(runner, areaBroker);
+                const $container = runner.getAreaBroker().getToolboxArea();
 
-        assert.expect(4);
+                assert.expect(4);
 
-        magnifier
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                return magnifier
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                const $button = $container.find('[data-control="magnify"]');
+                        const $button = $container.find('[data-control="magnify"]');
 
-                assert.equal($button.length, 1, 'The magnifier has created a button');
-                assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
-                assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
-                assert.ok($button.hasClass('disabled'), 'The button starts disabled');
-
-                ready();
+                        assert.equal($button.length, 1, 'The magnifier has created a button');
+                        assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
+                        assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
+                        assert.ok($button.hasClass('disabled'), 'The button starts disabled');
+                    });
             })
             .catch(err => {
-                assert.ok(false, `The init method must not fail : ${  err.message}`);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('render', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const magnifier = magnifierFactory(runner, areaBroker);
-        const $container = runner.getAreaBroker().getToolboxArea();
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const magnifier = magnifierFactory(runner, areaBroker);
+                const $container = runner.getAreaBroker().getToolboxArea();
 
-        assert.expect(4);
+                assert.expect(4);
 
-        magnifier
-            .init()
-            .then(() => {
-                assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
+                return magnifier
+                    .init()
+                    .then(() => {
+                        assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
 
-                areaBroker.getToolbox().render($container);
+                        areaBroker.getToolbox().render($container);
 
-                const $button = $container.find('[data-control="magnify"]');
+                        const $button = $container.find('[data-control="magnify"]');
 
-                assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
-                assert.equal($button.length, 1, 'The plugin button has been appended');
-                assert.ok($button.hasClass('disabled'), 'The plugin button starts disabled');
-
-                ready();
+                        assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
+                        assert.equal($button.length, 1, 'The plugin button has been appended');
+                        assert.ok($button.hasClass('disabled'), 'The plugin button starts disabled');
+                    });
             })
             .catch(err => {
-                assert.ok(false, `Unexpected failure : ${  err.message}`);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('state', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const magnifier = magnifierFactory(runner, areaBroker);
-        const $container = runner.getAreaBroker().getToolboxArea();
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const magnifier = magnifierFactory(runner, areaBroker);
+                const $container = runner.getAreaBroker().getToolboxArea();
 
-        assert.expect(11);
+                assert.expect(11);
 
-        magnifier
-            .init()
-            .then(() => {
-                assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
+                return magnifier
+                    .init()
+                    .then(() => {
+                        assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
 
-                areaBroker.getToolbox().render($container);
+                        areaBroker.getToolbox().render($container);
 
-                const $button = $container.find('[data-control="magnify"]');
+                        const $button = $container.find('[data-control="magnify"]');
 
-                assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
-                assert.equal($button.length, 1, 'The plugin button has been appended');
-                assert.ok($button.hasClass('disabled'), 'The plugin button starts disabled');
+                        assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
+                        assert.equal($button.length, 1, 'The plugin button has been appended');
+                        assert.ok($button.hasClass('disabled'), 'The plugin button starts disabled');
 
-                return magnifier.enable().then(() => {
-                    assert.ok(magnifier.getState('enabled'), 'The magnifier is now enabled');
-                    assert.ok(!$button.hasClass('disabled'), 'The plugin button is enabled');
+                        return magnifier.enable();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="magnify"]');
 
-                    assert.ok(!$button.hasClass('hidden'), 'The plugin button is visible');
+                        assert.ok(magnifier.getState('enabled'), 'The magnifier is now enabled');
+                        assert.ok(!$button.hasClass('disabled'), 'The plugin button is enabled');
 
-                    return magnifier.hide().then(() => {
+                        assert.ok(!$button.hasClass('hidden'), 'The plugin button is visible');
+
+                        return magnifier.hide();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="magnify"]');
+
                         assert.ok($button.hasClass('hidden'), 'The plugin button is hidden');
 
-                        return magnifier.show().then(() => {
-                            assert.ok(!$button.hasClass('hidden'), 'The plugin button is visible');
+                        return magnifier.show();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="magnify"]');
 
-                            return magnifier.disable().then(() => {
-                                assert.ok(!magnifier.getState('enabled'), 'The magnifier is now disabled');
-                                assert.ok($button.hasClass('disabled'), 'The plugin button is disabled');
+                        assert.ok(!$button.hasClass('hidden'), 'The plugin button is visible');
 
-                                ready();
-                            });
-                        });
+                        return magnifier.disable();
+                    })
+                    .then(() => {
+                        const $button = $container.find('[data-control="magnify"]');
+
+                        assert.ok(!magnifier.getState('enabled'), 'The magnifier is now disabled');
+                        assert.ok($button.hasClass('disabled'), 'The plugin button is disabled');
                     });
-                });
             })
             .catch(err => {
-                assert.ok(false, `Unexpected failure : ${  err.message}`);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.test('destroy', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const magnifier = magnifierFactory(runner, areaBroker);
-        const $container = runner.getAreaBroker().getToolboxArea();
+        getTestRunner()
+            .then(runner => {
+                const areaBroker = runner.getAreaBroker();
+                const magnifier = magnifierFactory(runner, areaBroker);
+                const $container = runner.getAreaBroker().getToolboxArea();
 
-        assert.expect(3);
+                assert.expect(3);
 
-        magnifier
-            .init()
-            .then(() => {
-                areaBroker.getToolbox().render($container);
+                return magnifier
+                    .init()
+                    .then(() => {
+                        areaBroker.getToolbox().render($container);
 
-                const $button = $container.find('[data-control="magnify"]');
+                        const $button = $container.find('[data-control="magnify"]');
 
-                assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
+                        assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
 
-                assert.equal($button.length, 1, 'The plugin button has been appended');
+                        assert.equal($button.length, 1, 'The plugin button has been appended');
 
-                return magnifier.destroy().then(() => {
-                    areaBroker.getToolbox().destroy();
+                        return magnifier.destroy();
+                    })
+                    .then(() => {
+                        areaBroker.getToolbox().destroy();
 
-                    const $button = $container.find('[data-control="magnify"]');
+                        const $button = $container.find('[data-control="magnify"]');
 
-                    assert.equal($button.length, 0, 'The plugin button has been removed');
-                    ready();
-                });
+                        assert.equal($button.length, 0, 'The plugin button has been removed');
+                    });
             })
             .catch(err => {
-                assert.ok(false, `Unexpected failure : ${  err.message}`);
-                ready();
-            });
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
     });
 
     QUnit.module('magnifier');
 
     QUnit.test('create', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const magnifier = magnifierFactory(runner, areaBroker);
-        const $container = $('#qunit-fixture');
-        let $button;
+        getTestRunner()
+            .then(runner => new Promise(resolve => {
+                const areaBroker = runner.getAreaBroker();
+                const magnifier = magnifierFactory(runner, areaBroker);
+                const $container = $('#qunit-fixture');
+                let $button;
 
-        assert.expect(12);
+                assert.expect(12);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                runner.setTestContext(sampleTestContext);
+                runner.setTestMap(sampleTestMap);
 
-        runner.on('plugin-magnifier-create.magnifier', () => {
-            assert.equal($('.magnifier', $container).length, 1, 'A magnifier has been created');
-            assert.ok($('.magnifier', $container).hasClass('hidden'), 'The magnifier is hidden');
-        });
+                runner.on('plugin-magnifier-create.magnifier', () => {
+                    assert.equal($('.magnifier', $container).length, 1, 'A magnifier has been created');
+                    assert.ok($('.magnifier', $container).hasClass('hidden'), 'The magnifier is hidden');
+                });
 
-        runner.on('plugin-magnifier-show.magnifier', () => {
-            _.defer(() => {
-                assert.ok(!$('.magnifier', $container).hasClass('hidden'), 'The magnifier is visible');
-                assert.ok($button.hasClass('active'), 'The button is turned on');
+                runner.on('plugin-magnifier-show.magnifier', () => {
+                    _.defer(() => {
+                        assert.ok(!$('.magnifier', $container).hasClass('hidden'), 'The magnifier is visible');
+                        assert.ok($button.hasClass('active'), 'The button is turned on');
 
-                _.delay(() => {
-                    $button.trigger('click');
-                }, 250);
-            });
-        });
+                        _.delay(() => {
+                            $button.trigger('click');
+                        }, uiDelay);
+                    });
+                });
 
-        runner.on('plugin-magnifier-hide.magnifier', () => {
-            _.defer(() => {
-                assert.ok($('.magnifier', $container).hasClass('hidden'), 'The magnifier is hidden');
-                assert.ok(!$button.hasClass('active'), 'The button is turned off');
+                runner.on('plugin-magnifier-hide.magnifier', () => {
+                    _.defer(() => {
+                        assert.ok($('.magnifier', $container).hasClass('hidden'), 'The magnifier is hidden');
+                        assert.ok(!$button.hasClass('active'), 'The button is turned off');
 
-                ready();
-            });
-        });
+                        runner.off('.magnifier');
+                        resolve();
+                    });
+                });
 
-        magnifier
-            .init()
-            .then(() => {
-                assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
+                magnifier
+                    .init()
+                    .then(() => {
+                        assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
 
-                areaBroker.getToolbox().render(areaBroker.getToolboxArea());
-                $button = $('[data-control="magnify"]', areaBroker.getToolboxArea());
+                        areaBroker.getToolbox().render(areaBroker.getToolboxArea());
+                        $button = $('[data-control="magnify"]', areaBroker.getToolboxArea());
 
-                return magnifier.enable().then(() => {
-                    assert.ok(magnifier.getState('enabled'), 'The magnifier is not disabled anymore');
-                    assert.equal($button.length, 1, 'The plugin button has been appended');
-                    assert.ok(!$button.hasClass('disabled'), 'The button is not disabled anymore');
-                    assert.ok(!$button.hasClass('active'), 'The button is not turned on');
+                        return magnifier.enable();
+                    })
+                    .then(() => {
+                        assert.ok(magnifier.getState('enabled'), 'The magnifier is not disabled anymore');
+                        assert.equal($button.length, 1, 'The plugin button has been appended');
+                        assert.ok(!$button.hasClass('disabled'), 'The button is not disabled anymore');
+                        assert.ok(!$button.hasClass('active'), 'The button is not turned on');
 
-                    assert.equal($('.magnifier', $container).length, 0, 'No magnifier exists yet');
+                        assert.equal($('.magnifier', $container).length, 0, 'No magnifier exists yet');
 
-                    $button.trigger('click');
+                        $button.trigger('click');
+                    });
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
                 });
             })
-            .catch(err => {
-                assert.ok(false, `Unexpected failure : ${  err.message}`);
-                ready();
-            });
+            .then(ready);
     });
 
     QUnit.test('zoom', assert => {
         const ready = assert.async();
-        const runner = runnerFactory(providerName);
-        const areaBroker = runner.getAreaBroker();
-        const magnifier = magnifierFactory(runner, areaBroker);
-        const $container = $('#qunit-fixture');
-        let $button;
-        let expectedZoomLevel = 2;
+        getTestRunner()
+            .then(runner => new Promise(resolve => {
+                const areaBroker = runner.getAreaBroker();
+                const magnifier = magnifierFactory(runner, areaBroker);
+                const $container = $('#qunit-fixture');
+                let $button;
+                let expectedZoomLevel = 2;
 
-        assert.expect(8);
+                assert.expect(8);
 
-        runner.setTestContext(sampleTestContext);
-        runner.setTestMap(sampleTestMap);
+                runner.setTestContext(sampleTestContext);
+                runner.setTestMap(sampleTestMap);
 
-        runner.on('plugin-magnifier-create.magnifier', () => {
-            assert.equal($('.magnifier', $container).length, 1, 'A magnifier has been created');
-
-            _.delay(() => {
-                expectedZoomLevel = 2.5;
-
-                runner.trigger('tool-magnifier-in');
-
-                _.delay(() => {
-                    expectedZoomLevel = 2;
-                    runner.trigger('tool-magnifier-out');
+                runner.on('plugin-magnifier-create.magnifier', () => {
+                    assert.equal($('.magnifier', $container).length, 1, 'A magnifier has been created');
 
                     _.delay(() => {
-                        ready();
-                    }, 250);
-                }, 250);
-            }, 250);
-        });
+                        expectedZoomLevel = 2.5;
 
-        runner.on('plugin-magnifier-zoom.magnifier', (plugin, zoomLevel) => {
-            assert.equal(zoomLevel, expectedZoomLevel, 'The magnifier is set the right zoom level');
-        });
+                        runner.trigger('tool-magnifier-in');
 
-        magnifier
-            .init()
-            .then(() => {
-                assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
+                        _.delay(() => {
+                            expectedZoomLevel = 2;
+                            runner.trigger('tool-magnifier-out');
 
-                areaBroker.getToolbox().render(areaBroker.getToolboxArea());
-                $button = $('[data-control="magnify"]', areaBroker.getToolboxArea());
+                            _.delay(() => {
+                                resolve();
+                            }, uiDelay);
+                        }, uiDelay);
+                    }, uiDelay);
+                });
 
-                return magnifier.enable().then(() => {
-                    assert.ok(magnifier.getState('enabled'), 'The magnifier is not disabled anymore');
-                    assert.equal($button.length, 1, 'The plugin button has been appended');
-                    assert.ok(!$button.hasClass('disabled'), 'The button is not disabled anymore');
+                runner.on('plugin-magnifier-zoom.magnifier', (plugin, zoomLevel) => {
+                    assert.equal(zoomLevel, expectedZoomLevel, 'The magnifier is set the right zoom level');
+                });
 
-                    assert.equal($('.magnifier', $container).length, 0, 'No magnifier exists yet');
+                magnifier
+                    .init()
+                    .then(() => {
+                        assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
 
-                    $button.trigger('click');
+                        areaBroker.getToolbox().render(areaBroker.getToolboxArea());
+                        $button = $('[data-control="magnify"]', areaBroker.getToolboxArea());
+
+                        return magnifier.enable();
+                    })
+                    .then(() => {
+                        assert.ok(magnifier.getState('enabled'), 'The magnifier is not disabled anymore');
+                        assert.equal($button.length, 1, 'The plugin button has been appended');
+                        assert.ok(!$button.hasClass('disabled'), 'The button is not disabled anymore');
+
+                        assert.equal($('.magnifier', $container).length, 0, 'No magnifier exists yet');
+
+                        $button.trigger('click');
+                    });
+            }))
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
                 });
             })
-            .catch(err => {
-                assert.ok(false, `Unexpected failure : ${  err.message}`);
-                ready();
-            });
+            .then(ready);
     });
 });

--- a/test/plugins/tools/magnifier/plugin/test.js
+++ b/test/plugins/tools/magnifier/plugin/test.js
@@ -25,7 +25,7 @@ define([
 ], function($, _, runnerFactory, providerMock, magnifierFactory) {
     'use strict';
 
-    var providerName = 'mock';
+    const providerName = 'mock';
     runnerFactory.registerProvider(providerName, providerMock());
 
     const sampleTestContext = {
@@ -55,8 +55,8 @@ define([
 
     QUnit.module('API');
 
-    QUnit.test('module', function(assert) {
-        var runner = runnerFactory(providerName);
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
 
         assert.expect(3);
 
@@ -67,48 +67,47 @@ define([
 
     QUnit.cases
         .init([
-            { name: 'init', title: 'init' },
-            { name: 'render', title: 'render' },
-            { name: 'finish', title: 'finish' },
-            { name: 'destroy', title: 'destroy' },
-            { name: 'trigger', title: 'trigger' },
-            { name: 'getTestRunner', title: 'getTestRunner' },
-            { name: 'getAreaBroker', title: 'getAreaBroker' },
-            { name: 'getConfig', title: 'getConfig' },
-            { name: 'setConfig', title: 'setConfig' },
-            { name: 'getState', title: 'getState' },
-            { name: 'setState', title: 'setState' },
-            { name: 'show', title: 'show' },
-            { name: 'hide', title: 'hide' },
-            { name: 'enable', title: 'enable' },
-            { name: 'disable', title: 'disable' }
+            { title: 'init' },
+            { title: 'render' },
+            { title: 'finish' },
+            { title: 'destroy' },
+            { title: 'trigger' },
+            { title: 'getTestRunner' },
+            { title: 'getAreaBroker' },
+            { title: 'getConfig' },
+            { title: 'setConfig' },
+            { title: 'getState' },
+            { title: 'setState' },
+            { title: 'show' },
+            { title: 'hide' },
+            { title: 'enable' },
+            { title: 'disable' }
         ])
-        .test('plugin ', function(data, assert) {
-            var runner = runnerFactory(providerName);
-            var magnifier = magnifierFactory(runner);
+        .test('plugin ', (data, assert) => {
+            const runner = runnerFactory(providerName);
+            const magnifier = magnifierFactory(runner);
             assert.expect(1);
 
-            assert.equal(typeof magnifier[data.name], 'function', `The plugin exposes a ${  data.name  } method`);
+            assert.equal(typeof magnifier[data.title], 'function', `The plugin exposes a ${  data.title  } method`);
         });
 
     QUnit.module('plugin lifecycle');
 
-    QUnit.test('init', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            magnifier = magnifierFactory(runner, areaBroker),
-            $container = runner.getAreaBroker().getToolboxArea(),
-            $button;
+    QUnit.test('init', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const magnifier = magnifierFactory(runner, areaBroker);
+        const $container = runner.getAreaBroker().getToolboxArea();
 
         assert.expect(4);
 
         magnifier
             .init()
-            .then(function() {
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="magnify"]');
+                const $button = $container.find('[data-control="magnify"]');
 
                 assert.equal($button.length, 1, 'The magnifier has created a button');
                 assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
@@ -117,30 +116,29 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `The init method must not fail : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('render', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            magnifier = magnifierFactory(runner, areaBroker),
-            $container = runner.getAreaBroker().getToolboxArea(),
-            $button;
+    QUnit.test('render', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const magnifier = magnifierFactory(runner, areaBroker);
+        const $container = runner.getAreaBroker().getToolboxArea();
 
         assert.expect(4);
 
         magnifier
             .init()
-            .then(function() {
+            .then(() => {
                 assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="magnify"]');
+                const $button = $container.find('[data-control="magnify"]');
 
                 assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
                 assert.equal($button.length, 1, 'The plugin button has been appended');
@@ -148,48 +146,47 @@ define([
 
                 ready();
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('state', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            magnifier = magnifierFactory(runner, areaBroker),
-            $container = runner.getAreaBroker().getToolboxArea(),
-            $button;
+    QUnit.test('state', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const magnifier = magnifierFactory(runner, areaBroker);
+        const $container = runner.getAreaBroker().getToolboxArea();
 
         assert.expect(11);
 
         magnifier
             .init()
-            .then(function() {
+            .then(() => {
                 assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
 
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="magnify"]');
+                const $button = $container.find('[data-control="magnify"]');
 
                 assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
                 assert.equal($button.length, 1, 'The plugin button has been appended');
                 assert.ok($button.hasClass('disabled'), 'The plugin button starts disabled');
 
-                return magnifier.enable().then(function() {
+                return magnifier.enable().then(() => {
                     assert.ok(magnifier.getState('enabled'), 'The magnifier is now enabled');
                     assert.ok(!$button.hasClass('disabled'), 'The plugin button is enabled');
 
                     assert.ok(!$button.hasClass('hidden'), 'The plugin button is visible');
 
-                    return magnifier.hide().then(function() {
+                    return magnifier.hide().then(() => {
                         assert.ok($button.hasClass('hidden'), 'The plugin button is hidden');
 
-                        return magnifier.show().then(function() {
+                        return magnifier.show().then(() => {
                             assert.ok(!$button.hasClass('hidden'), 'The plugin button is visible');
 
-                            return magnifier.disable().then(function() {
+                            return magnifier.disable().then(() => {
                                 assert.ok(!magnifier.getState('enabled'), 'The magnifier is now disabled');
                                 assert.ok($button.hasClass('disabled'), 'The plugin button is disabled');
 
@@ -199,43 +196,42 @@ define([
                     });
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('destroy', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            magnifier = magnifierFactory(runner, areaBroker),
-            $container = runner.getAreaBroker().getToolboxArea(),
-            $button;
+    QUnit.test('destroy', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const magnifier = magnifierFactory(runner, areaBroker);
+        const $container = runner.getAreaBroker().getToolboxArea();
 
         assert.expect(3);
 
         magnifier
             .init()
-            .then(function() {
+            .then(() => {
                 areaBroker.getToolbox().render($container);
 
-                $button = $container.find('[data-control="magnify"]');
+                const $button = $container.find('[data-control="magnify"]');
 
                 assert.ok(magnifier.getState('init'), 'The magnifier is initialised');
 
                 assert.equal($button.length, 1, 'The plugin button has been appended');
 
-                return magnifier.destroy().then(function() {
+                return magnifier.destroy().then(() => {
                     areaBroker.getToolbox().destroy();
 
-                    $button = $container.find('[data-control="magnify"]');
+                    const $button = $container.find('[data-control="magnify"]');
 
                     assert.equal($button.length, 0, 'The plugin button has been removed');
                     ready();
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
@@ -243,37 +239,37 @@ define([
 
     QUnit.module('magnifier');
 
-    QUnit.test('create', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            magnifier = magnifierFactory(runner, areaBroker),
-            $container = $('#qunit-fixture'),
-            $button;
+    QUnit.test('create', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const magnifier = magnifierFactory(runner, areaBroker);
+        const $container = $('#qunit-fixture');
+        let $button;
 
         assert.expect(12);
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
 
-        runner.on('plugin-magnifier-create.magnifier', function() {
+        runner.on('plugin-magnifier-create.magnifier', () => {
             assert.equal($('.magnifier', $container).length, 1, 'A magnifier has been created');
             assert.ok($('.magnifier', $container).hasClass('hidden'), 'The magnifier is hidden');
         });
 
-        runner.on('plugin-magnifier-show.magnifier', function() {
-            _.defer(function() {
+        runner.on('plugin-magnifier-show.magnifier', () => {
+            _.defer(() => {
                 assert.ok(!$('.magnifier', $container).hasClass('hidden'), 'The magnifier is visible');
                 assert.ok($button.hasClass('active'), 'The button is turned on');
 
-                _.delay(function() {
+                _.delay(() => {
                     $button.trigger('click');
                 }, 250);
             });
         });
 
-        runner.on('plugin-magnifier-hide.magnifier', function() {
-            _.defer(function() {
+        runner.on('plugin-magnifier-hide.magnifier', () => {
+            _.defer(() => {
                 assert.ok($('.magnifier', $container).hasClass('hidden'), 'The magnifier is hidden');
                 assert.ok(!$button.hasClass('active'), 'The button is turned off');
 
@@ -283,13 +279,13 @@ define([
 
         magnifier
             .init()
-            .then(function() {
+            .then(() => {
                 assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
 
                 areaBroker.getToolbox().render(areaBroker.getToolboxArea());
                 $button = $('[data-control="magnify"]', areaBroker.getToolboxArea());
 
-                return magnifier.enable().then(function() {
+                return magnifier.enable().then(() => {
                     assert.ok(magnifier.getState('enabled'), 'The magnifier is not disabled anymore');
                     assert.equal($button.length, 1, 'The plugin button has been appended');
                     assert.ok(!$button.hasClass('disabled'), 'The button is not disabled anymore');
@@ -300,58 +296,58 @@ define([
                     $button.trigger('click');
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });
     });
 
-    QUnit.test('zoom', function(assert) {
-        var ready = assert.async();
-        var runner = runnerFactory(providerName),
-            areaBroker = runner.getAreaBroker(),
-            magnifier = magnifierFactory(runner, areaBroker),
-            $container = $('#qunit-fixture'),
-            $button,
-            expectedZoomLevel = 2;
+    QUnit.test('zoom', assert => {
+        const ready = assert.async();
+        const runner = runnerFactory(providerName);
+        const areaBroker = runner.getAreaBroker();
+        const magnifier = magnifierFactory(runner, areaBroker);
+        const $container = $('#qunit-fixture');
+        let $button;
+        let expectedZoomLevel = 2;
 
         assert.expect(8);
 
         runner.setTestContext(sampleTestContext);
         runner.setTestMap(sampleTestMap);
 
-        runner.on('plugin-magnifier-create.magnifier', function() {
+        runner.on('plugin-magnifier-create.magnifier', () => {
             assert.equal($('.magnifier', $container).length, 1, 'A magnifier has been created');
 
-            _.delay(function() {
+            _.delay(() => {
                 expectedZoomLevel = 2.5;
 
                 runner.trigger('tool-magnifier-in');
 
-                _.delay(function() {
+                _.delay(() => {
                     expectedZoomLevel = 2;
                     runner.trigger('tool-magnifier-out');
 
-                    _.delay(function() {
+                    _.delay(() => {
                         ready();
                     }, 250);
                 }, 250);
             }, 250);
         });
 
-        runner.on('plugin-magnifier-zoom.magnifier', function(plugin, zoomLevel) {
+        runner.on('plugin-magnifier-zoom.magnifier', (plugin, zoomLevel) => {
             assert.equal(zoomLevel, expectedZoomLevel, 'The magnifier is set the right zoom level');
         });
 
         magnifier
             .init()
-            .then(function() {
+            .then(() => {
                 assert.ok(!magnifier.getState('enabled'), 'The magnifier starts disabled');
 
                 areaBroker.getToolbox().render(areaBroker.getToolboxArea());
                 $button = $('[data-control="magnify"]', areaBroker.getToolboxArea());
 
-                return magnifier.enable().then(function() {
+                return magnifier.enable().then(() => {
                     assert.ok(magnifier.getState('enabled'), 'The magnifier is not disabled anymore');
                     assert.equal($button.length, 1, 'The plugin button has been appended');
                     assert.ok(!$button.hasClass('disabled'), 'The button is not disabled anymore');
@@ -361,7 +357,7 @@ define([
                     $button.trigger('click');
                 });
             })
-            .catch(function(err) {
+            .catch(err => {
                 assert.ok(false, `Unexpected failure : ${  err.message}`);
                 ready();
             });

--- a/test/proxy/offline/proxy/test.html
+++ b/test/proxy/offline/proxy/test.html
@@ -7,14 +7,6 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
-                    // mock Client Config data:
-                    requirejs.config({
-                        config: {
-                            'core/tokenHandler': {
-                                tokens: ['token1', 'token2', 'token3', 'token4', 'token5']
-                            }
-                        }
-                    });
                     require(['taoQtiTest/test/runner/proxy/offline/proxy/test'], function() {
                         QUnit.start();
                     });

--- a/test/proxy/qtiServiceProxy/test.html
+++ b/test/proxy/qtiServiceProxy/test.html
@@ -7,14 +7,6 @@
         <script type="text/javascript">
             require(['/environment/config.js'], function() {
                 require(['qunitEnv'], function() {
-                    // mock Client Config data:
-                    requirejs.config({
-                        config: {
-                            'core/tokenHandler': {
-                                tokens: ['token1', 'token2', 'token3', 'token4', 'token5']
-                            }
-                        }
-                    });
                     require(['taoQtiTest/test/runner/proxy/qtiServiceProxy/test'], function() {
                         QUnit.start();
                     });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-702

As the unit tests were failing silently on the CI, and loudly on local, several things have been made:
- Add a missing URI path in the environment config that was preventing the unit tests to complete
- Updated the package `tao-qunit-testrunner`
- Update several libraries
- Fixed several unit tests (list below)

Note: the unit tests may still fail sometimes due to a timeout on a particular module. Usually, starting the test again should work. This issue will need to be addressed in another story as it relates to the package `@oat-sa/tao-qunit-testrunner`

Updated unit tests:
- `test/plugins/content/dialog/itemInlineMessage/test.html`
- `test/plugins/content/responsiveness/collapser/test.html`
- `test/plugins/content/rubricBlock/test.html`
- `test/plugins/controls/duration/test.html`
- `test/plugins/controls/progressbar/plugin/test.html`
- `test/plugins/controls/timer/plugin/test.html`
- `test/plugins/controls/title/test.html`
- `test/plugins/navigation/allowSkipping/test.html`
- `test/plugins/navigation/next/linearNextItemWarning/test.html`
- `test/plugins/navigation/validateResponses/test.html`
- `test/plugins/tools/answerElimination/eliminator/test.html`
- `test/plugins/tools/answerElimination/plugin/test.html`
- `test/plugins/tools/answerMasking/plugin/test.html`
- `test/plugins/tools/apipTextToSpeech/plugin/test.html`
- `test/plugins/tools/areaMasking/plugin/test.html`
- `test/plugins/tools/highlighter/plugin/test.html`
- `test/plugins/tools/lineReader/plugin/test.html`
- `test/plugins/tools/magnifier/plugin/test.html`
- `test/proxy/qtiServiceProxy/test.html`
- `test/proxy/offline/proxy/test.html`


How to test:
- Run the following commands
```
npm i
npm run build
npm test
```
- All tests must pass (see the note above about possible random timeout)
- You may also start the local test server `npm run test:keepAlive`, then open your browser at the displayed URL, and access each test separately