### PR TITLE
Fix/tr 4940/review mode no padding on long title items

### DIFF
--- a/scss/inc/_navigator.scss
+++ b/scss/inc/_navigator.scss
@@ -74,8 +74,8 @@ $borderColor: $textHighlight;
         position: relative;
         top: 1px;
         display: inline-block;
-        width: 2rem;
         line-height: #{$lineHeight - .2rem};
+        margin-right: 0.5rem;
     }
 
     // unseen items cannot be marked for review, disable the pointer cursor on them


### PR DESCRIPTION
**Related to :** 
https://oat-sa.atlassian.net/browse/TR-4940
TaoQtiTest

Padding left in delivery for items with long title no present

**How to test:**
create Items with long titles (more than 5 characters"
Create a test with those Items and enable preview & no linear.
Publish the test.
Take the assignment as a test taker


**CURRENT RESULT:**
Item title doesn't have left padding with icon

**EXPECTED RESULT:**
Item has padding left with icon no matter the length of title

<img width="400" alt="image" src="https://user-images.githubusercontent.com/60346520/207056373-e802dabf-1211-49a9-a48a-9e70bff16b42.png">
