### PR TITLE
Fix/tr 3390 force calculator widget to ltr direction

### DIFF
--- a/src/plugins/tools/calculator.js
+++ b/src/plugins/tools/calculator.js
@@ -32,6 +32,7 @@ import shortcut from 'util/shortcut';
 import namespaceHelper from 'util/namespace';
 import pluginFactory from 'taoTests/runner/plugin';
 import mapHelper from 'taoQtiTest/runner/helpers/map';
+import calculatorTpl from 'taoQtiTest/runner/plugins/tools/calculator/calculator.tpl';
 
 /**
  * Default config for calculator components
@@ -217,7 +218,7 @@ export default pluginFactory({
                 icon: 'table',
                 text: __('Calculator')
             });
-        this.$calculatorContainer = $('<div class="widget-calculator">');
+        this.$calculatorContainer = $(calculatorTpl());
 
         //init calculator instance var, it will be created only necessary
         this.calculator = null;

--- a/src/plugins/tools/calculator/calculator.tpl
+++ b/src/plugins/tools/calculator/calculator.tpl
@@ -1,0 +1,1 @@
+<div class="widget-calculator" dir="ltr"></div>


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3390

- Refactor calculator plugin and create a template file.
- Force `LTR` direction

Test:

- Have test where calculator is enabled as test taker tool (there are 3 type, so all should be tested)
- Set a test taker language to `ar-arb` during LTI launch
- Calculator should be LTR