### PR TITLE
Feature/tr 2500/add feat flag control pause message

### DIFF
--- a/src/plugins/content/dialog/exitMessages.js
+++ b/src/plugins/content/dialog/exitMessages.js
@@ -44,7 +44,12 @@ export default pluginFactory({
         // intercepts the `leave` event,
         // then if a message needs to be displayed displays it and waits the user acknowledges it
         testRunner.before('leave', function leave(e, data) {
-            if (_.isObject(data) && data.message) {
+            const dataIsObject = _.isObject(data);
+            if (dataIsObject && data.skipExitMessage) {
+                return;
+            }
+
+            if (dataIsObject && data.message) {
                 return new Promise(function(resolve) {
                     var context = testRunner.getTestContext();
 

--- a/src/plugins/controls/testState/testState.js
+++ b/src/plugins/controls/testState/testState.js
@@ -62,8 +62,7 @@ export default pluginFactory({
      * Initializes the plugin (called during runner's init)
      */
     init: function init() {
-        const testRunner = this.getTestRunner();
-        const testRunnerOptions = testRunner.getOptions();
+        var testRunner = this.getTestRunner();
         var isLeaving = false;
 
         // immediate handling of proctor's actions
@@ -75,16 +74,12 @@ export default pluginFactory({
                 !testRunner.getState('closedOrSuspended')
             ) {
                 isLeaving = true;
-                let triggerData = data;
-                if (testRunnerOptions.skipPausedAssessmentDialog && data) {
-                    triggerData = Object.assign({}, data, { skipPausedAssessmentDialog: testRunnerOptions.skipPausedAssessmentDialog });
-                }
 
                 if ('pause' === data.type) {
-                    testRunner.trigger('pause', triggerData);
+                    testRunner.trigger('pause', data);
                 } else {
                     testRunner.setState('closedOrSuspended', true);
-                    testRunner.trigger('leave', triggerData);
+                    testRunner.trigger('leave', data);
                 }
             }
         });

--- a/src/plugins/controls/testState/testState.js
+++ b/src/plugins/controls/testState/testState.js
@@ -78,8 +78,8 @@ export default pluginFactory({
 
             isLeaving = true;
             let triggerData = data;
-            if (testRunnerOptions.skipPausedAssesmentDialog && data) {
-                triggerData = Object.assign({}, data, { skipPausedAssesmentDialog: testRunnerOptions.skipPausedAssesmentDialog });
+            if (testRunnerOptions.skipPausedAssessmentDialog && data) {
+                triggerData = Object.assign({}, data, { skipPausedAssessmentDialog: testRunnerOptions.skipPausedAssessmentDialog });
             }
 
             if ('pause' === testStateType) {

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -508,12 +508,15 @@ var qtiProvider = {
                     params.itemState = itemState;
                 }
 
+                const skipPausedAssesmentDialog = data && data.skipPausedAssesmentDialog;
+                const pauseMessage = skipPausedAssesmentDialog ? null : data && data.message;
+
                 this.getProxy()
                     .callTestAction('pause', params)
                     .then(function() {
                         self.trigger('leave', {
                             code: states.testSession.suspended,
-                            message: data && data.message
+                            message: pauseMessage
                         });
                     })
                     .catch(function(err) {

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -249,16 +249,20 @@ var qtiProvider = {
         function computeNext(action, params, loadPromise) {
             const context = self.getTestContext();
             const currentItem = self.getCurrentItem();
+            const options = self.getOptions();
+            const skipPausedAssessmentDialog = !!options.skipPausedAssessmentDialog;
 
             //catch server errors
             var submitError = function submitError(err) {
                 if (err && err.unrecoverable){
-                    self.trigger(
-                        'alert.error',
-                        __(
-                            'An unrecoverable error occurred. Your test session will be paused.'
-                        )
-                    );
+                    if (!skipPausedAssessmentDialog) {
+                        self.trigger(
+                            'alert.error',
+                            __(
+                                'An unrecoverable error occurred. Your test session will be paused.'
+                            )
+                        );
+                    }
 
                     self.trigger('pause', {message : err.message});
                 } else if (err.code === 200) {
@@ -492,6 +496,8 @@ var qtiProvider = {
             })
             .on('pause', function(data) {
                 const testContext = self.getTestContext();
+                const options = self.getOptions();
+                const skipPausedAssessmentDialog = !!options.skipPausedAssessmentDialog;
 
                 this.setState('closedOrSuspended', true);
 
@@ -514,7 +520,7 @@ var qtiProvider = {
                         self.trigger('leave', {
                             code: states.testSession.suspended,
                             message: data && data.message,
-                            skipExitMessage: data && data.skipPausedAssessmentDialog
+                            skipExitMessage: skipPausedAssessmentDialog
                         });
                     })
                     .catch(function(err) {

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -508,15 +508,13 @@ var qtiProvider = {
                     params.itemState = itemState;
                 }
 
-                const skipPausedAssessmentDialog = data && data.skipPausedAssessmentDialog;
-                const pauseMessage = skipPausedAssessmentDialog ? null : data && data.message;
-
                 this.getProxy()
                     .callTestAction('pause', params)
                     .then(function() {
                         self.trigger('leave', {
                             code: states.testSession.suspended,
-                            message: pauseMessage
+                            message: data && data.message,
+                            skipExitMessage: data && data.skipPausedAssesmentDialog
                         });
                     })
                     .catch(function(err) {

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -508,8 +508,8 @@ var qtiProvider = {
                     params.itemState = itemState;
                 }
 
-                const skipPausedAssesmentDialog = data && data.skipPausedAssesmentDialog;
-                const pauseMessage = skipPausedAssesmentDialog ? null : data && data.message;
+                const skipPausedAssessmentDialog = data && data.skipPausedAssessmentDialog;
+                const pauseMessage = skipPausedAssessmentDialog ? null : data && data.message;
 
                 this.getProxy()
                     .callTestAction('pause', params)


### PR DESCRIPTION
# [TR-2500](https://oat-sa.atlassian.net/browse/TR-2500)

## Changelog
- feat: add the skipPausedAssessmentDialog configuration variable in the trigger data
- feat: validate skipPausedAssessmentDialog from data to send the pause message

## How to test
1. Go to the [kitchen](http://test-tr-bosa.playground.kitchen.it.taocloud.org:41921)
2. Run a proctored assessment as a test taker
3. Authorize the assessment as a proctor
4. Pause the assessment as the test taker
5. Pause the assessment as the test taker
6. Observe that it does not show the message to the test-taker and reload the page