### PR TITLE
fix: TR-1206 disallow reload page on opened error popup

### DIFF
--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -52,7 +52,7 @@ export default pluginFactory({
         const testRunner = this.getTestRunner();
         const returnToHome = () => testRunner.trigger('pause', pauseContext);
         const reloadPage = () => testRunner.trigger('reloadpage');
-        const processError = (error) => {
+        const processError = error => {
             testRunner
                 .on('reloadpage', () => window.location.reload())
                 .trigger('disablenav disabletools hidenav')

--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -21,6 +21,7 @@ import pluginFactory from 'taoTests/runner/plugin';
 import dialogTpl from 'taoQtiTest/runner/plugins/controls/connectivity/pauseOnError.tpl';
 
 const name = 'pauseOnError';
+const preventReloadState = 'preventReasonablePageReload';
 const dialogMessage = {
     title: __('Something unexpected happened.'),
     message: __('Please try reloading the page or pause the test. If you pause, you will be able to resume the test from this page.')
@@ -50,7 +51,10 @@ export default pluginFactory({
      */
     init() {
         const testRunner = this.getTestRunner();
-        const returnToHome = () => testRunner.trigger('pause', pauseContext);
+        const returnToHome = () => {
+            testRunner.setState(preventReloadState, false);
+            testRunner.trigger('pause', pauseContext);
+        };
         const reloadPage = () => testRunner.trigger('reloadpage');
         const processError = () => {
             testRunner
@@ -59,6 +63,7 @@ export default pluginFactory({
                 .trigger(`confirm.${name}`, dialogTpl(dialogMessage), returnToHome, reloadPage, dialogConfig);
         };
 
+        testRunner.setState(preventReloadState, true);
         testRunner.on('error', processError);
     }
 });

--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -21,7 +21,6 @@ import pluginFactory from 'taoTests/runner/plugin';
 import dialogTpl from 'taoQtiTest/runner/plugins/controls/connectivity/pauseOnError.tpl';
 
 const name = 'pauseOnError';
-const preventReloadState = 'preventReasonablePageReload';
 const dialogMessage = {
     title: __('Something unexpected happened.'),
     message: __('Please try reloading the page or pause the test. If you pause, you will be able to resume the test from this page.')
@@ -51,22 +50,19 @@ export default pluginFactory({
      */
     init() {
         const testRunner = this.getTestRunner();
-        const returnToHome = () => {
-            testRunner.setState(preventReloadState, false);
-            testRunner.trigger('pause', pauseContext);
-        };
+        const returnToHome = () => testRunner.trigger('pause', pauseContext);
         const reloadPage = () => testRunner.trigger('reloadpage');
-        const processError = err => {
+        const processError = (error) => {
             testRunner
                 .on('reloadpage', () => window.location.reload())
                 .trigger('disablenav disabletools hidenav')
                 .trigger(`confirm.${name}`, dialogTpl(dialogMessage), returnToHome, reloadPage, dialogConfig);
-            if (err.code === 500) {
-                err.originalCode = err.code;
-                delete err.code;
+            if (error.code === 500) {
+                error.originalCode = error.code;
+                delete error.code;
             }
         };
 
-        testRunner.before('error', (e, err) => processError(err));
+        testRunner.before('error', (e, error) => processError(error));
     }
 });

--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -56,14 +56,17 @@ export default pluginFactory({
             testRunner.trigger('pause', pauseContext);
         };
         const reloadPage = () => testRunner.trigger('reloadpage');
-        const processError = () => {
+        const processError = err => {
             testRunner
                 .on('reloadpage', () => window.location.reload())
                 .trigger('disablenav disabletools hidenav')
                 .trigger(`confirm.${name}`, dialogTpl(dialogMessage), returnToHome, reloadPage, dialogConfig);
+            if (err.code === 500) {
+                err.originalCode = err.code;
+                delete err.code;
+            }
         };
 
-        testRunner.setState(preventReloadState, true);
-        testRunner.on('error', processError);
+        testRunner.before('error', (e, err) => processError(err));
     }
 });

--- a/test/plugins/controls/connectivity/pauseOnError/test.js
+++ b/test/plugins/controls/connectivity/pauseOnError/test.js
@@ -84,7 +84,7 @@ define([
         runner
             .on('init', () => {
                 assert.ok(true, 'Runner has been initialized');
-                runner.trigger('error');
+                runner.trigger('error', new Error('test'));
             })
             .on('confirm.*', (message, accept, cancel, options) => {
                 assert.equal(typeof message, 'string', 'String message provided');
@@ -115,7 +115,7 @@ define([
         runner
             .on('init', () => {
                 assert.ok(true, 'Runner has been initialized');
-                runner.trigger('error');
+                runner.trigger('error', new Error('test'));
             })
             .on('confirm.*', (message, accept, cancel, options) => {
                 assert.equal(typeof message, 'string', 'String message provided');


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/TR-1206

**Changes:**
- handle errors to avoid default behavior (reloading)

**How to check:**
- add code to `class.Runner.php` after line 600 to emulate error
> $this->returnJson([], 500);
> die;
- run delivery and press `next` button
- ensure page not reloaded while popup opened

**Requires:**
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/2015