### PR TITLE
fix: TR-3068. Restore item state after pause

### DIFF
--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -495,15 +495,21 @@ var qtiProvider = {
 
                 this.setState('closedOrSuspended', true);
 
+                let params = {
+                    itemDefinition: testContext.itemIdentifier,
+                    reason: {
+                        reasons: data && data.reasons,
+                        comment: data && (data.originalMessage || data.message)
+                    }
+                };
+
+                const itemState = self.itemRunner.getState();
+                if (Object.keys(itemState).length) {
+                    params = Object.assign({}, params, { itemState });
+                }
+
                 this.getProxy()
-                    .callTestAction('pause', {
-                        itemDefinition: testContext.itemIdentifier,
-                        itemState: self.itemRunner.getState(),
-                        reason: {
-                            reasons: data && data.reasons,
-                            comment: data && (data.originalMessage || data.message)
-                        }
-                    })
+                    .callTestAction('pause', params)
                     .then(function() {
                         self.trigger('leave', {
                             code: states.testSession.suspended,

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -495,7 +495,7 @@ var qtiProvider = {
 
                 this.setState('closedOrSuspended', true);
 
-                let params = {
+                const params = {
                     itemDefinition: testContext.itemIdentifier,
                     reason: {
                         reasons: data && data.reasons,

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -505,7 +505,7 @@ var qtiProvider = {
 
                 const itemState = self.itemRunner.getState();
                 if (Object.keys(itemState).length) {
-                    params = Object.assign({}, params, { itemState });
+                    params.itemState = itemState;
                 }
 
                 this.getProxy()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-3068

Continue [discussion](https://github.com/oat-sa/tao-test-runner-qti-fe/pull/456) here:

I knew this weaknesses for my solution, but follow me step by step:
1. In time of handling pause we have two situations: or user pressed navigation button before or didn't. If he didn't press anything my code follow current flow and send correct item state to server. If button is pressed, this means we are finished unloading element and we go to point 2
2. We have 3 ways to get item state: a) using caching proxy (our case), b) using local storage (as i understand it is `answerCache` plugin), c) request to server. Returning to our situation, we are in a moment of handling "paused" state (navigation button is already pressed), where item already is unloaded. To get info about the item state we can use three ways i mentioned: a) - i used it, b) - was not available, c) - the worst case. 
3. I absolutely understand that using proxy cache for getting data is risky, as soon as believe in any plugin which can be disabled, so i added various checks which allow/try to get info from a) or b). If all failed, it means we did not have any possibility to restore state ( c) - is not a variant at all) in terms of ticket's ACs. 
4. Let's imagine now, that we have client which uses proctoring, but without proxy cache and caching plugins, what will happen? Ticket's issue is happened and no way to avoid this with or without my fix. Should we take care about this potential case? From my point yes, but we should decide than what we want: change our expectations or add new feature. In any case it is far from ticket scope.
5. `isCleared` method is really bad. I understand this now, by spending couple of hours to deep dive in architecture from calling controller and rendering item. 

All this text above is just a lyric where i focused that didn't have a lot variants to fix issue in terms of ACs and limited time for unblocking regression. 

Current solution i mentioned in previous PR and it has some unclear moments for me on BE side. The core moment - i do not sent the `itemState` during "paused" state. From my experiments old cache replaced by new one field by field. It means, if field is absent it won't be touched. BE still can not confirm this. Based on this assumption fix is working, but i don't like this also, because we depends on how BE handle our "partial" item state.

I think as solution we can change nothing and enable `answerCache` plugin, but need to test this + does customer want to enable something?

Or we can say, that this is not a bug, it is a feature)))

