### PR TITLE
fix/TR-2274/refactor-toolbox-header

### DIFF
--- a/scss/inc/_test-action-bars.scss
+++ b/scss/inc/_test-action-bars.scss
@@ -255,13 +255,11 @@
                     }
                 }
 
-                .landmark-title--hidden {
+                .landmark-title-hidden {
                     position: absolute;
-                    clip: rect(1px, 1px, 1px, 1px);
                     overflow: hidden;
                     height: 1px;
                     width: 1px;
-                    word-wrap: normal;
                 }
             }
         }

--- a/scss/inc/_test-action-bars.scss
+++ b/scss/inc/_test-action-bars.scss
@@ -254,13 +254,6 @@
                         padding: 0;
                     }
                 }
-
-                .landmark-title-hidden {
-                    position: absolute;
-                    overflow: hidden;
-                    height: 1px;
-                    width: 1px;
-                }
             }
         }
     }

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -93,12 +93,11 @@
     .test-sidebar-left {
         border-right: 1px $uiGeneralContentBorder solid;
 
-        .landmark-title--hidden {
+        .landmark-title-hidden {
             position: absolute;
             overflow: hidden;
             height: 1px;
             width: 1px;
-            word-wrap: normal;
         }
     }
 

--- a/scss/inc/_test-layout.scss
+++ b/scss/inc/_test-layout.scss
@@ -92,13 +92,6 @@
 
     .test-sidebar-left {
         border-right: 1px $uiGeneralContentBorder solid;
-
-        .landmark-title-hidden {
-            position: absolute;
-            overflow: hidden;
-            height: 1px;
-            width: 1px;
-        }
     }
 
     .test-sidebar-right {

--- a/src/provider/layout.tpl
+++ b/src/provider/layout.tpl
@@ -6,7 +6,7 @@
     <div class="test-runner-sections">
 
         <aside class="test-sidebar test-sidebar-left" aria-labelledby="test-sidebar-left-header">
-            <h2 id="test-sidebar-left-header" class="landmark-title--hidden">{{__ 'Test status and review structure'}}</h2>
+            <h2 id="test-sidebar-left-header" class="landmark-title-hidden">{{__ 'Test status and review structure'}}</h2>
         </aside>
 
         <section class="content-wrapper" aria-labelledby="test-title-header">
@@ -18,10 +18,10 @@
     <div class="action-bar content-action-bar horizontal-action-bar bottom-action-bar">
         <div class="control-box size-wrapper">
             <aside class="lft tools-box" aria-labelledby="toolboxheader">
-              <h2 id="toolboxheader" class="landmark-title--hidden">{{__ "Tool box and flagging for review"}}</h2>
+              <h2 id="toolboxheader" class="landmark-title-hidden">{{__ "Tool box and flagging for review"}}</h2>
             </aside>
             <nav class="rgt navi-box" aria-labelledby="navheader">
-                <h2 id="navheader" class="landmark-title--hidden">{{__ "Main navigation"}}</h2>
+                <h2 id="navheader" class="landmark-title-hidden">{{__ "Main navigation"}}</h2>
                 <ul class="plain navi-box-list"></ul>
             </div>
         </div>


### PR DESCRIPTION
**Related to:** [TR-2274](https://oat-sa.atlassian.net/browse/TR-2274)

**Description:**
- The title of the toolbox was visible because the CSS class associated did not exist on the CSS file.
There is an image attached to the ticket.

**Changes:**

- Two similar classes have been unified so now we only keep one name and one behaviour.

**How to check:**

- As TT access a test with the reader theme and open the Tools box.

**Requires:**

- Use this [composer.json](https://github.com/oat-sa/tao-enterprise-nfer-enot/blob/main/composer.json). If you have any issue installing one of the client extensions, don't worry as the issue is happening anyway.