### PR TITLE
fix: TR-857 swap title bar margins for RTL languages

### DIFF
--- a/scss/inc/rtl/_title-bar.scss
+++ b/scss/inc/rtl/_title-bar.scss
@@ -7,6 +7,24 @@
     .action-bar.content-action-bar.horizontal-action-bar.top-action-bar {
       .control-box {
 
+        & > .connectivity-box {
+          margin-left: 0px;
+          margin-right: 40px;
+          &.with-message {
+            .message-connect {
+              margin-left: 3px;
+              margin-right: 0px;
+            }
+          }
+        }
+
+        & > .progress-box {
+          & > * {
+            margin-left: 0px;
+            margin-right: 20px;
+          }
+        }
+
         & > .timer-box {
           .timer-wrapper {
             .countdown {

--- a/scss/inc/rtl/_title-bar.scss
+++ b/scss/inc/rtl/_title-bar.scss
@@ -19,13 +19,16 @@
         }
 
         & > .progress-box {
-          & > * {
+          & > .qti-controls {
             margin-left: 0px;
             margin-right: 20px;
           }
         }
 
         & > .timer-box {
+          .timer-toggler {
+            right: 20px;
+          }
           .timer-wrapper {
             .countdown {
               &:first-child {


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/TR-857

**Changes:**
- changed margins (swapped left-right) for title bar elements: `connectivity-box` and `progress-box`

**How to check:**
- run delivery with enabled RTL language
- ensure elements have correct margins

**Requires:**
- none
 
**Note:**
  the other PR requires this one: https://github.com/oat-sa/extension-tao-testqti/pull/2031