### PR TITLE
[INF-566] fix: render ruby in exit dialog header

### DIFF
--- a/src/helpers/templates/messageHeader.tpl
+++ b/src/helpers/templates/messageHeader.tpl
@@ -1,1 +1,1 @@
-{{#if header}}<b>{{header}}</b><br><br>{{/if}}
+{{#if header}}<b>{{{header}}}</b><br><br>{{/if}}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-566

<img width="921" height="342" alt="image" src="https://github.com/user-attachments/assets/2b4c0818-04ec-48cf-a366-a3ae6d93a5e5" />

## Summary
- Stop HTML-escaping the exit dialog header in `messageHeader.tpl` so ruby annotations render like the rest of the dialog body (`INF-566`).
- Aligns with existing unescaped dialog message content built from translations.

## Test plan
- [ ] Enable `next-section` in test runner config
- [ ] Enable Allow Section Skipping + Display Next Section Warning on a multi-section test
- [ ] Add ruby markup to msgid `You are about to leave this section.` in a locale, compile + update
- [ ] Open Next Section confirmation: ruby renders in the bold header (not as literal tags)
- [ ] Confirm End Test / End Part dialogs still render headers correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message headers now correctly preserve supported HTML formatting instead of displaying markup as plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->