### PR TITLE
Fix/INF-314/Handle all timeConstraint values in test navigation

### DIFF
--- a/src/plugins/navigation/previous.js
+++ b/src/plugins/navigation/previous.js
@@ -85,9 +85,12 @@ export default pluginFactory({
 
                 //if the previous section is adaptive or a timed section
                 previousSection = mapHelper.getItemSection(testMap, context.itemPosition - 1);
+                // since 2025.02, empty timeConstraint can be null or []; defined timeConstraint will still be an object
+                const previousSectionHasTimeConstraint =
+                    previousSection.timeConstraint && 'allowLateSubmission' in previousSection.timeConstraint;
                 if (
                     previousSection.isCatAdaptive ||
-                    (previousSection.timeConstraint && !noExitTimedSectionWarning)
+                    (previousSectionHasTimeConstraint && !noExitTimedSectionWarning)
                 ) {
                     return false;
                 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-314

Mitigate a change in the serialized test format introduced [here](https://github.com/oat-sa/extension-tao-testqti/pull/2542/files#diff-aaaa9b2d494e27b0c261de3002367e5d274b30b20bb46a8f00adffdb29513900), which resulted in a lost "Previous" button.

The old serialized values in a testMap were 1. `timeConstraint: null` if no timer, 2. `timeConstraint: { minTime, maxTime, allowLateSubmission }` if timer.
The regression introduced the value `timeConstraint: []` if no timer. This PR aims to treat `[]` the same as `null`, so that deliveries published before or after the regression will behave the same.

It means that a "Previous" button can appear again when in the 2nd non-linear testPart or section, and the previous section has no timer.
![Screenshot 2025-04-23 at 14 41 53](https://github.com/user-attachments/assets/96da1a48-f9f8-447d-bf97-2d1fa537e0fd)
