### PR TITLE
Fix/eslint errors

### DIFF
--- a/src/helpers/offlineSyncModal.js
+++ b/src/helpers/offlineSyncModal.js
@@ -132,6 +132,6 @@ function offlineSyncModalFactory(proxy) {
         });
 
     return waitingDialog;
-};
+}
 
 export default offlineSyncModalFactory;

--- a/src/helpers/stats.js
+++ b/src/helpers/stats.js
@@ -46,6 +46,7 @@ export default {
                 stats.answered--;
             } else if ((isItemCurrentlyAnswered || sync) && !item.answered) {
                 stats.answered++;
+                // eslint-disable-next-line no-dupe-else-if
             } else if (sync && !isItemCurrentlyAnswered && item.answered && testPart.isLinear) {
                 stats.answered++;
             }

--- a/src/helpers/testContextBuilder.js
+++ b/src/helpers/testContextBuilder.js
@@ -106,7 +106,7 @@ function getTestContext(testContext, testMap, item, section, part, position, att
     if (attempt) {
         newTestContext.attempt = attempt + 1;
     }
-    
+
     if (isLeavingSection) {
         newTestContext.numberRubrics = 0;
         newTestContext.rubrics = '';

--- a/src/navigator/offlineNavigator.js
+++ b/src/navigator/offlineNavigator.js
@@ -65,7 +65,7 @@ export default function offlineNavigatorFactory(itemStore, responseStore) {
 
         /**
          * Initialization method for the offline navigator component
-         * It get called in proxy init function 
+         * It get called in proxy init function
          *
          * @returns {Promise}
          */
@@ -118,7 +118,7 @@ export default function offlineNavigatorFactory(itemStore, responseStore) {
                         // 4. return new textContext with right attempt
                         itemStore.get(lastJump.item)
                             .then(itemFromStore => {
-                                const newTestContext = testContextBuilder.buildTestContextFromJump(testContext, testMap, lastJump, itemFromStore.attempt)
+                                const newTestContext = testContextBuilder.buildTestContextFromJump(testContext, testMap, lastJump, itemFromStore.attempt);
                                 itemStore.update(newTestContext.itemIdentifier, 'attempt', newTestContext.attempt)
                                     .then(() => resolve(newTestContext));
                             });

--- a/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
+++ b/src/plugins/content/accessibility/keyNavigation/strategies/itemNavigation.js
@@ -64,7 +64,7 @@ const manageLabelledByAttribute = (navigator) => {
         navigator.on('focus', addLabelledByAttribute);
         navigator.on('blur', removeLabelledByAttribute); // applies WCAG behavior for the radio buttons
     }
-}
+};
 
 /**
  * Key navigator strategy applying inside the item.
@@ -92,7 +92,7 @@ export default {
          */
         const getQtiChoice = function (cursor){
             return cursor && cursor.navigable.getElement().closest('.qti-choice');
-        }
+        };
 
         /**
          * Creates and registers a keyNavigator for the supplied list of elements

--- a/src/plugins/content/accessibility/mainLandmark/header.js
+++ b/src/plugins/content/accessibility/mainLandmark/header.js
@@ -63,7 +63,7 @@ export default pluginFactory({
             })
             .on('tool-flagitem', () => {
                 let item = testRunner.getCurrentItem();
-                item = { ...item, flagged: !item.flagged};
+                item = Object.assign({}, item, { flagged: !item.flagged });
                 updateState(item);
             });
     },

--- a/src/plugins/content/responsiveness/collapser.js
+++ b/src/plugins/content/responsiveness/collapser.js
@@ -257,13 +257,13 @@ export default pluginFactory({
          * @returns {Array}
          */
         function getSortedCollapsiblesFromDom() {
-            var $elements = getControlsFromDom(),
+            var $controlElements = getControlsFromDom(),
                 _allCollapsibles = [],
                 order = {};
 
             // group items by prefix
             // eg. zoomIn and zoomOut -> zoom
-            $elements.each(function() {
+            $controlElements.each(function() {
                 var ctrl = this.dataset.control,
                     // re makes group `foo` from `foo-bar`, `fooBar` and `foo_bar`
                     // if we do not have a prefix use the control name as key to ensure uniqueness

--- a/src/plugins/tools/lineReader/compoundMask.js
+++ b/src/plugins/tools/lineReader/compoundMask.js
@@ -750,6 +750,7 @@ export default function compoundMaskFactory(options, dimensions, position) {
                     .setSize(size.width - options.resizeHandleSize * 2, size.height + options.resizeHandleSize * 2);
             },
 
+            // eslint-disable-next-line no-unused-vars
             beforeResize: function beforeResize(width, height, fromLeft) {
                 this.config.maxWidth = dimensions.rightWidth + (dimensions.innerWidth - constrains.minWidth);
                 this.config.minWidth = constrains.minWidth;

--- a/src/plugins/tools/magnifier/magnifierPanel.js
+++ b/src/plugins/tools/magnifier/magnifierPanel.js
@@ -606,6 +606,7 @@ function magnifierPanelFactory(config) {
 
     dynamicComponentInstance = dynamicComponent({})
         .on('rendercontent', function($content) {
+            // eslint-disable-next-line consistent-this
             var dynamicComponentContext = this;
             var $element = this.getElement();
 

--- a/src/proxy/cache/preloaders/interactions/extendedText.js
+++ b/src/proxy/cache/preloaders/interactions/extendedText.js
@@ -94,6 +94,7 @@ export default {
              * @param {string} itemIdentifier - the id of the item the interaction belongs to
              * @returns {boolean}
              */
+            // eslint-disable-next-line no-unused-vars
             loaded(interaction, itemData, itemIdentifier) {
                 if (interaction.attributes && interaction.attributes.format === 'xhtml') {
                     const lang = getItemLanguage(itemData);
@@ -109,6 +110,7 @@ export default {
              * @param {string} itemIdentifier - the id of the item the interaction belongs to
              * @returns {Promise}
              */
+            // eslint-disable-next-line no-unused-vars
             load(interaction, itemData, itemIdentifier) {
                 if (interaction.attributes && interaction.attributes.format === 'xhtml') {
                     const lang = getItemLanguage(itemData);
@@ -127,6 +129,7 @@ export default {
              * @param {string} itemIdentifier - the id of the item the interaction belongs to
              * @returns {Promise}
              */
+            // eslint-disable-next-line no-unused-vars
             unload(interaction, itemData, itemIdentifier) {
                 // nothing to do actually
                 return Promise.resolve();

--- a/src/proxy/cache/proxy.js
+++ b/src/proxy/cache/proxy.js
@@ -356,10 +356,12 @@ export default _.defaults(
              * @returns {Promise} resolves with the action result
              */
             this.syncData = () => {
+                let actions;
                 return this.queue.serie(() => {
                     return this.actiontStore
                         .flush()
                         .then(data => {
+                            actions = data;
                             if (data && data.length) {
                                 return this.send('sync', data);
                             }
@@ -367,7 +369,7 @@ export default _.defaults(
                         .catch(err => {
                             if (this.isConnectivityError(err)) {
                                 this.setOffline('communicator');
-                                _.forEach(data, action => {
+                                _.forEach(actions, action => {
                                     this.actiontStore.push(action.action, action.parameters);
                                 });
                             }

--- a/src/proxy/offline/proxy.js
+++ b/src/proxy/offline/proxy.js
@@ -142,7 +142,7 @@ export default _.defaults(
                         var newTestContext;
 
                         navigator
-                            .setTestContext(options.testContext)	
+                            .setTestContext(options.testContext)
                             .setTestMap(options.testMap)
                             .navigate(actionParams.direction, actionParams.scope, actionParams.ref, actionParams)
                             .then(function(res) {
@@ -182,7 +182,7 @@ export default _.defaults(
                                 .on('proceed', function() {
                                     self.syncData()
                                         .then(function() {
-                                            // if is online resolve promise 
+                                            // if is online resolve promise
                                             if (self.isOnline()) {
                                                 return resolve(result);
                                             }
@@ -190,13 +190,13 @@ export default _.defaults(
                                         .catch(function() {
                                             return resolve({ success: false });
                                         });
-                                    })
+                                })
                                 .on('secondaryaction', function() {
                                     self.initiateDownload().catch(function() {
                                         return resolve({ success: false });
                                     });
                                 });
-                            };
+                        };
                         if (isOffline) {
                             return offlineSync();
                         } else {
@@ -219,9 +219,9 @@ export default _.defaults(
                         if (isOffline) {
                             navigate(
                                 self.offlineNavigator,
-                                {	
-                                    testContext: testContext,	
-                                    testMap: testMap	
+                                {
+                                    testContext: testContext,
+                                    testMap: testMap
                                 },
                                 result
                             );
@@ -231,9 +231,9 @@ export default _.defaults(
                                 .then(function() {
                                     navigate(
                                         self.offlineNavigator,
-                                        {	
-                                            testContext: testContext,	
-                                            testMap: testMap	
+                                        {
+                                            testContext: testContext,
+                                            testMap: testMap
                                         },
                                         result
                                     );
@@ -429,7 +429,7 @@ export default _.defaults(
                         return self.offlineNavigator
                             .setTestContext(response.testContext)
                             .setTestMap(response.testMap)
-                            .init()
+                            .init();
                     })
                     .then(() => response);
             });

--- a/src/services/offlineJumpTable.js
+++ b/src/services/offlineJumpTable.js
@@ -146,7 +146,7 @@ var offlineJumpTableFactory = function offlineJumpTableFactory(itemStore, respon
             if (firstJumpItem) {
                 this.addJump(firstJumpItem.part, firstJumpItem.section, firstJumpItem.item);
             }
-            
+
             if (!contextItemPosition) {
                 return Promise.resolve();
             }
@@ -165,7 +165,7 @@ var offlineJumpTableFactory = function offlineJumpTableFactory(itemStore, respon
                 }
                 return Promise.resolve();
             }
-            
+
             return calculateNextJump();
         },
         /**

--- a/src/ui/toolbox/entry.js
+++ b/src/ui/toolbox/entry.js
@@ -83,7 +83,7 @@ var itemComponentApi = {
     turnOn: function turnOn() {
         this.setState('active', true);
 
-        const element = this.getElement()
+        const element = this.getElement();
         if (!element || (element.attr('role') !== 'option')) { // Not pretty bit quick
             return;
         }
@@ -99,7 +99,7 @@ var itemComponentApi = {
     turnOff: function turnOff() {
         this.setState('active', false);
 
-        const element = this.getElement()
+        const element = this.getElement();
         if (!element || (element.attr('role') !== 'option')) { // Not pretty bit quick
             return;
         }

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -22,8 +22,8 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
     'use strict';
 
     var messagesHelperApi = [{ title: 'getExitMessage' }];
-    var testActionMessage = 'You will not be able to access this test once submitted. Click \"OK\" to continue and submit the test.';
-    var actionMessage = 'Click \"OK\" to continue.';
+    var testActionMessage = 'You will not be able to access this test once submitted. Click "OK" to continue and submit the test.';
+    var actionMessage = 'Click "OK" to continue.';
 
     QUnit.module('helpers/messages');
 

--- a/test/navigator/offlineNavigator/test.js
+++ b/test/navigator/offlineNavigator/test.js
@@ -79,8 +79,8 @@ define([
     QUnit.test('it returns Promise after calling init method', function(assert) {
         offlineNavigator
             .setTestMap(mapHelper.createJumpTable(testMapJson))
-            .setTestContext(testContextJson)
-        var promise = offlineNavigator['init']();
+            .setTestContext(testContextJson);
+        const promise = offlineNavigator['init']();
         assert.equal(typeof promise, 'object');
     });
 
@@ -101,14 +101,14 @@ define([
                 .then(() => {
                     offlineNavigator.navigate(data.direction, data.scope, null, { itemResponse: {} }).then(function(result) {
                         assert.expect(4);
-        
+
                         assert.equal(typeof result, 'object');
                         assert.equal(result.itemIdentifier, data.expectedItem);
                         assert.equal(result.sectionId, data.expectedSection);
                         assert.equal(result.testPartId, data.expectedPart);
                         done();
                     });
-                })
+                });
         });
 
     QUnit.test('it supports previousItem navigation action', function(assert) {
@@ -127,7 +127,7 @@ define([
                 ]).then(function(result) {
                     result = result[2];
                     assert.expect(4);
-        
+
                     assert.equal(typeof result, 'object');
                     assert.equal(result.itemIdentifier, 'Q02');
                     assert.equal(result.sectionId, 'S01');

--- a/test/plugins/content/itemScrolling/test.js
+++ b/test/plugins/content/itemScrolling/test.js
@@ -38,7 +38,6 @@ define([
     var runner;
     var containerId = 'item-container';
     var providerName = 'mock';
-    let testRunner;
 
     runnerFactory.registerProvider(providerName, providerMock());
 
@@ -72,8 +71,8 @@ define([
     ];
 
     QUnit.cases.init(pluginApi).test('plugin API ', function (data, assert) {
-        var runner = runnerFactory(providerName);
-        var plugin = pluginFactory(runner);
+        var testRunner = runnerFactory(providerName);
+        var plugin = pluginFactory(testRunner);
         assert.equal(
             typeof plugin[data.name],
             'function',
@@ -154,14 +153,15 @@ define([
             renderer.load(function () {
                 var result, $result;
                 var $textBlocks;
-
-                item = _item;
-                item.setRenderer(this);
-
                 var $container = $(`#rendering`);
                 var areaBroker = areaBrokerMock({
                     $brokerContainer: $container
                 });
+                var testRunner;
+
+                item = _item;
+                item.setRenderer(this);
+
                 runnerFactory.registerProvider(providerName, providerMock({areaBroker: areaBroker}));
 
                 testRunner = runnerFactory(providerName);

--- a/test/plugins/content/jumplinks/jumplinks/test.js
+++ b/test/plugins/content/jumplinks/jumplinks/test.js
@@ -32,7 +32,7 @@ define([
         const config = {
             isReviewPanelEnabled: true,
             questionStatus: '',
-        }
+        };
 
         const jumplinksComponent = componentFactory({});
 
@@ -48,7 +48,7 @@ define([
         const config = {
             isReviewPanelEnabled: false,
             questionStatus: '',
-        }
+        };
 
         const jumplinksComponent = componentFactory({});
 
@@ -70,7 +70,7 @@ define([
         const config = {
             isReviewPanelEnabled: true,
             questionStatus: '',
-        }
+        };
 
         const jumplinksComponent = componentFactory({});
 

--- a/test/proxy/cache/itemStore/test.js
+++ b/test/proxy/cache/itemStore/test.js
@@ -77,9 +77,7 @@ define(['taoQtiTest/runner/proxy/cache/itemStore'], function (itemStoreFactory) 
             .then(value => {
                 assert.equal(typeof value, 'undefined', 'The store does not contains the given item');
             })
-            .then(() => {
-                return itemStore.set(key, item);
-            })
+            .then(() => itemStore.set(key, item))
             .then(assigned => {
                 assert.ok(assigned, 'The value assignment is done');
                 assert.ok(itemStore.has(key), 'The store contains the given item');
@@ -108,33 +106,25 @@ define(['taoQtiTest/runner/proxy/cache/itemStore'], function (itemStoreFactory) 
             .then(() => {
                 assert.ok(itemStore.has('item1'), 'The store contains the given item');
             })
-            .then(() => {
-                return itemStore.set('item2', { name: 'item2' });
-            })
+            .then(() => itemStore.set('item2', { name: 'item2' }))
             .then(() => {
                 assert.ok(itemStore.has('item1'), 'The store contains the given item');
                 assert.ok(itemStore.has('item2'), 'The store contains the given item');
             })
-            .then(() => {
-                return itemStore.set('item3', { name: 'item3' });
-            })
+            .then(() => itemStore.set('item3', { name: 'item3' }))
             .then(() => {
                 assert.ok(itemStore.has('item1'), 'The store contains the given item');
                 assert.ok(itemStore.has('item2'), 'The store contains the given item');
                 assert.ok(itemStore.has('item3'), 'The store contains the given item');
             })
-            .then(() => {
-                return itemStore.set('item4', { name: 'item4' });
-            })
+            .then(() => itemStore.set('item4', { name: 'item4' }))
             .then(() => {
                 assert.ok(itemStore.has('item1'), 'The store contains the given item');
                 assert.ok(itemStore.has('item2'), 'The store contains the given item');
                 assert.ok(itemStore.has('item3'), 'The store contains the given item');
                 assert.ok(itemStore.has('item4'), 'The store contains the given item');
             })
-            .then(() => {
-                return itemStore.set('item5', { name: 'item5' });
-            })
+            .then(() => itemStore.set('item5', { name: 'item5' }))
             .then(() => {
                 assert.ok(itemStore.has('item2'), 'The store contains the given item');
                 assert.ok(itemStore.has('item3'), 'The store contains the given item');
@@ -192,9 +182,7 @@ define(['taoQtiTest/runner/proxy/cache/itemStore'], function (itemStoreFactory) 
                 assert.ok(itemStore.has('item3'), 'The store contains the given item');
                 assert.ok(itemStore.has('item4'), 'The store contains the given item');
             })
-            .then(() => {
-                return itemStore.remove('item3');
-            })
+            .then(() => itemStore.remove('item3'))
             .then(removed => {
                 assert.ok(removed, 'The removal went well');
                 assert.ok(!itemStore.has('item3'), 'The item was removed from the store');
@@ -206,9 +194,7 @@ define(['taoQtiTest/runner/proxy/cache/itemStore'], function (itemStoreFactory) 
             .then(removed => {
                 assert.ok(!removed, 'Nothing to remove');
             })
-            .then(() => {
-                return itemStore.set('item5', { name: 'item5' });
-            })
+            .then(() => itemStore.set('item5', { name: 'item5' }))
             .then(() => {
                 assert.ok(itemStore.has('item1'), 'The store contains the given item');
                 assert.ok(itemStore.has('item2'), 'The store contains the given item');
@@ -244,12 +230,8 @@ define(['taoQtiTest/runner/proxy/cache/itemStore'], function (itemStoreFactory) 
                 assert.ok(itemStore.has('item2'), 'The store contains the given item');
                 assert.ok(itemStore.has('item3'), 'The store contains the given item');
             })
-            .then(() => {
-                return itemStore.update('item2', 'response', []);
-            })
-            .then(() => {
-                return itemStore.update('item2', 'some', 'thing else');
-            })
+            .then(() => itemStore.update('item2', 'response', []))
+            .then(() => itemStore.update('item2', 'some', 'thing else'))
             .then(updated => {
                 assert.ok(updated, 'The updated went well');
                 assert.ok(itemStore.has('item2'), 'The item is still in the store from the store');
@@ -349,9 +331,7 @@ define(['taoQtiTest/runner/proxy/cache/itemStore'], function (itemStoreFactory) 
                 assert.ok(itemStore.has('item2'), 'The store contains the given item');
                 assert.ok(itemStore.has('item3'), 'The store contains the given item');
             })
-            .then(() => {
-                return itemStore.clear();
-            })
+            .then(() => itemStore.clear())
             .then(cleared => {
                 assert.ok(cleared, 'The clear wen well');
                 assert.ok(!itemStore.has('item1'), 'The item was removed from the store');

--- a/test/toolStateBridge/test.js
+++ b/test/toolStateBridge/test.js
@@ -17,7 +17,6 @@
  */
 /**
  * Test the module taoQtiTest/runner/provider/toolStateBridge
-
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define(['taoQtiTest/runner/provider/toolStateBridge'], function(toolStateBridgeFactory) {


### PR DESCRIPTION
I'm trying to get this repo to zero ESLint errors and warnings, so PR commits will have a green ✅  more often than a red ❌ .

Most of the fixes were simple; I'll comment any where another set of eyes 👀  would be nice.

Out-of-scope: full ES6 conversions of edited files.

To have some more security you can also checkout the middle commit (https://github.com/oat-sa/tao-test-runner-qti-fe/pull/476/commits/f88fae01996eb0f6bcea4067368209ca42c802d1 - changed src but not tests) and run the old tests. Then run the changed tests in the final commit.