### PR TITLE
Feature/TR-5854/Detect delivery concurrency

### DIFF
--- a/src/plugins/controls/session/preventConcurrency.js
+++ b/src/plugins/controls/session/preventConcurrency.js
@@ -1,0 +1,85 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ */
+import context from 'context';
+import loggerFactory from 'core/logger';
+import store from 'core/store';
+import __ from 'i18n';
+import states from 'taoQtiTest/runner/config/states';
+import pluginFactory from 'taoTests/runner/plugin';
+
+const logger = loggerFactory('taoQtiTest/runner/plugins/controls/session/preventConcurrency');
+
+const STORE_ID = 'current';
+const SEQUENCE_NUMBER = 'sequence';
+const FEATURE_FLAG = 'FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS';
+
+/**
+ * Test Runner Control Plugin : detect concurrent deliveries launched from the same user session.
+ */
+export default pluginFactory({
+    name: 'preventConcurrency',
+
+    /**
+     * Initializes the plugin (called during runner's init)
+     */
+    init() {
+        if (!context.featureFlags[FEATURE_FLAG]) {
+            return;
+        }
+
+        const testRunner = this.getTestRunner();
+        const options = testRunner.getOptions();
+        const skipPausedAssessmentDialog = !!options.skipPausedAssessmentDialog;
+
+        return testRunner
+            .getTestStore()
+            .getStorageIdentifier()
+            .then(storeId => {
+                const sequenceNumber = `${storeId}-${Date.now()}`;
+
+                function detectConcurrency(lastSequenceNumber) {
+                    if (lastSequenceNumber !== sequenceNumber) {
+                        logger.warn(
+                            `The sequence number has changed. Was another delivery opened in the same browser?`
+                        );
+                        testRunner.off('tick');
+                        testRunner.trigger('concurrency');
+                        return Promise.reject();
+                    }
+                }
+
+                function stopOnConcurrency() {
+                    testRunner.trigger('leave', {
+                        code: states.testSession.suspended,
+                        message: __(
+                            'A concurrent delivery has been detected. Please use the last open session. The present window can be closed.'
+                        ),
+                        skipExitMessage: skipPausedAssessmentDialog
+                    });
+                }
+
+                return store(STORE_ID).then(deliveryStore =>
+                    deliveryStore.setItem(SEQUENCE_NUMBER, sequenceNumber).then(() => {
+                        testRunner
+                            .on('tick', () => deliveryStore.getItem(SEQUENCE_NUMBER).then(detectConcurrency))
+                            .on('concurrency', stopOnConcurrency);
+                    })
+                );
+            });
+    }
+});

--- a/src/plugins/controls/session/preventConcurrency.js
+++ b/src/plugins/controls/session/preventConcurrency.js
@@ -49,6 +49,9 @@ export default pluginFactory({
                                 return sequenceStore.getSequenceNumber().then(lastSequenceNumber => {
                                     if (lastSequenceNumber !== sequenceNumber) {
                                         testRunner.off('tick');
+                                        testRunner.trigger('disabletools');
+                                        testRunner.trigger('disablenav');
+                                        testRunner.trigger('disableitem');
                                         testRunner.trigger('concurrency');
                                         return Promise.reject();
                                     }

--- a/src/services/sequenceStore.js
+++ b/src/services/sequenceStore.js
@@ -1,0 +1,59 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ */
+import store from 'core/store';
+
+const STORE_ID = 'current';
+const SEQUENCE_NUMBER = 'sequence';
+
+export default {
+    /**
+     * Creates a store for the sequence number for the session.
+     * @returns {Promise} - Resolved with the store API.
+     */
+    getSequenceStore() {
+        return store(STORE_ID).then(sequenceStore => ({
+            /**
+             * Stores the sequence number for the session.
+             * @param {string} sequenceNumber - The new sequence number to set for the session.
+             * @returns {Promise} - Resolved once the sequence number has been stored.
+             */
+            setSequenceNumber(sequenceNumber) {
+                return sequenceStore.setItem(SEQUENCE_NUMBER, sequenceNumber);
+            },
+
+            /**
+             * Reads the sequence number for the session from the storage.
+             * @returns {Promise<string>} - Resolved with the sequence number for the session.
+             */
+            getSequenceNumber() {
+                return sequenceStore.getItem(SEQUENCE_NUMBER);
+            }
+        }));
+    },
+
+    /**
+     * Creates a sequence number for the test runner.
+     * @returns {Promise<string>} - Resolved with sequence number for the session.
+     */
+    getSequenceNumber(testRunner) {
+        return testRunner
+            .getTestStore()
+            .getStorageIdentifier()
+            .then(storeId => `${storeId}-${Date.now()}`);
+    }
+};

--- a/test/plugins/controls/preventConcurrency/mocks/sequenceStore.js
+++ b/test/plugins/controls/preventConcurrency/mocks/sequenceStore.js
@@ -1,0 +1,28 @@
+define(function () {
+    ('use strict');
+
+    let sequenceNumber = '';
+
+    return {
+        getSequenceStore() {
+            return Promise.resolve({
+                setSequenceNumber(seq) {
+                    sequenceNumber = seq;
+                    return Promise.resolve();
+                },
+
+                getSequenceNumber() {
+                    return Promise.resolve(sequenceNumber);
+                }
+            });
+        },
+
+        getSequenceNumber(testRunner) {
+            return Promise.resolve(testRunner.sequenceNumber);
+        },
+
+        setSequenceNumber(seq) {
+            sequenceNumber = seq;
+        }
+    };
+});

--- a/test/plugins/controls/preventConcurrency/test.html
+++ b/test/plugins/controls/preventConcurrency/test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner Plugins - preventConcurrency</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    requirejs.config({
+                        paths: {
+                            'taoQtiTest/runner/services/sequenceStore': '/test/plugins/controls/preventConcurrency/mocks/sequenceStore'
+                        }
+                    });
+                    require(['taoQtiTest/test/runner/plugins/controls/preventConcurrency/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/plugins/controls/preventConcurrency/test.js
+++ b/test/plugins/controls/preventConcurrency/test.js
@@ -1,0 +1,284 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA
+ */
+define([
+    'context',
+    'taoTests/runner/runner',
+    'taoTests/runner/proxy',
+    'taoQtiTest/test/runner/mocks/providerMock',
+    'taoQtiTest/test/runner/mocks/proxyMock',
+    'taoQtiTest/runner/plugins/controls/session/preventConcurrency',
+    'taoQtiTest/runner/services/sequenceStore'
+], function (context, runnerFactory, proxyFactory, providerMock, providerProxyMock, pluginFactory, sequenceStore) {
+    'use strict';
+
+    const providerName = 'mock';
+    proxyFactory.registerProvider(providerName, providerProxyMock());
+    runnerFactory.registerProvider(providerName, providerMock());
+
+    const sampleTestContext = {
+        itemIdentifier: 'item-1',
+        attempt: 1
+    };
+
+    const sampleTestMap = {
+        parts: {
+            p1: {
+                sections: {
+                    s1: {
+                        items: {
+                            'item-1': {
+                                categories: ['x-tao-option-apiptts']
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        jumps: [
+            {
+                identifier: 'item-1',
+                section: 's1',
+                part: 'p1',
+                position: 0
+            }
+        ]
+    };
+
+    /**
+     * Gets a configured instance of the Test Runner
+     * @param {Object} [config] - Optional config to setup the test runner
+     * @returns {Promise<runner>}
+     */
+    function getTestRunner(config) {
+        const runner = runnerFactory(providerName, [], config);
+        runner.getDataHolder();
+        runner.setTestContext(sampleTestContext);
+        runner.setTestMap(sampleTestMap);
+        return Promise.resolve(runner);
+    }
+
+    /**
+     * Generic tests
+     */
+    QUnit.module('pluginFactory');
+
+    QUnit.test('module', assert => {
+        const runner = runnerFactory(providerName);
+
+        assert.expect(3);
+
+        assert.equal(typeof pluginFactory, 'function', 'The pluginFactory module exposes a function');
+        assert.equal(typeof pluginFactory(runner), 'object', 'The plugin factory produces an instance');
+        assert.notStrictEqual(
+            pluginFactory(runner),
+            pluginFactory(runner),
+            'The plugin factory provides a different instance on each call'
+        );
+    });
+
+    QUnit.module('Plugin API');
+
+    QUnit.cases
+        .init([
+            { title: 'init' },
+            { title: 'render' },
+            { title: 'finish' },
+            { title: 'destroy' },
+            { title: 'trigger' },
+            { title: 'getTestRunner' },
+            { title: 'getAreaBroker' },
+            { title: 'getConfig' },
+            { title: 'setConfig' },
+            { title: 'getState' },
+            { title: 'setState' },
+            { title: 'show' },
+            { title: 'hide' },
+            { title: 'enable' },
+            { title: 'disable' }
+        ])
+        .test('plugin API ', (data, assert) => {
+            const runner = runnerFactory(providerName);
+            const plugin = pluginFactory(runner);
+
+            assert.expect(1);
+
+            assert.equal(
+                typeof plugin[data.title],
+                'function',
+                `The pluginFactory instances expose a ${data.title} function`
+            );
+        });
+
+    QUnit.module('Plugin', {
+        beforeEach() {
+            context.featureFlags = {};
+        }
+    });
+
+    QUnit.test('set sequence number', assert => {
+        const ready = assert.async();
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
+
+                runner.sequenceNumber = '1234-5678';
+
+                assert.expect(1);
+
+                return sequenceStore.getSequenceStore().then(store =>
+                    store
+                        .setSequenceNumber('0')
+                        .then(() => plugin.init())
+                        .then(() => store.getSequenceNumber())
+                        .then(sequenceNumber => {
+                            assert.equal(sequenceNumber, runner.sequenceNumber);
+                        })
+                );
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+
+    QUnit.test('detect concurrency', assert => {
+        const ready = assert.async();
+        context.featureFlags.FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS = true;
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
+
+                runner.sequenceNumber = '1234-5678';
+
+                assert.expect(3);
+
+                return sequenceStore.getSequenceStore().then(store =>
+                    plugin
+                        .init()
+                        .then(() => store.getSequenceNumber())
+                        .then(sequenceNumber => {
+                            assert.equal(sequenceNumber, runner.sequenceNumber);
+                        })
+                        .then(
+                            () =>
+                                new Promise(resolve => {
+                                    runner.on('concurrency', () => assert.ok('true', 'Concurrency detected'));
+                                    runner.on('leave', () => {
+                                        assert.ok('true', 'Test runner leaving');
+                                        resolve();
+                                    });
+                                    sequenceStore.setSequenceNumber('foo');
+                                    runner.trigger('tick');
+                                })
+                        )
+                );
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+
+    QUnit.test('no concurrency', assert => {
+        const ready = assert.async();
+        context.featureFlags.FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS = true;
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
+
+                runner.sequenceNumber = '1234-5678';
+
+                assert.expect(1);
+
+                return sequenceStore.getSequenceStore().then(store =>
+                    plugin
+                        .init()
+                        .then(() => store.getSequenceNumber())
+                        .then(sequenceNumber => {
+                            assert.equal(sequenceNumber, runner.sequenceNumber);
+                        })
+                        .then(
+                            () =>
+                                new Promise(resolve => {
+                                    runner.on('concurrency', () => assert.ok('false', 'Concurrency detected'));
+                                    runner.on('leave', () => {
+                                        assert.ok('false', 'Test runner leaving');
+                                        resolve();
+                                    });
+                                    runner.trigger('tick');
+                                    setTimeout(resolve, 20);
+                                })
+                        )
+                );
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+
+    QUnit.test('detection disabled', assert => {
+        const ready = assert.async();
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
+
+                runner.sequenceNumber = '1234-5678';
+
+                assert.expect(1);
+
+                return sequenceStore.getSequenceStore().then(store =>
+                    plugin
+                        .init()
+                        .then(() => store.getSequenceNumber())
+                        .then(sequenceNumber => {
+                            assert.equal(sequenceNumber, runner.sequenceNumber);
+                        })
+                        .then(
+                            () =>
+                                new Promise(resolve => {
+                                    runner.on('concurrency', () => assert.ok('false', 'Concurrency detected'));
+                                    runner.on('leave', () => {
+                                        assert.ok('false', 'Test runner leaving');
+                                        resolve();
+                                    });
+                                    sequenceStore.setSequenceNumber('foo');
+                                    runner.trigger('tick');
+                                    setTimeout(resolve, 20);
+                                })
+                        )
+                );
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+});

--- a/test/services/sequenceStore/mocks/store.js
+++ b/test/services/sequenceStore/mocks/store.js
@@ -1,0 +1,16 @@
+define(function () {
+    'use strict';
+
+    return function () {
+        const store = new Map();
+        return Promise.resolve({
+            setItem(key, value) {
+                store.set(key, value);
+                return Promise.resolve();
+            },
+            getItem(key) {
+                return Promise.resolve(store.get(key));
+            }
+        });
+    };
+});

--- a/test/services/sequenceStore/test.html
+++ b/test/services/sequenceStore/test.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner - sequenceStore</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function() {
+                require(['qunitEnv'], function() {
+                    requirejs.config({
+                        paths: {
+                            'core/store': '/test/services/sequenceStore/mocks/store'
+                        }
+                    });
+                    require(['taoQtiTest/test/runner/services/sequenceStore/test'], function() {
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/test/services/sequenceStore/test.js
+++ b/test/services/sequenceStore/test.js
@@ -1,0 +1,114 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ */
+define(['taoQtiTest/runner/services/sequenceStore'], function (sequenceStore) {
+    'use strict';
+
+    QUnit.module('sequenceStore');
+
+    QUnit.test('is a namespace', function (assert) {
+        assert.equal(typeof sequenceStore, 'object');
+    });
+
+    QUnit.test('it has the required methods', function (assert) {
+        assert.equal(typeof sequenceStore.getSequenceStore, 'function');
+        assert.equal(typeof sequenceStore.getSequenceNumber, 'function');
+    });
+
+    QUnit.module('sequenceStore.getSequenceStore()');
+
+    QUnit.test('is a factory', function (assert) {
+        assert.equal(typeof sequenceStore.getSequenceStore, 'function');
+        assert.notEqual(sequenceStore.getSequenceStore(), sequenceStore.getSequenceStore());
+    });
+
+    QUnit.test('returns a promise', function (assert) {
+        assert.equal(typeof sequenceStore.getSequenceStore(), 'object');
+        assert.ok(sequenceStore.getSequenceStore() instanceof Promise);
+    });
+
+    QUnit.test('it has the required methods', function (assert) {
+        const done = assert.async();
+        sequenceStore
+            .getSequenceStore()
+            .then(sequenceNumber => {
+                assert.equal(typeof sequenceNumber.setSequenceNumber, 'function');
+                assert.equal(typeof sequenceNumber.getSequenceNumber, 'function');
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(done);
+    });
+
+    QUnit.test('write/read the sequence number', function (assert) {
+        const done = assert.async();
+        sequenceStore
+            .getSequenceStore()
+            .then(sequenceNumber => {
+                const number = '1234-5678';
+                return sequenceNumber
+                    .setSequenceNumber(number)
+                    .then(() => sequenceNumber.getSequenceNumber())
+                    .then(value => {
+                        assert.equal(value, number);
+                    });
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(done);
+    });
+
+    QUnit.module('sequenceStore.getSequenceNumber()');
+
+    QUnit.test('returns a sequence number', function (assert) {
+        const done = assert.async();
+        const now = 1234;
+        const identifier = 'test';
+        const testRunner = {
+            getTestStore() {
+                return {
+                    getStorageIdentifier() {
+                        return Promise.resolve(identifier);
+                    }
+                };
+            }
+        };
+
+        Date.now = () => now;
+
+        sequenceStore
+            .getSequenceNumber(testRunner)
+            .then(sequenceNumber => {
+                assert.equal(sequenceNumber, `${identifier}-${now}`);
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(done);
+    });
+});


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5854

RFE: https://oat-sa.atlassian.net/browse/RFE-748

### Summary

Add a mechanism for detecting concurrent delivery sessions.

### Details

When the test runner initializes, a sequence number is stored in the browser's storage. Each time the duration is updated, the sequence number is read from the storage and compared with the value created at the beginning. If a discrepancy is discovered this means another test runner started meanwhile and updated the storage. A dialog message is presented to the user and the test runner is stopped.

### How to test
- install: `npm ci`
- run the tests: `npm test`

For checking the feature, please refer to the companion PR: https://github.com/oat-sa/extension-tao-testqti/pull/2420