### PR TITLE
Fix/TR-1473/Pause timers after a connectivity issue while waiting for reconnection

### DIFF
--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -379,7 +379,7 @@ var qtiProvider = {
         stopwatch.init();
         stopwatch.spread(this, 'tick');
 
-        const timerClientMode = config.options.timer && config.options.timer.restoreTimerFromClient;
+        const isTimerClientMode = () => config.options.timer && config.options.timer.restoreTimerFromClient;
 
         /*
          * Install behavior on events
@@ -562,13 +562,13 @@ var qtiProvider = {
                 this.trigger('enableitem enablenav');
             })
             .on('disableitem', function() {
-                if (timerClientMode) {
+                if (isTimerClientMode()) {
                     stopwatch.stop();
                 }
                 this.trigger('disabletools');
             })
             .on('enableitem', function() {
-                if (timerClientMode) {
+                if (isTimerClientMode()) {
                     stopwatch.start();
                 }
                 this.trigger('enabletools');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1473

When entering in "waiting for reconnection" stage, the timers should be paused. Visually it was already the case, but the duration was still increasing in the background under certain condition (item with feedbacks).

This was due to the fact that the stopwatch is not stopped when the item is disabled. It should, but the option conditioning this behaviour was not properly initialised (the value is set a bit later, but the value was already read...).

**How to test:**
- install the companion branch
- have a test with a timer and multiple items, one needs to have a modal feedback activated (see the ticket for a ready-to-use test package)
- pass the test, move to the item with the modal feedback and set the browser to offline, then move next again
- wait a bit, the timer should be paused. You can also watch the browser's indexeddb, the duration of the current item should not increase
- after a few time, that should be enough to exhaust the timer if it was running, restore the connection and move forward
- the timer should recover from the last position and no timeout should happen yet