### PR TITLE
hotfix/TR-1535/choice-container-remains-expanded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.14.1-2",
+    "version": "2.14.1-3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.14.1-2",
+    "version": "2.14.1-3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -5,6 +5,12 @@
     position: relative;
 }
 
+.qti-choiceInteraction {
+    .overlay-answer-eliminator {
+        display: none;
+    }
+}
+
 .test-runner-scope {
 
     position: relative;
@@ -56,29 +62,37 @@
         overflow-y: auto;
 
         max-width: 350px;
-        & > .qti-panel {
+
+        &>.qti-panel {
             max-width: 350px;
             padding: 10px;
         }
+
         @media only screen and (max-device-width : 800px) {
             max-width: 200px;
-            & > .qti-panel {
+
+            &>.qti-panel {
                 max-width: 200px;
             }
         }
+
         @media only screen and (min-device-width : 800px) and (max-device-width : 1280px) {
             max-width: 250px;
-            & > .qti-panel {
+
+            &>.qti-panel {
                 max-width: 250px;
             }
         }
+
         @media only screen and (min-device-width : 1280px) and (max-device-width : 1440px) {
             max-width: 300px;
-            & > .qti-panel {
+
+            &>.qti-panel {
                 max-width: 300px;
             }
         }
     }
+
     .test-sidebar-left {
         border-right: 1px $uiGeneralContentBorder solid;
 
@@ -113,11 +127,11 @@
             top: 0;
             bottom: 0;
             width: 100%;
-            opacity : .9;
+            opacity: .9;
 
             &-full {
                 background-color: $uiGeneralContentBg;
-                opacity : 1;
+                opacity: 1;
             }
         }
     }
@@ -150,24 +164,25 @@
         margin: auto;
         max-width: map-get($widths, item-max-width) * 1px;
         width: 100%;
+
         .qti-rubricBlock {
             margin: 20px 0;
         }
+
         .hidden {
             display: none;
         }
     }
 
     .visible-hidden {
-      position: absolute;
-      overflow: hidden;
-      height: 1px;
-      width: 1px;
-      word-wrap: normal;
-  }
+        position: absolute;
+        overflow: hidden;
+        height: 1px;
+        width: 1px;
+        word-wrap: normal;
+    }
 }
 
 .no-controls .test-runner-scope {
     height: 100vh;
 }
-


### PR DESCRIPTION
Backport of [TR-1535](https://oat-sa.atlassian.net/browse/TR-1535)

**Description:**
Hide by default the tool 'answer-eliminator because the SVG from the tool is creating extra space on loading and pushing choice interaction box on resizing function.

**Changes:**

- CSS hide property

**How to check:**

- Test attached to the ticket.
- Use a low 3G network connection to reproduce

**Requires:**

- None