### PR TITLE
Fix/TR-3071/Wrong dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,9 +2570,9 @@
             "dev": true
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.17.0.tgz",
-            "integrity": "sha512-psV3IaPUIpgzENGfh7JCp2xY8w/yIXFJpM83S7NOsahtvvyNLmaNrPrQsoSvVvfYD7XEpREPTXwTKx04Rc15ag==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.18.0.tgz",
+            "integrity": "sha512-ErnhAjk6vkywdpag4d0S9lEqGoZqf9y/2S6mP+2sw1E5ftcpv5kaXb+ZVrFqaI7QiVMRSE50djN6iTsQqUwhNQ==",
             "dev": true,
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "@oat-sa/prettier-config": "^0.1.1",
         "@oat-sa/rollup-plugin-wildcard-external": "^0.1.0",
         "@oat-sa/tao-core-libs": "0.4.4",
-        "@oat-sa/tao-core-sdk": "1.17.0",
+        "@oat-sa/tao-core-sdk": "1.18.0",
         "@oat-sa/tao-core-ui": "1.52.0",
         "@oat-sa/tao-item-runner": "^0.8.0",
         "@oat-sa/tao-item-runner-qti": "0.25.0",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-3071

Set the correct dependency version to bring the module `util/browser`.

In a previous [pull request](https://github.com/oat-sa/tao-test-runner-qti-fe/pull/469), the version was updated to align with a companion[ PR](https://github.com/oat-sa/tao-core-sdk-fe/pull/130). Unfortunately, the version was wrong.

**How to test?**
- install the package: `npm i`
- run the unit tests: `npm test`

**Actual result:**
The test `test/provider/qti/test.html` fails

**Expected result:**
The test `test/provider/qti/test.html` succeeds