### PR TITLE
feature: TR-892 add RTL feature for items in LTR interface

### DIFF
--- a/src/plugins/content/accessibility/rtlHandler.js
+++ b/src/plugins/content/accessibility/rtlHandler.js
@@ -32,14 +32,14 @@ export default pluginFactory({
      * Initializes the plugin (called during runner's init)
      */
     init: function init() {
-        var testRunner = this.getTestRunner();
+        const testRunner = this.getTestRunner();
         testRunner
             .on('renderitem', function applyRtlLayout() {
-                var $item = testRunner
+                const $item = testRunner
                     .getAreaBroker()
                     .getContentArea()
                     .find('.qti-item');
-                var itemLang = $item.attr('lang');
+                const itemLang = $item.attr('lang');
                 $item
                     .find('.grid-row')
                     .attr('dir', locale.getLanguageDirection(itemLang));

--- a/src/plugins/content/accessibility/rtlHandler.js
+++ b/src/plugins/content/accessibility/rtlHandler.js
@@ -1,0 +1,48 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Aliaksandr Paliakou <lecosson@gmail.com>
+ */
+import pluginFactory from 'taoTests/runner/plugin';
+import locale from 'util/locale';
+
+/**
+ * Apply RTL/LTR layout for rendered item depends of language configured on item authoring
+ * Overrides test runner language if it defined on item authoring
+ */
+export default pluginFactory({
+    name: 'rtlHandler',
+
+    /**
+     * Initializes the plugin (called during runner's init)
+     */
+    init: function init() {
+        var testRunner = this.getTestRunner();
+        testRunner
+            .on('renderitem', function applyRtlLayout() {
+                var $item = testRunner
+                    .getAreaBroker()
+                    .getContentArea()
+                    .find('.qti-item');
+                var itemLang = $item.attr('lang');
+                $item
+                    .find('.grid-row')
+                    .attr('dir', locale.getLanguageDirection(itemLang));
+            });
+    }
+});


### PR DESCRIPTION
**Related to:** https://oat-sa.atlassian.net/browse/TR-892

**Changes:**
- `rtlHandler` plugin added to support right-to left languages writing directions

**How to check:**
- check description of related pull request

**Related to:**
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/2057
