### PR TITLE
[Feat] allow to unpause concurrent session on close

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -82,6 +82,7 @@ export default inputs.map(input => {
         },
         external: [
             ...localExternals,
+            'context',
             'handlebars',
             'interact',
             'jquery',

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -49,7 +49,10 @@ Handlebars.Visitor.prototype.accept = function() {
 /* --------------------------------------------------------- */
 
 const globPath = p => p.replace(/\\/g, '/');
-const inputs = glob.sync(globPath(path.join(srcDir, '**', '*.js')));
+const workerFiles = glob.sync(globPath(path.join(srcDir, '**', '*.worker.js')));
+const inputs = glob
+    .sync(globPath(path.join(srcDir, '**', '*.js')))
+    .filter(input => !input.endsWith('.worker.js'));
 
 /**
  * Define all modules as external, so rollup won't bundle them together.
@@ -138,4 +141,13 @@ glob(globPath(path.join(srcDir, '**', '*.tpl'))).then(files => {
         await mkdirp(path.dirname(targetFile));
         copyFile(file, targetFile);
     });
+});
+
+/**
+ * copy worker files into dist as plain scripts, because SharedWorker expects a direct script URL.
+ */
+workerFiles.forEach(async (file) => {
+    const targetFile = path.resolve(outputDir, path.relative(srcDir, file));
+    await mkdirp(path.dirname(targetFile));
+    copyFile(file, targetFile);
 });

--- a/src/config/sharedWorkerConfig.js
+++ b/src/config/sharedWorkerConfig.js
@@ -1,0 +1,31 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+export const SHARED_WORKERS = Object.freeze({
+    PREVENT_CONCURRENCY: 'taoQtiTest/runner/workers/preventConcurrency.worker.js'
+});
+
+export const WORKER_MESSAGE_TYPE = Object.freeze({
+    REGISTER: 'REGISTER',
+    ACTIVE: 'ACTIVE',
+    PAUSED: 'PAUSED',
+    FOCUS: 'FOCUS',
+    BLUR: 'BLUR',
+    CLOSING: 'CLOSING',
+    UNPAUSE: 'UNPAUSE'
+});

--- a/src/plugins/controls/session/preventConcurrency.js
+++ b/src/plugins/controls/session/preventConcurrency.js
@@ -18,6 +18,7 @@
 import context from 'context';
 import loggerFactory from 'core/logger';
 import __ from 'i18n';
+import module from 'module';
 import states from 'taoQtiTest/runner/config/states';
 import { getSequenceNumber, getSequenceStore } from 'taoQtiTest/runner/services/sequenceStore';
 import pluginFactory from 'taoTests/runner/plugin';
@@ -25,6 +26,53 @@ import pluginFactory from 'taoTests/runner/plugin';
 const logger = loggerFactory('taoQtiTest/runner/plugins/controls/session/preventConcurrency');
 
 const FEATURE_FLAG = 'FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS';
+const WORKER_FILENAME = 'preventConcurrency.worker.js';
+const WORKER_MESSAGE_TYPE = {
+    REGISTER: 'REGISTER',
+    ACTIVE: 'ACTIVE',
+    PAUSED: 'PAUSED',
+    FOCUS: 'FOCUS',
+    BLUR: 'BLUR',
+    CLOSING: 'CLOSING',
+    UNPAUSE: 'UNPAUSE'
+};
+
+/**
+ * Creates a tiny SharedWorker that coordinates active/paused tabs for one browser session.
+ * The worker grants unpause to a focused paused tab when active tab closes.
+ * @returns {SharedWorker|null}
+ */
+function createSharedWorker() {
+    if (typeof window === 'undefined' || typeof SharedWorker === 'undefined') {
+        return null;
+    }
+
+    const requireToUrl =
+        typeof require === 'function' && require.toUrl
+            ? require.toUrl.bind(require)
+            : window.require && window.require.toUrl
+              ? window.require.toUrl.bind(window.require)
+              : null;
+
+    const workerUrl =
+        module && module.uri
+            ? module.uri.replace(/[^/]+$/, WORKER_FILENAME)
+            : requireToUrl
+              ? requireToUrl(`taoQtiTest/runner/plugins/controls/session/${WORKER_FILENAME}`)
+              : null;
+
+    if (!workerUrl) {
+        logger.warn('Cannot resolve SharedWorker url, SharedWorker is disabled.');
+        return null;
+    }
+
+    try {
+        return new SharedWorker(workerUrl);
+    } catch (err) {
+        logger.warn(`Failed to connect SharedWorker url "${workerUrl}"`, err);
+        return null;
+    }
+}
 
 /**
  * Test Runner Control Plugin : detect concurrent deliveries launched from the same user session.
@@ -39,10 +87,73 @@ export default pluginFactory({
         const testRunner = this.getTestRunner();
         const options = testRunner.getOptions();
         const skipPausedAssessmentDialog = !!options.skipPausedAssessmentDialog;
+        const tabId = `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        let isActiveTab = false;
+        let isPaused = false;
+        let refreshTriggered = false;
+        let workerPort = null;
+
+        const sendWorkerMessage = type => {
+            if (workerPort) {
+                workerPort.postMessage({ type, tabId });
+            }
+        };
+
+        const onFocus = () => sendWorkerMessage(WORKER_MESSAGE_TYPE.FOCUS);
+        const onBlur = () => sendWorkerMessage(WORKER_MESSAGE_TYPE.BLUR);
+        const onVisibilityChange = () => {
+            if (typeof document === 'undefined') {
+                return;
+            }
+            if (document.visibilityState === 'visible') {
+                onFocus();
+            } else if (document.visibilityState === 'hidden') {
+                onBlur();
+            }
+        };
+        const onClosing = () => {
+            if (isActiveTab) {
+                sendWorkerMessage(WORKER_MESSAGE_TYPE.CLOSING);
+            }
+        };
+
+        const sharedWorker = createSharedWorker();
+        if (sharedWorker) {
+            workerPort = sharedWorker.port;
+            workerPort.start();
+            workerPort.onmessage = ({ data }) => {
+                if (
+                    data &&
+                    data.type === WORKER_MESSAGE_TYPE.UNPAUSE &&
+                    isPaused &&
+                    !refreshTriggered &&
+                    typeof window !== 'undefined'
+                ) {
+                    refreshTriggered = true;
+                    window.location.reload();
+                }
+            };
+            sendWorkerMessage(WORKER_MESSAGE_TYPE.REGISTER);
+
+            if (typeof window !== 'undefined') {
+                window.addEventListener('focus', onFocus);
+                window.addEventListener('blur', onBlur);
+                window.addEventListener('pagehide', onClosing);
+                window.addEventListener('beforeunload', onClosing);
+                if (typeof document !== 'undefined') {
+                    document.addEventListener('visibilitychange', onVisibilityChange);
+                }
+                if (typeof document !== 'undefined' && document.hasFocus && document.hasFocus()) {
+                    onFocus();
+                }
+            }
+        }
 
         return Promise.all([getSequenceNumber(testRunner), getSequenceStore()]).then(
             ([sequenceNumber, sequenceStore]) =>
                 sequenceStore.setSequenceNumber(sequenceNumber).then(() => {
+                    isActiveTab = true;
+                    sendWorkerMessage(WORKER_MESSAGE_TYPE.ACTIVE);
                     testRunner
                         .on('tick', () => {
                             if (context.featureFlags[FEATURE_FLAG]) {
@@ -59,6 +170,9 @@ export default pluginFactory({
                             }
                         })
                         .on('concurrency', () => {
+                            isPaused = true;
+                            isActiveTab = false;
+                            sendWorkerMessage(WORKER_MESSAGE_TYPE.PAUSED);
                             logger.warn(
                                 `The sequence number has changed. Was another delivery opened in the same browser?`
                             );

--- a/src/plugins/controls/session/preventConcurrency.js
+++ b/src/plugins/controls/session/preventConcurrency.js
@@ -46,11 +46,11 @@ export default pluginFactory({
         let refreshTriggered = false;
         const sharedWorkerClient = isConcurrencyFeatureEnabled
             ? createSharedWorkerClient(() => {
-                  if (isPaused && !refreshTriggered && typeof window !== 'undefined') {
-                      refreshTriggered = true;
-                      window.location.reload();
-                  }
-              })
+                if (isPaused && !refreshTriggered && typeof window !== 'undefined') {
+                    refreshTriggered = true;
+                    window.location.reload();
+                }
+            })
             : null;
 
         return Promise.all([getSequenceNumber(testRunner), getSequenceStore()]).then(

--- a/src/plugins/controls/session/preventConcurrency.js
+++ b/src/plugins/controls/session/preventConcurrency.js
@@ -13,66 +13,20 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2023-2026 (original work) Open Assessment Technologies SA ;
  */
+
 import context from 'context';
 import loggerFactory from 'core/logger';
 import __ from 'i18n';
-import module from 'module';
 import states from 'taoQtiTest/runner/config/states';
+import { createSharedWorkerClient } from 'taoQtiTest/runner/plugins/controls/session/preventConcurrencySharedWorker';
 import { getSequenceNumber, getSequenceStore } from 'taoQtiTest/runner/services/sequenceStore';
 import pluginFactory from 'taoTests/runner/plugin';
 
 const logger = loggerFactory('taoQtiTest/runner/plugins/controls/session/preventConcurrency');
 
 const FEATURE_FLAG = 'FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS';
-const WORKER_FILENAME = 'preventConcurrency.worker.js';
-const WORKER_MESSAGE_TYPE = {
-    REGISTER: 'REGISTER',
-    ACTIVE: 'ACTIVE',
-    PAUSED: 'PAUSED',
-    FOCUS: 'FOCUS',
-    BLUR: 'BLUR',
-    CLOSING: 'CLOSING',
-    UNPAUSE: 'UNPAUSE'
-};
-
-/**
- * Creates a tiny SharedWorker that coordinates active/paused tabs for one browser session.
- * The worker grants unpause to a focused paused tab when active tab closes.
- * @returns {SharedWorker|null}
- */
-function createSharedWorker() {
-    if (typeof window === 'undefined' || typeof SharedWorker === 'undefined') {
-        return null;
-    }
-
-    const requireToUrl =
-        typeof require === 'function' && require.toUrl
-            ? require.toUrl.bind(require)
-            : window.require && window.require.toUrl
-              ? window.require.toUrl.bind(window.require)
-              : null;
-
-    const workerUrl =
-        module && module.uri
-            ? module.uri.replace(/[^/]+$/, WORKER_FILENAME)
-            : requireToUrl
-              ? requireToUrl(`taoQtiTest/runner/plugins/controls/session/${WORKER_FILENAME}`)
-              : null;
-
-    if (!workerUrl) {
-        logger.warn('Cannot resolve SharedWorker url, SharedWorker is disabled.');
-        return null;
-    }
-
-    try {
-        return new SharedWorker(workerUrl);
-    } catch (err) {
-        logger.warn(`Failed to connect SharedWorker url "${workerUrl}"`, err);
-        return null;
-    }
-}
 
 /**
  * Test Runner Control Plugin : detect concurrent deliveries launched from the same user session.
@@ -86,77 +40,26 @@ export default pluginFactory({
     init() {
         const testRunner = this.getTestRunner();
         const options = testRunner.getOptions();
+        const isConcurrencyFeatureEnabled = !!context?.featureFlags?.[FEATURE_FLAG];
         const skipPausedAssessmentDialog = !!options.skipPausedAssessmentDialog;
-        const tabId = `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-        let isActiveTab = false;
         let isPaused = false;
         let refreshTriggered = false;
-        let workerPort = null;
-
-        const sendWorkerMessage = type => {
-            if (workerPort) {
-                workerPort.postMessage({ type, tabId });
-            }
-        };
-
-        const onFocus = () => sendWorkerMessage(WORKER_MESSAGE_TYPE.FOCUS);
-        const onBlur = () => sendWorkerMessage(WORKER_MESSAGE_TYPE.BLUR);
-        const onVisibilityChange = () => {
-            if (typeof document === 'undefined') {
-                return;
-            }
-            if (document.visibilityState === 'visible') {
-                onFocus();
-            } else if (document.visibilityState === 'hidden') {
-                onBlur();
-            }
-        };
-        const onClosing = () => {
-            if (isActiveTab) {
-                sendWorkerMessage(WORKER_MESSAGE_TYPE.CLOSING);
-            }
-        };
-
-        const sharedWorker = createSharedWorker();
-        if (sharedWorker) {
-            workerPort = sharedWorker.port;
-            workerPort.start();
-            workerPort.onmessage = ({ data }) => {
-                if (
-                    data &&
-                    data.type === WORKER_MESSAGE_TYPE.UNPAUSE &&
-                    isPaused &&
-                    !refreshTriggered &&
-                    typeof window !== 'undefined'
-                ) {
-                    refreshTriggered = true;
-                    window.location.reload();
-                }
-            };
-            sendWorkerMessage(WORKER_MESSAGE_TYPE.REGISTER);
-
-            if (typeof window !== 'undefined') {
-                window.addEventListener('focus', onFocus);
-                window.addEventListener('blur', onBlur);
-                window.addEventListener('pagehide', onClosing);
-                window.addEventListener('beforeunload', onClosing);
-                if (typeof document !== 'undefined') {
-                    document.addEventListener('visibilitychange', onVisibilityChange);
-                }
-                if (typeof document !== 'undefined' && document.hasFocus && document.hasFocus()) {
-                    onFocus();
-                }
-            }
-        }
+        const sharedWorkerClient = isConcurrencyFeatureEnabled
+            ? createSharedWorkerClient(() => {
+                  if (isPaused && !refreshTriggered && typeof window !== 'undefined') {
+                      refreshTriggered = true;
+                      window.location.reload();
+                  }
+              })
+            : null;
 
         return Promise.all([getSequenceNumber(testRunner), getSequenceStore()]).then(
             ([sequenceNumber, sequenceStore]) =>
                 sequenceStore.setSequenceNumber(sequenceNumber).then(() => {
-                    isActiveTab = true;
-                    sendWorkerMessage(WORKER_MESSAGE_TYPE.ACTIVE);
+                    sharedWorkerClient?.markActive();
                     testRunner
                         .on('tick', () => {
-                            if (context.featureFlags[FEATURE_FLAG]) {
+                            if (isConcurrencyFeatureEnabled) {
                                 return sequenceStore.getSequenceNumber().then(lastSequenceNumber => {
                                     if (lastSequenceNumber !== sequenceNumber) {
                                         testRunner.off('tick');
@@ -171,8 +74,7 @@ export default pluginFactory({
                         })
                         .on('concurrency', () => {
                             isPaused = true;
-                            isActiveTab = false;
-                            sendWorkerMessage(WORKER_MESSAGE_TYPE.PAUSED);
+                            sharedWorkerClient?.markPaused();
                             logger.warn(
                                 `The sequence number has changed. Was another delivery opened in the same browser?`
                             );

--- a/src/plugins/controls/session/preventConcurrency.worker.js
+++ b/src/plugins/controls/session/preventConcurrency.worker.js
@@ -1,0 +1,133 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ */
+(function() {
+    const MESSAGE_TYPE = {
+        REGISTER: 'REGISTER',
+        ACTIVE: 'ACTIVE',
+        PAUSED: 'PAUSED',
+        FOCUS: 'FOCUS',
+        BLUR: 'BLUR',
+        CLOSING: 'CLOSING',
+        UNPAUSE: 'UNPAUSE'
+    };
+
+    const tabs = new Map();
+    let activeTabId = null;
+    let focusedPausedTabId = null;
+    let waitingForFocusedPausedTab = false;
+
+    const ensureTab = tabId => {
+        if (!tabs.has(tabId)) {
+            tabs.set(tabId, {
+                port: null,
+                isPaused: false,
+                isFocused: false
+            });
+        }
+        return tabs.get(tabId);
+    };
+
+    const tryGrantUnpause = () => {
+        if (!waitingForFocusedPausedTab || !focusedPausedTabId) {
+            return;
+        }
+
+        const candidate = tabs.get(focusedPausedTabId);
+        if (!candidate || !candidate.port || !candidate.isPaused) {
+            return;
+        }
+
+        waitingForFocusedPausedTab = false;
+        focusedPausedTabId = null;
+        candidate.port.postMessage({ type: MESSAGE_TYPE.UNPAUSE });
+    };
+
+    onconnect = event => {
+        const port = event.ports[0];
+        let tabId = null;
+
+        port.onmessage = ({ data }) => {
+            if (!data || !data.type) {
+                return;
+            }
+
+            if (data.type === MESSAGE_TYPE.REGISTER) {
+                tabId = data.tabId;
+                const tab = ensureTab(tabId);
+                tab.port = port;
+                return;
+            }
+
+            if (!tabId) {
+                return;
+            }
+
+            const tab = ensureTab(tabId);
+
+            if (data.type === MESSAGE_TYPE.ACTIVE) {
+                activeTabId = tabId;
+                tab.isPaused = false;
+                waitingForFocusedPausedTab = false;
+                if (focusedPausedTabId === tabId) {
+                    focusedPausedTabId = null;
+                }
+                return;
+            }
+
+            if (data.type === MESSAGE_TYPE.PAUSED) {
+                tab.isPaused = true;
+                if (activeTabId === tabId) {
+                    activeTabId = null;
+                }
+                return;
+            }
+
+            if (data.type === MESSAGE_TYPE.FOCUS) {
+                tab.isFocused = true;
+                if (tab.isPaused) {
+                    focusedPausedTabId = tabId;
+                    tryGrantUnpause();
+                }
+                return;
+            }
+
+            if (data.type === MESSAGE_TYPE.BLUR) {
+                tab.isFocused = false;
+                if (focusedPausedTabId === tabId) {
+                    focusedPausedTabId = null;
+                }
+                return;
+            }
+
+            if (data.type === MESSAGE_TYPE.CLOSING) {
+                const wasActive = activeTabId === tabId;
+                tabs.delete(tabId);
+                if (focusedPausedTabId === tabId) {
+                    focusedPausedTabId = null;
+                }
+                if (wasActive) {
+                    activeTabId = null;
+                    waitingForFocusedPausedTab = true;
+                    tryGrantUnpause();
+                }
+            }
+        };
+
+        port.start();
+    };
+})();

--- a/src/plugins/controls/session/preventConcurrencySharedWorker.js
+++ b/src/plugins/controls/session/preventConcurrencySharedWorker.js
@@ -1,0 +1,92 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+import loggerFactory from 'core/logger';
+import module from 'module';
+import {
+    createSharedWorker,
+    resolveWorkerUrl
+} from 'taoQtiTest/runner/services/sharedWorker';
+import {
+    SHARED_WORKERS,
+    WORKER_MESSAGE_TYPE
+} from 'taoQtiTest/runner/config/sharedWorkerConfig';
+
+const logger = loggerFactory('taoQtiTest/runner/services/preventConcurrencySharedWorker');
+const EMPTY_CLIENT = {
+    markActive() {},
+    markPaused() {}
+};
+
+export function createSharedWorkerClient(onUnpause) {
+    const workerUrl = resolveWorkerUrl(module, SHARED_WORKERS.PREVENT_CONCURRENCY);
+    const sharedWorker = workerUrl ? createSharedWorker(workerUrl) : null;
+
+    if (!sharedWorker) {
+        logger.warn('SharedWorker is unavailable for preventConcurrency.');
+        return EMPTY_CLIENT;
+    }
+
+    const tabId = `tab-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    let isActiveTab = false;
+    const workerPort = sharedWorker.port;
+    const sendWorkerMessage = type => workerPort.postMessage({ type, tabId });
+
+    const markFocused = () => sendWorkerMessage(WORKER_MESSAGE_TYPE.FOCUS);
+    const markBlurred = () => sendWorkerMessage(WORKER_MESSAGE_TYPE.BLUR);
+    const onClosing = () => {
+        if (isActiveTab) {
+            sendWorkerMessage(WORKER_MESSAGE_TYPE.CLOSING);
+        }
+    };
+    const onVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+            markFocused();
+        } else if (document.visibilityState === 'hidden') {
+            markBlurred();
+        }
+    };
+
+    workerPort.start();
+    workerPort.onmessage = ({ data }) => {
+        if (data?.type === WORKER_MESSAGE_TYPE.UNPAUSE) {
+            onUnpause?.();
+        }
+    };
+    sendWorkerMessage(WORKER_MESSAGE_TYPE.REGISTER);
+
+    window.addEventListener('focus', markFocused);
+    window.addEventListener('blur', markBlurred);
+    window.addEventListener('pagehide', onClosing);
+    window.addEventListener('beforeunload', onClosing);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    if (document.hasFocus?.()) {
+        markFocused();
+    }
+
+    return {
+        markActive() {
+            isActiveTab = true;
+            sendWorkerMessage(WORKER_MESSAGE_TYPE.ACTIVE);
+        },
+        markPaused() {
+            isActiveTab = false;
+            sendWorkerMessage(WORKER_MESSAGE_TYPE.PAUSED);
+        }
+    };
+}

--- a/src/services/sharedWorker.js
+++ b/src/services/sharedWorker.js
@@ -1,0 +1,56 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 Open Assessment Technologies SA ;
+ */
+
+/**
+ * Resolves a worker URL relative to the current module file.
+ * @param {Object} currentModule
+ * @param {string} workerRelativePath
+ * @returns {string|null}
+ */
+export function resolveWorkerUrl(currentModule, workerRelativePath) {
+    if (!workerRelativePath) {
+        return null;
+    }
+
+    if (typeof require === 'function' && require.toUrl) {
+        return require.toUrl(workerRelativePath);
+    }
+
+    if (!currentModule?.uri) {
+        return null;
+    }
+
+    if (typeof URL !== 'undefined') {
+        return new URL(workerRelativePath, currentModule.uri).toString();
+    }
+
+    return null;
+}
+
+/**
+ * Creates SharedWorker instance by URL.
+ * @param {string} workerUrl
+ * @returns {SharedWorker|null}
+ */
+export function createSharedWorker(workerUrl) {
+    if (typeof window === 'undefined' || typeof SharedWorker === 'undefined' || !workerUrl) {
+        return null;
+    }
+
+    return new SharedWorker(workerUrl);
+}

--- a/src/workers/preventConcurrency.worker.js
+++ b/src/workers/preventConcurrency.worker.js
@@ -11,21 +11,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
  */
-(function() {
-    const MESSAGE_TYPE = {
-        REGISTER: 'REGISTER',
-        ACTIVE: 'ACTIVE',
-        PAUSED: 'PAUSED',
-        FOCUS: 'FOCUS',
-        BLUR: 'BLUR',
-        CLOSING: 'CLOSING',
-        UNPAUSE: 'UNPAUSE'
-    };
 
+(function() {
     const tabs = new Map();
     let activeTabId = null;
     let focusedPausedTabId = null;
@@ -54,10 +45,10 @@
 
         waitingForFocusedPausedTab = false;
         focusedPausedTabId = null;
-        candidate.port.postMessage({ type: MESSAGE_TYPE.UNPAUSE });
+        candidate.port.postMessage({ type: 'UNPAUSE' });
     };
 
-    onconnect = event => {
+    self.onconnect = event => {
         const port = event.ports[0];
         let tabId = null;
 
@@ -66,7 +57,7 @@
                 return;
             }
 
-            if (data.type === MESSAGE_TYPE.REGISTER) {
+            if (data.type === 'REGISTER') {
                 tabId = data.tabId;
                 const tab = ensureTab(tabId);
                 tab.port = port;
@@ -79,7 +70,7 @@
 
             const tab = ensureTab(tabId);
 
-            if (data.type === MESSAGE_TYPE.ACTIVE) {
+            if (data.type === 'ACTIVE') {
                 activeTabId = tabId;
                 tab.isPaused = false;
                 waitingForFocusedPausedTab = false;
@@ -89,7 +80,7 @@
                 return;
             }
 
-            if (data.type === MESSAGE_TYPE.PAUSED) {
+            if (data.type === 'PAUSED') {
                 tab.isPaused = true;
                 if (activeTabId === tabId) {
                     activeTabId = null;
@@ -97,7 +88,7 @@
                 return;
             }
 
-            if (data.type === MESSAGE_TYPE.FOCUS) {
+            if (data.type === 'FOCUS') {
                 tab.isFocused = true;
                 if (tab.isPaused) {
                     focusedPausedTabId = tabId;
@@ -106,7 +97,7 @@
                 return;
             }
 
-            if (data.type === MESSAGE_TYPE.BLUR) {
+            if (data.type === 'BLUR') {
                 tab.isFocused = false;
                 if (focusedPausedTabId === tabId) {
                     focusedPausedTabId = null;
@@ -114,7 +105,7 @@
                 return;
             }
 
-            if (data.type === MESSAGE_TYPE.CLOSING) {
+            if (data.type === 'CLOSING') {
                 const wasActive = activeTabId === tabId;
                 tabs.delete(tabId);
                 if (focusedPausedTabId === tabId) {

--- a/test/plugins/controls/preventConcurrency/mocks/preventConcurrencySharedWorker.js
+++ b/test/plugins/controls/preventConcurrency/mocks/preventConcurrencySharedWorker.js
@@ -1,0 +1,38 @@
+define(function () {
+    ('use strict');
+
+    let stats = {
+        createCalls: 0,
+        markActiveCalls: 0,
+        markPausedCalls: 0
+    };
+
+    return {
+        createSharedWorkerClient() {
+            stats.createCalls += 1;
+
+            return {
+                markActive() {
+                    stats.markActiveCalls += 1;
+                },
+                markPaused() {
+                    stats.markPausedCalls += 1;
+                }
+            };
+        },
+
+        getStats() {
+            return {
+                ...stats
+            };
+        },
+
+        reset() {
+            stats = {
+                createCalls: 0,
+                markActiveCalls: 0,
+                markPausedCalls: 0
+            };
+        }
+    };
+});

--- a/test/plugins/controls/preventConcurrency/test.html
+++ b/test/plugins/controls/preventConcurrency/test.html
@@ -9,7 +9,8 @@
                 require(['qunitEnv'], function() {
                     requirejs.config({
                         paths: {
-                            'taoQtiTest/runner/services/sequenceStore': '/test/plugins/controls/preventConcurrency/mocks/sequenceStore'
+                            'taoQtiTest/runner/services/sequenceStore': '/test/plugins/controls/preventConcurrency/mocks/sequenceStore',
+                            'taoQtiTest/runner/plugins/controls/session/preventConcurrencySharedWorker': '/test/plugins/controls/preventConcurrency/mocks/preventConcurrencySharedWorker'
                         }
                     });
                     require(['taoQtiTest/test/runner/plugins/controls/preventConcurrency/test'], function() {

--- a/test/plugins/controls/preventConcurrency/test.js
+++ b/test/plugins/controls/preventConcurrency/test.js
@@ -22,8 +22,18 @@ define([
     'taoQtiTest/test/runner/mocks/providerMock',
     'taoQtiTest/test/runner/mocks/proxyMock',
     'taoQtiTest/runner/plugins/controls/session/preventConcurrency',
-    'taoQtiTest/runner/services/sequenceStore'
-], function (context, runnerFactory, proxyFactory, providerMock, providerProxyMock, pluginFactory, sequenceStore) {
+    'taoQtiTest/runner/services/sequenceStore',
+    'taoQtiTest/runner/plugins/controls/session/preventConcurrencySharedWorker'
+], function (
+    context,
+    runnerFactory,
+    proxyFactory,
+    providerMock,
+    providerProxyMock,
+    pluginFactory,
+    sequenceStore,
+    preventConcurrencySharedWorker
+) {
     'use strict';
 
     const providerName = 'mock';
@@ -127,6 +137,7 @@ define([
     QUnit.module('Plugin', {
         beforeEach() {
             context.featureFlags = {};
+            preventConcurrencySharedWorker.reset();
         }
     });
 
@@ -138,7 +149,7 @@ define([
 
                 runner.sequenceNumber = '1234-5678';
 
-                assert.expect(1);
+                assert.expect(3);
 
                 return sequenceStore.getSequenceStore().then(store =>
                     store
@@ -147,6 +158,8 @@ define([
                         .then(() => store.getSequenceNumber())
                         .then(sequenceNumber => {
                             assert.equal(sequenceNumber, runner.sequenceNumber);
+                            assert.equal(preventConcurrencySharedWorker.getStats().createCalls, 0);
+                            assert.equal(preventConcurrencySharedWorker.getStats().markActiveCalls, 0);
                         })
                 );
             })
@@ -168,7 +181,7 @@ define([
 
                 runner.sequenceNumber = '1234-5678';
 
-                assert.expect(3);
+                assert.expect(5);
 
                 return sequenceStore.getSequenceStore().then(store =>
                     plugin
@@ -176,12 +189,15 @@ define([
                         .then(() => store.getSequenceNumber())
                         .then(sequenceNumber => {
                             assert.equal(sequenceNumber, runner.sequenceNumber);
+                            assert.equal(preventConcurrencySharedWorker.getStats().createCalls, 1);
+                            assert.equal(preventConcurrencySharedWorker.getStats().markActiveCalls, 1);
                         })
                         .then(
                             () =>
                                 new Promise(resolve => {
                                     runner.on('concurrency', () => assert.ok('true', 'Concurrency detected'));
                                     runner.on('leave', () => {
+                                        assert.equal(preventConcurrencySharedWorker.getStats().markPausedCalls, 1);
                                         assert.ok('true', 'Test runner leaving');
                                         resolve();
                                     });
@@ -209,7 +225,7 @@ define([
 
                 runner.sequenceNumber = '1234-5678';
 
-                assert.expect(1);
+                assert.expect(3);
 
                 return sequenceStore.getSequenceStore().then(store =>
                     plugin
@@ -217,6 +233,8 @@ define([
                         .then(() => store.getSequenceNumber())
                         .then(sequenceNumber => {
                             assert.equal(sequenceNumber, runner.sequenceNumber);
+                            assert.equal(preventConcurrencySharedWorker.getStats().createCalls, 1);
+                            assert.equal(preventConcurrencySharedWorker.getStats().markActiveCalls, 1);
                         })
                         .then(
                             () =>
@@ -249,7 +267,7 @@ define([
 
                 runner.sequenceNumber = '1234-5678';
 
-                assert.expect(1);
+                assert.expect(4);
 
                 return sequenceStore.getSequenceStore().then(store =>
                     plugin
@@ -257,6 +275,9 @@ define([
                         .then(() => store.getSequenceNumber())
                         .then(sequenceNumber => {
                             assert.equal(sequenceNumber, runner.sequenceNumber);
+                            assert.equal(preventConcurrencySharedWorker.getStats().createCalls, 0);
+                            assert.equal(preventConcurrencySharedWorker.getStats().markActiveCalls, 0);
+                            assert.equal(preventConcurrencySharedWorker.getStats().markPausedCalls, 0);
                         })
                         .then(
                             () =>


### PR DESCRIPTION
# [INF-349](https://oat-sa.atlassian.net/browse/INF-349)

## Description
Concurrent test sessions in multiple tabs could leave users stuck on a paused session after closing the active tab.
This change adds automatic recovery so the correct paused tab refreshes and resumes, while still enforcing single active session per browser session.

## Changes
- Added a SharedWorker-based tab coordination flow for preventConcurrency.
- Implemented worker script to track active/paused tabs and grant unpause to the focused paused tab when active tab closes.
- Added plugin-side worker client logic for:
  - tab registration
  - focus/blur/visibility handling
  - close handling (pagehide/beforeunload)
  - one-time auto refresh on unpause
- Gated all new worker logic behind `FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS`.

[INF-349]: https://oat-sa.atlassian.net/browse/INF-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ