### PR TITLE
Fix/tr 4477/itemThemeSwitcher reset active theme on destroy

### DIFF
--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -58,7 +58,7 @@ export default pluginFactory({
         var pluginShortcuts = (testRunnerOptions.shortcuts || {})[this.getName()] || {};
 
         const pluginConfig = this.getConfig();
-        const oldNamespace = themeHandler.getActiveNamespace();
+        this.oldNamespace = themeHandler.getActiveNamespace();
         const state = {
             availableThemes: [],
             defaultTheme: '',
@@ -70,7 +70,7 @@ export default pluginFactory({
             themeHandler.setActiveNamespace(pluginConfig.activeNamespace);
         }
         const themesConfig = themeHandler.get('items') || {};
-        if (pluginConfig.activeNamespace !== oldNamespace && !_.isEmpty(themesConfig)) {
+        if (pluginConfig.activeNamespace !== this.oldNamespace && !_.isEmpty(themesConfig)) {
             reloadThemes();
         }
 
@@ -265,6 +265,10 @@ export default pluginFactory({
      * Called during the runner's destroy phase
      */
     destroy: function destroy() {
+        var themeConfig = themeHandler.get('items');
+        themeLoader(themeConfig).unload();
+        themeHandler.setActiveNamespace(this.oldNamespace);
+
         shortcut.remove(`.${this.getName()}`);
         return this.getTestRunner().getPluginStore(this.getName()).then(function(itemThemesStore) {
             return itemThemesStore.removeItem('itemThemeId');

--- a/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
+++ b/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js
@@ -265,8 +265,6 @@ export default pluginFactory({
      * Called during the runner's destroy phase
      */
     destroy: function destroy() {
-        var themeConfig = themeHandler.get('items');
-        themeLoader(themeConfig).unload();
         themeHandler.setActiveNamespace(this.oldNamespace);
 
         shortcut.remove(`.${this.getName()}`);


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4477

Theme handler is global https://github.com/oat-sa/tao-core-ui-fe/blob/develop/src/themes.js#L28 . After you set active theme once, it stays.
So when Preview sets active theme here once https://github.com/oat-sa/tao-test-runner-qti-fe/blob/develop/src/plugins/tools/itemThemeSwitcher/itemThemeSwitcher.js#L70 , it stays and gets applied when Authoring Editor is rendered the next time, because Editor doesn't set active theme itself: https://github.com/oat-sa/extension-tao-itemqti/blob/master/views/js/qtiCreator/itemCreator.js#L362 does nothing then https://github.com/oat-sa/tao-item-runner-qti-fe/blob/develop/src/qtiRunner/core/Renderer.js#L528 applies what's already active. 

But it shouldn't be applied in Authoring Editor .

See ticket description for more detailed steps to reproduce.

Alternative solution could be to reset active theme to default when Editor is created https://github.com/oat-sa/extension-tao-itemqti/blob/master/views/js/qtiCreator/itemCreator.js - store original `config` of themes helper https://github.com/oat-sa/tao-core-ui-fe/blob/develop/src/themes.js and add a method to restore it, then call it from `itemCreator`.

