### PR TITLE
Fix/tr 4344/integer float textentry response

### DIFF
--- a/src/helpers/currentItem.js
+++ b/src/helpers/currentItem.js
@@ -92,13 +92,17 @@ var currentItemHelper = {
         var mappedCardinality = responseCardinalities[cardinality];
         var response = {};
 
-        if (_.isString(value)) {
+        if (_.isString(value) || _.isNumber(value)) {
             value = [value];
         }
 
         let transform = v => v;
         if (baseType === 'boolean') {
             transform = v => v === true || v === 'true';
+        } else if (baseType === 'integer') {
+            transform = v => typeof v === 'number' ? v : parseInt(v)
+        } else if (baseType === 'float') {
+            transform = v => typeof v === 'number' ? v : parseFloat(v)
         } else if (baseType === 'directedPair' || baseType === 'pair') {
             transform = v => {
                 if (_.isString(v)) {
@@ -149,9 +153,11 @@ var currentItemHelper = {
             value = value[mappedCardinality][baseType];
         }
 
+        const stringyValue = 'string' === baseType || 'integer' === baseType || 'float' === baseType
+
         return (
             null === value ||
-            ('string' === baseType && _.isEmpty(value)) ||
+            (stringyValue && value === '') ||
             (cardinality !== 'single' && _.isEmpty(value))
         );
     },
@@ -168,7 +174,7 @@ var currentItemHelper = {
     isQuestionAnswered: function isQuestionAnswered(response, baseType, cardinality, defaultValue, constraintValue) {
         var answered, currentCardinality, responses;
         var fullyAnswered = true;
-        defaultValue = defaultValue || null;
+        defaultValue = _.isUndefined(defaultValue) ? null : defaultValue;
         constraintValue = constraintValue || 0;
 
         if (currentItemHelper.isQtiValueNull(response, baseType, cardinality)) {

--- a/src/helpers/currentItem.js
+++ b/src/helpers/currentItem.js
@@ -100,9 +100,9 @@ var currentItemHelper = {
         if (baseType === 'boolean') {
             transform = v => v === true || v === 'true';
         } else if (baseType === 'integer') {
-            transform = v => typeof v === 'number' ? v : parseInt(v)
+            transform = v => typeof v === 'number' ? v : parseInt(v);
         } else if (baseType === 'float') {
-            transform = v => typeof v === 'number' ? v : parseFloat(v)
+            transform = v => typeof v === 'number' ? v : parseFloat(v);
         } else if (baseType === 'directedPair' || baseType === 'pair') {
             transform = v => {
                 if (_.isString(v)) {
@@ -153,7 +153,7 @@ var currentItemHelper = {
             value = value[mappedCardinality][baseType];
         }
 
-        const stringyValue = 'string' === baseType || 'integer' === baseType || 'float' === baseType
+        const stringyValue = 'string' === baseType || 'integer' === baseType || 'float' === baseType;
 
         return (
             null === value ||

--- a/test/helpers/currentItem/test.js
+++ b/test/helpers/currentItem/test.js
@@ -225,7 +225,7 @@ define(['lodash', 'taoQtiTest/runner/helpers/currentItem'], function(_, currentI
     });
 
     QUnit.test('helpers/currentItem.isQuestionAnswered', function(assert) {
-        assert.expect(11);
+        assert.expect(21);
 
         // Null
         assert.equal(
@@ -243,6 +243,16 @@ define(['lodash', 'taoQtiTest/runner/helpers/currentItem'], function(_, currentI
             false,
             'The question should not be answered'
         );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered(null, 'integer', 'single'),
+            false,
+            'The question should not be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered(null, 'float', 'single'),
+            false,
+            'The question should not be answered'
+        );
 
         // Default
         assert.equal(
@@ -252,6 +262,26 @@ define(['lodash', 'taoQtiTest/runner/helpers/currentItem'], function(_, currentI
         );
         assert.equal(
             currentItemHelper.isQuestionAnswered({ list: { string: ['foo'] } }, 'string', 'multiple', ['foo']),
+            false,
+            'The question should not be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { integer: 0 } }, 'integer', 'single', 0),
+            false,
+            'The question should not be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { integer: 5000000000 } }, 'integer', 'single', 5e9),
+            false,
+            'The question should not be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { float: 1.1 } }, 'float', 'single', 1.1),
+            false,
+            'The question should not be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { float: 1.0000000001 } }, 'float', 'single', 1.0000000001),
             false,
             'The question should not be answered'
         );
@@ -272,6 +302,16 @@ define(['lodash', 'taoQtiTest/runner/helpers/currentItem'], function(_, currentI
             false,
             'The question should not be answered'
         );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { integer: null } }, 'integer', 'single', 0),
+            false,
+            'The question should not be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { float: null } }, 'float', 'single', 1.1),
+            false,
+            'The question should not be answered'
+        );
 
         // Not null or default
         assert.equal(
@@ -288,6 +328,16 @@ define(['lodash', 'taoQtiTest/runner/helpers/currentItem'], function(_, currentI
             currentItemHelper.isQuestionAnswered({ list: { string: [] } }, 'string', 'multiple'),
             false,
             'The question should not be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { integer: 0 } }, 'integer', 'single'),
+            true,
+            'The question should be answered'
+        );
+        assert.equal(
+            currentItemHelper.isQuestionAnswered({ base: { float: 1.1 } }, 'float', 'single'),
+            true,
+            'The question should be answered'
         );
     });
 


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/TR-4344

### Description

null values for TextEntry interaction with response type integer and float been treated as valid answers. This PR fixes the behaviour

### How to test

Unit tests
`npm run test:keepAlive` , run `helpers/curentItem` test

Check on deployed environment (check env section in the original. ticket)
