### PR TITLE
feature: TR-2326. Display section titles

### DIFF
--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -25,6 +25,7 @@ import autoscroll from 'ui/autoscroll';
 import mapHelper from 'taoQtiTest/runner/helpers/map';
 import fizzyTpl from './navigatorFizzy.tpl';
 import fizzyTreeTpl from './navigatorBubbles.tpl';
+import fizzyTreeLinearTpl from './navigatorBubblesLinear.tpl';
 import accordionTpl from 'taoQtiTest/runner/plugins/navigation/review/navigator.tpl';
 import accordionTreeTpl from 'taoQtiTest/runner/plugins/navigation/review/navigatorTree';
 
@@ -567,6 +568,9 @@ function navigatorFactory(config, map, context) {
     if (config.reviewLayout === 'fizzy') {
         navigatorTpl = fizzyTpl;
         navigatorTreeTpl = fizzyTreeTpl;
+        if(!config["displaySectionTitles"]){
+            navigatorTreeTpl = fizzyTreeLinearTpl;
+        }
         // hack to not allow activate/deactivate bookmarking on icon click in item button
         _cssCls.collapsed = 'fizzy';
         _selectors.filter = 'abc';

--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -568,7 +568,7 @@ function navigatorFactory(config, map, context) {
     if (config.reviewLayout === 'fizzy') {
         navigatorTpl = fizzyTpl;
         navigatorTreeTpl = fizzyTreeTpl;
-        if(!config.displaySectionTitles){
+        if (!config.displaySectionTitles) {
             navigatorTreeTpl = fizzyTreeLinearTpl;
         }
         // hack to not allow activate/deactivate bookmarking on icon click in item button

--- a/src/plugins/navigation/review/navigator.js
+++ b/src/plugins/navigation/review/navigator.js
@@ -568,7 +568,7 @@ function navigatorFactory(config, map, context) {
     if (config.reviewLayout === 'fizzy') {
         navigatorTpl = fizzyTpl;
         navigatorTreeTpl = fizzyTreeTpl;
-        if(!config["displaySectionTitles"]){
+        if(!config.displaySectionTitles){
             navigatorTreeTpl = fizzyTreeLinearTpl;
         }
         // hack to not allow activate/deactivate bookmarking on icon click in item button

--- a/src/plugins/navigation/review/navigatorBubblesLinear.tpl
+++ b/src/plugins/navigation/review/navigatorBubblesLinear.tpl
@@ -1,0 +1,29 @@
+<ul class="qti-navigator-parts plain">
+    <li class="qti-navigator-part active">
+        <ul class="qti-navigator-sections plain">
+            <li class="qti-navigator-section active">
+                <ul class="qti-navigator-items plain">
+                    {{#each parts}}
+                        {{#each sections}}
+                            {{#each items}}
+                                <li class="qti-navigator-item {{cls}}" data-id="{{id}}" data-position="{{position}}">
+                                    <button
+                                            class="qti-navigator-label step"
+                                            {{#if active}}class="current"{{/if}}
+                                            aria-disabled="{{#if viewed}}false{{else}}true{{/if}}"
+                                            {{#if active}}aria-current='location'{{/if}}
+                                            role="link"
+                                            aria-label="{{#if numberTest}}Question {{numberTest}}, {{/if}} {{icon}}">
+                                        {{#if active}}<span class="{{#if active}}icon-indicator {{/if}}indicator" aria-hidden="true"></span>{{/if}}
+                                        <span class="qti-navigator-icon icon-{{icon}}" aria-hidden="true"></span>
+                                        <span class="step-label" aria-hidden="true">{{numberTest}}</span>
+                                    </button>
+                                </li>
+                            {{/each}}
+                        {{/each}}
+                    {{/each}}
+                </ul>
+            </li>
+        </ul>
+    </li>
+</ul>

--- a/test/plugins/navigation/review/navigator/data.json
+++ b/test/plugins/navigation/review/navigator/data.json
@@ -8,7 +8,8 @@
     "defaultOpen": true,
     "itemTitle": "Item %d",
     "preventsUnseen": true,
-    "canCollapse": false
+    "canCollapse": false,
+    "reviewLayout": "default"
   },
   "map": {
     "parts": {

--- a/test/plugins/navigation/review/navigator/test.html
+++ b/test/plugins/navigation/review/navigator/test.html
@@ -11,6 +11,9 @@
                 margin: 10px auto;
                 padding: 10px;
             }
+            body #qunit {
+                position: relative;
+            }
         </style>
 
         <script type="text/javascript" src="/environment/require.js"></script>

--- a/test/plugins/navigation/review/navigator/test.js
+++ b/test/plugins/navigation/review/navigator/test.js
@@ -334,7 +334,7 @@ define([
     QUnit.test('test layout structure', function(assert) {
         const ready = assert.async();
         const $container = $('#qunit-fixture');
-        const config = Object.assign({}, sample.config, { "reviewLayout": "fizzy"});
+        const config = Object.assign({}, sample.config, { "reviewLayout": "fizzy", "displaySectionTitles": true});
 
         assert.expect(5);
 
@@ -439,6 +439,63 @@ define([
         })
         .render($container)
         .update(map, sample.context);
+    });
+
+    QUnit.test('check enabled section titles', function(assert) {
+        const ready = assert.async();
+        const $container = $('#qunit-fixture');
+        const config = Object.assign({}, sample.config, { "reviewLayout": "fizzy", "displaySectionTitles": true});
+
+        assert.expect(2);
+
+        navigatorFactory(config, sample.map, sample.context)
+        .on('update', function() {
+            assert.equal(
+                $('.qti-navigator-section .qti-navigator-text', $container).text(),
+                'Section 1',
+                'Section title is showing on panel'
+            );
+            assert.equal(
+                $('.fizzy > .qti-navigator-label > .qti-navigator-text', $container).text(),
+                'Test review',
+                'Review panel title exists'
+            );
+
+            ready();
+        })
+        .render($container)
+        .update(sample.map, sample.context);
+    });
+
+    QUnit.test('check disabling section titles', function(assert) {
+        const ready = assert.async();
+        const $container = $('#qunit-fixture');
+        const config = Object.assign({}, sample.config, { "reviewLayout": "fizzy", "displaySectionTitles": false});
+
+        assert.expect(3);
+
+        navigatorFactory(config, sample.map, sample.context)
+        .on('update', function() {
+            assert.equal(
+                $('.qti-navigator-tree .qti-navigator-label:not(button) ', $container).length,
+                0,
+                'No any labels on panel'
+            );
+            assert.equal(
+                $('.fizzy .qti-navigator-item ', $container).length,
+                10,
+                'All items are visible'
+            );
+            assert.equal(
+                $('.fizzy > .qti-navigator-label > .qti-navigator-text', $container).text(),
+                'Test review',
+                'Review panel title still exists'
+            );
+
+            ready();
+        })
+        .render($container)
+        .update(sample.map, sample.context);
     });
 
     QUnit.test('visual test', function(assert) {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-2326

AC1 and AC2 were implemented in initial "fizzy" layout. This task is more about AC3. For this AC, part of "fizzy" layout was reworked. Main difference in this layout - no splitting test items between test parts, test sections. Let say 'all-in-one'.

TODO:
- [x] add tests

How to test: see instructions in https://github.com/oat-sa/extension-tao-testqti/pull/2119

