### PR TITLE
fix: add condition to correct NaN value in timer.extraTime min

### DIFF
--- a/src/plugins/controls/timer/timers.js
+++ b/src/plugins/controls/timer/timers.js
@@ -188,7 +188,7 @@ export default function getTimers(timeConstraints, isLinear, config) {
         }
 
         timer.remainingWithoutExtraTime = timer.remainingTime;
-        if (timer.extraTime) {
+        if (timer.extraTime && timer.type !== 'min') {
             timer.extraTime.consumed = timer.extraTime.consumed * precision;
             timer.extraTime.remaining = timer.extraTime.remaining * precision;
             timer.extraTime.total = timer.extraTime.total * precision;


### PR DESCRIPTION
Related to: [TR-3481](https://oat-sa.atlassian.net/browse/TR-3481)

**STEPS TO TEST:**
1º Create a test and set minimum duration time limit option for one of the items in test.
![image](https://user-images.githubusercontent.com/60346520/191032898-2e54d027-4ee6-44c5-935a-5af8d86fc1de.png)

2º Publish the test and assign it to a test-taker
4º Take test as test taker.

**ACTUAL RESULT:**
when the test reaches the item with the minimum time limit set, timer count is 0.0.0 and test freezes.

**EXPECTED RESULT:**
When test taker reaches the item with the minimum time limit set, the counter will show the set time and the next button will be disabled, once the timer gets to 0 then the next button will be activated and the test taker will be able to continue with the rest if the test.


![timers](https://user-images.githubusercontent.com/60346520/191032496-5e097f88-86c4-47d9-897c-b9b299ac3236.gif)

