### PR TITLE
hotfix/TR-2400/highlighter-tool-missing-enable-listener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.23.4-2",
+    "version": "2.23.4-3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "2.23.4-2",
+    "version": "2.23.4-3",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/tools/highlighter/plugin.js
+++ b/src/plugins/tools/highlighter/plugin.js
@@ -284,7 +284,7 @@ export default pluginFactory({
                     if (isPluginEnabled()) {
                         _.forEach(highlighters.getAllHighlighters(), function (instance) {
                             if (!instance.isEnabled()) {
-                                instance.on('start').toggleHighlighting(true).enable();
+                                instance.on('start').toggleHighlighting(false).enable();
                             }
                         });
                     }

--- a/src/plugins/tools/highlighter/plugin.js
+++ b/src/plugins/tools/highlighter/plugin.js
@@ -280,6 +280,14 @@ export default pluginFactory({
                 .on('loaditem', togglePlugin)
                 .on('enabletools renderitem', function() {
                     self.enable();
+
+                    if (isPluginEnabled()) {
+                        _.forEach(highlighters.getAllHighlighters(), function (instance) {
+                            if (!instance.isEnabled()) {
+                                instance.on('start').toggleHighlighting(true).enable();
+                            }
+                        });
+                    }
                 })
                 .on('renderitem', function() {
                     var textStimuli;

--- a/test/plugins/tools/highlighter/plugin/test.js
+++ b/test/plugins/tools/highlighter/plugin/test.js
@@ -199,7 +199,7 @@ define([
                 const $container = areaBroker.getToolboxArea();
                 const plugin = pluginFactory(runner, areaBroker);
 
-                assert.expect(4);
+                assert.expect(6);
 
                 return plugin
                     .init()
@@ -231,6 +231,15 @@ define([
                             true,
                             'The remove button has been disabled'
                         );
+                    })
+                    .then(() => {
+                        runner.trigger('enabletools');
+
+                        const $buttonMain = $container.find('[data-control="highlight-trigger"]');
+                        const $buttonRemove = $container.find('[data-control="highlight-clear"]');
+
+                        assert.equal($buttonMain.hasClass('disabled'), false, 'The trigger button has been enabled');
+                        assert.equal($buttonRemove.hasClass('disabled'), false, 'The remove button has been enabled');
                     });
             })
             .catch(err => {


### PR DESCRIPTION
BACKPORT
**Related to:** [TR-2400](https://oat-sa.atlassian.net/browse/TR-2400)

**Description:**

The highlighter tool is disabled when the security plugin is enabled.

**Changes:**

- Enable the tool on the Highlighter enabled listener if it is not enabled already.

**How to check:**

- Create a test with the Highlight tool enabled on the Test-Taker Tools and add the security plugin on the Delivery settings.
![image](https://user-images.githubusercontent.com/11692751/141149130-a7598040-d4db-46f3-b158-607710c24284.png)
- Check if you can use the Highlighter tool on fullscreen mode.

**TAE Environment:**

- http://test-maria-2400.playground.kitchen.it.taocloud.org:42611/
- [credentials](http://playground.kitchen.it.taocloud.org/?p=test-maria-2400_delivery.git;a=blob;f=app/admin.txt;h=3c523e3f3f782c849e7407e8df36d6ef31a60917;hb=96d6bf53593239a7fec560697eabf948b742a2d4)

**Local test:**

- https://github.com/oat-sa/kitchen-playground/blob/test/maria-2400/files/delivery/composer.json