### PR TITLE
Backport/INF-314/Handle all timeConstraint values in test navigation [2024.08]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-test-runner-qti",
-            "version": "4.1.0",
+            "version": "4.1.1",
             "license": "GPL-2.0",
             "devDependencies": {
                 "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "TAO Test Runner QTI implementation",
     "files": [
         "dist",

--- a/src/plugins/navigation/previous.js
+++ b/src/plugins/navigation/previous.js
@@ -85,9 +85,12 @@ export default pluginFactory({
 
                 //if the previous section is adaptive or a timed section
                 previousSection = mapHelper.getItemSection(testMap, context.itemPosition - 1);
+                // since 2025.02, empty timeConstraint can be null or []; defined timeConstraint will still be an object
+                const previousSectionHasTimeConstraint =
+                    previousSection.timeConstraint && 'allowLateSubmission' in previousSection.timeConstraint;
                 if (
                     previousSection.isCatAdaptive ||
-                    (previousSection.timeConstraint && !noExitTimedSectionWarning)
+                    (previousSectionHasTimeConstraint && !noExitTimedSectionWarning)
                 ) {
                     return false;
                 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-314

Backport of https://github.com/oat-sa/tao-test-runner-qti-fe/pull/532

To be published as v4.1.1, and used in extension-tao-testqti backport going to 2024.08.x release