### PR TITLE
fix: TR-1206 disable error 500 feedback message

### DIFF
--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -63,6 +63,9 @@ export default pluginFactory({
             }
         };
 
-        testRunner.before('error', (e, error) => processError(error));
+        testRunner.before('error', (e, error) => {
+            testRunner.trigger(`disablefeedbackalerts`);
+            processError(error);
+        });
     }
 });

--- a/src/plugins/controls/connectivity/pauseOnError.js
+++ b/src/plugins/controls/connectivity/pauseOnError.js
@@ -60,12 +60,15 @@ export default pluginFactory({
             if (error.code === 500) {
                 error.originalCode = error.code;
                 delete error.code;
+
+                testRunner.trigger(`disablefeedbackalerts`);
+                testRunner.after('error.pauseOnError', () => {
+                    testRunner.off('error.pauseOnError');
+                    testRunner.trigger(`enablefeedbackalerts`);
+                });
             }
         };
 
-        testRunner.before('error', (e, error) => {
-            testRunner.trigger(`disablefeedbackalerts`);
-            processError(error);
-        });
+        testRunner.before('error', (e, error) => processError(error));
     }
 });


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/TR-1206

**Changes:**
- disable error alerts overlayed popup message

**How to check:**
- add code to `class.Runner.php` after line 600 to emulate error (temporary available on http://test-alpol.playground.kitchen.it.taocloud.org:40321/)
> $this->returnJson([], 500);
> die;
- run delivery and press `next` button then check conditions:
- [ ] page not reloaded
- [ ] popup opened and offer options to reload page or pause test
- [ ] `error 500` message not appears

**Requires:**
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/2019