### PR TITLE
Force Safari iOS to reconsider the scrolling area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,9 +2570,8 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.16.1.tgz",
-            "integrity": "sha512-0AKqhAZaBRedOMUE/hrY19okaaO2OrcCGJFwifGrr2LiipvP7ODxUJ4jJFRwea/hbISCFl8RujCHpJ4nvdH1xg==",
+            "version": "github:oat-sa/tao-core-sdk-fe#2945f03167f4c08c6370be8a5589e4b281088844",
+            "from": "github:oat-sa/tao-core-sdk-fe#feature/TR-3071/add-util-to-detect-browser",
             "dev": true,
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,8 +2570,9 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "github:oat-sa/tao-core-sdk-fe#2945f03167f4c08c6370be8a5589e4b281088844",
-            "from": "github:oat-sa/tao-core-sdk-fe#feature/TR-3071/add-util-to-detect-browser",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.17.0.tgz",
+            "integrity": "sha512-psV3IaPUIpgzENGfh7JCp2xY8w/yIXFJpM83S7NOsahtvvyNLmaNrPrQsoSvVvfYD7XEpREPTXwTKx04Rc15ag==",
             "dev": true,
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "0.4.4",
-        "@oat-sa/tao-core-sdk": "1.16.1",
+        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#feature/TR-3071/add-util-to-detect-browser",
         "@oat-sa/tao-core-ui": "1.45.0",
         "@oat-sa/tao-item-runner": "^0.8.0",
         "@oat-sa/tao-item-runner-qti": "0.25.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "0.4.4",
-        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#feature/TR-3071/add-util-to-detect-browser",
+        "@oat-sa/tao-core-sdk": "1.17.0",
         "@oat-sa/tao-core-ui": "1.45.0",
         "@oat-sa/tao-item-runner": "^0.8.0",
         "@oat-sa/tao-item-runner-qti": "0.25.0",

--- a/src/provider/qti.js
+++ b/src/provider/qti.js
@@ -24,6 +24,7 @@ import $ from 'jquery';
 import _ from 'lodash';
 import __ from 'i18n';
 import cachedStore from 'core/cachedStore';
+import browser from 'util/browser';
 import areaBrokerFactory from 'taoTests/runner/areaBroker';
 import proxyFactory from 'taoTests/runner/proxy';
 import probeOverseerFactory from 'taoTests/runner/probeOverseer';
@@ -38,7 +39,6 @@ import getAssetManager from 'taoQtiTest/runner/config/assetManager';
 import layoutTpl from 'taoQtiTest/runner/provider/layout';
 import states from 'taoQtiTest/runner/config/states';
 import stopwatchFactory from 'taoQtiTest/runner/provider/stopwatch';
-import currentItem from "../helpers/currentItem";
 
 /**
  * A Test runner provider to be registered against the runner
@@ -741,6 +741,17 @@ var qtiProvider = {
                     this.on('statechange', changeState);
 
                     resolve();
+                })
+                .after('render', function() {
+                    //iOS only fix: sometimes the wrapper is not scrollable because of some bugs in Safari iOS
+                    //we have to force it to reconsider if the scroll needs to apply
+                    if (browser.isIOs()) {
+                        const wrapperElt = self.getAreaBroker().getContainer().find('.content-wrapper').get(0);
+                        if (wrapperElt) {
+                            wrapperElt.style.overflow = 'hidden';
+                            setTimeout(() => wrapperElt.style.overflow = 'auto', 0);
+                        }
+                    }
                 })
                 .on('warning', function(err) {
                     self.trigger('warning', err);


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3071

 - After an item renders on Safari iOS, the scrollable elements may not be actually scrollable (a Safari bug), so we force it to reconsider adding the scroll. This seems to be the same issue as [this one](https://stackoverflow.com/questions/28288710/cant-scroll-inside-a-div-after-applying-webkit-transform-in-safari), because it occurs only after a form having the focus AND the loading bar to animate :confused: 

Requires: 
 - [x] https://github.com/oat-sa/tao-core-sdk-fe/pull/130

How to test
 - run unit tests (the keyNavigation tests were already failing :unamused: )
 - along with the other PRs or on TAE by running the failing test on iOS