### PR TITLE
fix / TR 919 revert overflow hidden on control-box

### DIFF
--- a/scss/inc/_test-action-bars.scss
+++ b/scss/inc/_test-action-bars.scss
@@ -130,8 +130,6 @@
             & > .control-box {
                 color: white(.9);
                 text-shadow: 1px 1px 0 black;
-                display: flex;
-                overflow-x: hidden;
                 .lft, .rgt {
                     padding-left: 20px;
                     &:first-child {
@@ -146,12 +144,6 @@
                 }
                 [class^="btn-"], [class*=" btn-"] {
                     white-space: nowrap;
-                }
-                .tools-box {
-                    margin-right: auto;
-                }
-                .lft UL.tools-box-list, .rgt UL.navi-box-list {
-                    display: flex;
                 }
             }
             .tools-box {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-919

- Revert previous solution (https://github.com/oat-sa/tao-test-runner-qti-fe/pull/367/files) that added overflow to control-box, because it cuts plugin dialogs
