### PR TITLE
[Fix] ADF-545 Remove duplicated css 

### DIFF
--- a/scss/new-test-runner.scss
+++ b/scss/new-test-runner.scss
@@ -1,9 +1,5 @@
 @import 'inc/bootstrap';
 @import 'inc/plugin-colors';
-// TODO these 3 files are duplicated from tao-core and it should be removed later
-@import "inc/loading-bar";
-@import "inc/action-bars";
-@import 'inc/section-container';
 
 @import 'inc/navigator';
 @import 'inc/document-viewer';


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-545

Remove duplicated css (scss imports from tao-core) to avoid regressions in future when old code from tao-core gets bundled because we don't have a way to control such dependency version.

Related PR
https://github.com/oat-sa/extension-tao-testqti/pull/2073