### PR TITLE
fix/TR-2400/highlighter-tool-missing-enable-listener

### DIFF
--- a/src/plugins/tools/highlighter/plugin.js
+++ b/src/plugins/tools/highlighter/plugin.js
@@ -284,7 +284,7 @@ export default pluginFactory({
                     if (isPluginEnabled()) {
                         _.forEach(highlighters.getAllHighlighters(), function (instance) {
                             if (!instance.isEnabled()) {
-                                instance.on('start').toggleHighlighting(true).enable();
+                                instance.on('start').toggleHighlighting(false).enable();
                             }
                         });
                     }

--- a/src/plugins/tools/highlighter/plugin.js
+++ b/src/plugins/tools/highlighter/plugin.js
@@ -280,6 +280,14 @@ export default pluginFactory({
                 .on('loaditem', togglePlugin)
                 .on('enabletools renderitem', function() {
                     self.enable();
+
+                    if (isPluginEnabled()) {
+                        _.forEach(highlighters.getAllHighlighters(), function (instance) {
+                            if (!instance.isEnabled()) {
+                                instance.on('start').toggleHighlighting(true).enable();
+                            }
+                        });
+                    }
                 })
                 .on('renderitem', function() {
                     var textStimuli;

--- a/test/plugins/tools/highlighter/plugin/test.js
+++ b/test/plugins/tools/highlighter/plugin/test.js
@@ -199,13 +199,12 @@ define([
                 const $container = areaBroker.getToolboxArea();
                 const plugin = pluginFactory(runner, areaBroker);
 
-                assert.expect(4);
+                assert.expect(6);
 
                 return plugin
                     .init()
                     .then(() => {
                         areaBroker.getToolbox().render($container);
-
                         return plugin.enable();
                     })
                     .then(() => {
@@ -231,6 +230,15 @@ define([
                             true,
                             'The remove button has been disabled'
                         );
+                    })
+                    .then(() => {
+                        runner.trigger('enabletools');
+
+                        const $buttonMain = $container.find('[data-control="highlight-trigger"]');
+                        const $buttonRemove = $container.find('[data-control="highlight-clear"]');
+
+                        assert.equal($buttonMain.hasClass('disabled'), false, 'The trigger button has been enabled');
+                        assert.equal($buttonRemove.hasClass('disabled'), false, 'The remove button has been enabled');
                     });
             })
             .catch(err => {


### PR DESCRIPTION
**Related to:** [TR-2400](https://oat-sa.atlassian.net/browse/TR-2400)

**Description:**

The highlighter tool is disabled when the security plugin is enabled.

**Changes:**

- Enable the tool on the Highlighter enabled listener if it is not enabled already.

**How to check:**

- Create a test with the Highlight tool enabled on the Test-Taker Tools and add the security plugin on the Delivery settings.
![image](https://user-images.githubusercontent.com/11692751/141149130-a7598040-d4db-46f3-b158-607710c24284.png)
- Check if you can use the Highlighter tool on fullscreen mode.

**Local test:**

- https://github.com/oat-sa/kitchen-playground/blob/test/maria-2400/files/delivery/composer.json