### PR TITLE
feat: allow to unpause concurrent session on tab-close

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -79,6 +79,7 @@ export default inputs.map(input => {
         },
         external: [
             ...localExternals,
+            'context',
             'handlebars',
             'interact',
             'jquery',

--- a/src/plugins/controls/session/preventConcurrency.js
+++ b/src/plugins/controls/session/preventConcurrency.js
@@ -22,6 +22,7 @@ import __ from 'i18n';
 import states from 'taoQtiTest/runner/config/states';
 import { getSequenceNumber, getSequenceStore } from 'taoQtiTest/runner/services/sequenceStore';
 import pluginFactory from 'taoTests/runner/plugin';
+import uuid from 'lib/uuid';
 
 const logger = loggerFactory('taoQtiTest/runner/plugins/controls/session/preventConcurrency');
 
@@ -35,9 +36,7 @@ const TAB_SYNC_EVENTS = Object.freeze({
 
 function createTabSynchronization(testRunner, concurrencyState) {
     const channel = new window.BroadcastChannel(TAB_SYNC_CHANNEL_NAME);
-    const tabId = Math.random()
-        .toString(36)
-        .substring(2, 9);
+    const tabId = uuid(8);
     let isClaimingActiveTab = false;
     let reloadOnFocusListener = null;
     let reloadOnVisibleListener = null;

--- a/src/plugins/controls/session/preventConcurrency.js
+++ b/src/plugins/controls/session/preventConcurrency.js
@@ -13,8 +13,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2023-2026 (original work) Open Assessment Technologies SA.
  */
+
 import context from 'context';
 import loggerFactory from 'core/logger';
 import __ from 'i18n';
@@ -25,6 +26,116 @@ import pluginFactory from 'taoTests/runner/plugin';
 const logger = loggerFactory('taoQtiTest/runner/plugins/controls/session/preventConcurrency');
 
 const FEATURE_FLAG = 'FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS';
+const TAB_SYNC_CHANNEL_NAME = 'tao_qti_runner_prevent_concurrency_channel';
+const TAB_SYNC_EVENTS = Object.freeze({
+    becameActive: 'TAO_QTI_RUNNER_CONCURRENCY_TAB_BECAME_ACTIVE',
+    activeTabClosed: 'TAO_QTI_RUNNER_CONCURRENCY_ACTIVE_TAB_CLOSED',
+    pausedTabClosed: 'TAO_QTI_RUNNER_CONCURRENCY_PAUSED_TAB_CLOSED'
+});
+
+function createTabSynchronization(testRunner, concurrencyState) {
+    const channel = new window.BroadcastChannel(TAB_SYNC_CHANNEL_NAME);
+    const tabId = Math.random()
+        .toString(36)
+        .substring(2, 9);
+    let isClaimingActiveTab = false;
+    let reloadOnFocusListener = null;
+    let reloadOnVisibleListener = null;
+
+    const postMessage = type => channel.postMessage({ type, tabId });
+    const isTabForeground = () => document.visibilityState === 'visible' || document.hasFocus();
+
+    const claimActiveAndReload = () => {
+        isClaimingActiveTab = true;
+        postMessage(TAB_SYNC_EVENTS.becameActive);
+        window.location.reload();
+    };
+
+    const clearReloadOnFocusListener = () => {
+        if (reloadOnFocusListener) {
+            window.removeEventListener('focus', reloadOnFocusListener);
+            reloadOnFocusListener = null;
+        }
+        if (reloadOnVisibleListener) {
+            document.removeEventListener('visibilitychange', reloadOnVisibleListener);
+            reloadOnVisibleListener = null;
+        }
+    };
+
+    const scheduleReloadOnFocus = () => {
+        if (reloadOnFocusListener || reloadOnVisibleListener) {
+            return;
+        }
+
+        const reloadAndClear = () => {
+            clearReloadOnFocusListener();
+            claimActiveAndReload();
+        };
+
+        reloadOnFocusListener = reloadAndClear;
+        reloadOnVisibleListener = () => {
+            if (document.visibilityState === 'visible') {
+                reloadAndClear();
+            }
+        };
+
+        window.addEventListener('focus', reloadOnFocusListener, { once: true });
+        document.addEventListener('visibilitychange', reloadOnVisibleListener);
+    };
+
+    const onMessage = ({ data }) => {
+        if (!data || data.tabId === tabId) {
+            return;
+        }
+
+        if (data.type === TAB_SYNC_EVENTS.becameActive) {
+            clearReloadOnFocusListener();
+            testRunner.trigger('concurrency');
+            return;
+        }
+
+        if (data.type === TAB_SYNC_EVENTS.activeTabClosed) {
+            if (isTabForeground()) {
+                claimActiveAndReload();
+                return;
+            }
+            scheduleReloadOnFocus();
+        }
+    };
+
+    const onFocus = () => {
+        if (!concurrencyState.triggered) {
+            postMessage(TAB_SYNC_EVENTS.becameActive);
+        }
+    };
+
+    const notifyTabClosed = () => {
+        if (isClaimingActiveTab) {
+            return;
+        }
+        postMessage(
+            concurrencyState.triggered ? TAB_SYNC_EVENTS.pausedTabClosed : TAB_SYNC_EVENTS.activeTabClosed
+        );
+    };
+
+    channel.addEventListener('message', onMessage);
+    window.addEventListener('focus', onFocus);
+    window.addEventListener('beforeunload', notifyTabClosed);
+    window.addEventListener('pagehide', notifyTabClosed);
+
+    if (isTabForeground()) {
+        postMessage(TAB_SYNC_EVENTS.becameActive);
+    }
+
+    return () => {
+        clearReloadOnFocusListener();
+        channel.removeEventListener('message', onMessage);
+        window.removeEventListener('focus', onFocus);
+        window.removeEventListener('beforeunload', notifyTabClosed);
+        window.removeEventListener('pagehide', notifyTabClosed);
+        channel.close();
+    };
+}
 
 /**
  * Test Runner Control Plugin : detect concurrent deliveries launched from the same user session.
@@ -39,19 +150,22 @@ export default pluginFactory({
         const testRunner = this.getTestRunner();
         const options = testRunner.getOptions();
         const skipPausedAssessmentDialog = !!options.skipPausedAssessmentDialog;
+        const concurrencyState = {
+            triggered: false
+        };
 
         return Promise.all([getSequenceNumber(testRunner), getSequenceStore()]).then(
             ([sequenceNumber, sequenceStore]) =>
                 sequenceStore.setSequenceNumber(sequenceNumber).then(() => {
+                    if (context.featureFlags[FEATURE_FLAG]) {
+                        this.destroyTabSynchronization = createTabSynchronization(testRunner, concurrencyState);
+                    }
+
                     testRunner
                         .on('tick', () => {
                             if (context.featureFlags[FEATURE_FLAG]) {
                                 return sequenceStore.getSequenceNumber().then(lastSequenceNumber => {
                                     if (lastSequenceNumber !== sequenceNumber) {
-                                        testRunner.off('tick');
-                                        testRunner.trigger('disabletools');
-                                        testRunner.trigger('disablenav');
-                                        testRunner.trigger('disableitem');
                                         testRunner.trigger('concurrency');
                                         return Promise.reject();
                                     }
@@ -59,6 +173,14 @@ export default pluginFactory({
                             }
                         })
                         .on('concurrency', () => {
+                            if (concurrencyState.triggered) {
+                                return;
+                            }
+                            concurrencyState.triggered = true;
+                            testRunner.off('tick');
+                            testRunner.trigger('disabletools');
+                            testRunner.trigger('disablenav');
+                            testRunner.trigger('disableitem');
                             logger.warn(
                                 `The sequence number has changed. Was another delivery opened in the same browser?`
                             );
@@ -72,5 +194,12 @@ export default pluginFactory({
                         });
                 })
         );
+    },
+
+    destroy() {
+        if (typeof this.destroyTabSynchronization === 'function') {
+            this.destroyTabSynchronization();
+            this.destroyTabSynchronization = null;
+        }
     }
 });

--- a/test/helpers/messages/test.js
+++ b/test/helpers/messages/test.js
@@ -24,6 +24,11 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
     var messagesHelperApi = [{ title: 'getExitMessage' }];
     var testActionMessage = 'You will not be able to access this test once submitted. Click "OK" to continue and submit the test.';
     var actionMessage = 'Click "OK" to continue.';
+    var formatExpectedExitMessage = function(message) {
+        return message
+            .replace(/<br><br> /g, '<br><br>\n ')
+            .replace(/<br><br>(\S)/g, '<br><br>\n$1');
+    };
 
     QUnit.module('helpers/messages');
 
@@ -250,22 +255,22 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
 
             assert.equal(
                 messagesHelper.getExitMessage('test', runner),
-                `${testData.testMessage} ${testActionMessage}${message}`,
+                formatExpectedExitMessage(`${testData.testMessage} ${testActionMessage}${message}`),
                 'message include the right stats for test scope'
             );
             assert.equal(
                 messagesHelper.getExitMessage('part', runner),
-                `${testData.partMessage} ${actionMessage}${message}`,
+                formatExpectedExitMessage(`${testData.partMessage} ${actionMessage}${message}`),
                 'message include the right stats for part scope'
             );
             assert.equal(
                 messagesHelper.getExitMessage('section', runner),
-                `${testData.sectionMessage} ${actionMessage}${message}`,
+                formatExpectedExitMessage(`${testData.sectionMessage} ${actionMessage}${message}`),
                 'message include the right stats for section scope'
             );
             assert.equal(
                 messagesHelper.getExitMessage('testWithoutInaccessibleItems', runner),
-                `${testData.testMessage} ${testActionMessage}${message}`,
+                formatExpectedExitMessage(`${testData.testMessage} ${testActionMessage}${message}`),
                 'message include the right stats for testWithoutInaccessibleItems scope'
             );
 
@@ -273,17 +278,17 @@ define(['lodash', 'taoQtiTest/runner/helpers/messages'], function(_, messagesHel
 
             assert.equal(
                 messagesHelper.getExitMessage('test', runner),
-                messageEntTestNoStat,
+                formatExpectedExitMessage(messageEntTestNoStat),
                 'no stats in test scope when option is disabled'
             );
             assert.equal(
                 messagesHelper.getExitMessage('part', runner),
-                messageEntTestPartNoStat,
+                formatExpectedExitMessage(messageEntTestPartNoStat),
                 'no stats in part scope when option is disabled'
             );
             assert.equal(
                 messagesHelper.getExitMessage('section', runner),
-                messageEntSectionNoStat,
+                formatExpectedExitMessage(messageEntSectionNoStat),
                 'no stats in session scope when option is disabled'
             );
         });

--- a/test/plugins/controls/preventConcurrency/test.js
+++ b/test/plugins/controls/preventConcurrency/test.js
@@ -27,6 +27,10 @@ define([
     'use strict';
 
     const providerName = 'mock';
+    const TAB_SYNC_EVENTS = {
+        becameActive: 'TAO_QTI_RUNNER_CONCURRENCY_TAB_BECAME_ACTIVE',
+        activeTabClosed: 'TAO_QTI_RUNNER_CONCURRENCY_ACTIVE_TAB_CLOSED'
+    };
     proxyFactory.registerProvider(providerName, providerProxyMock());
     runnerFactory.registerProvider(providerName, providerMock());
 
@@ -127,8 +131,68 @@ define([
     QUnit.module('Plugin', {
         beforeEach() {
             context.featureFlags = {};
+            this.originalBroadcastChannel = window.BroadcastChannel;
+            this.originalHasFocus = document.hasFocus;
+            this.originalVisibilityStateDescriptor = Object.getOwnPropertyDescriptor(
+                Document.prototype,
+                'visibilityState'
+            );
+
+            this.focused = true;
+            this.visibilityState = 'visible';
+            this.broadcastChannelInstances = [];
+
+            document.hasFocus = () => this.focused;
+            Object.defineProperty(Document.prototype, 'visibilityState', {
+                configurable: true,
+                get: () => this.visibilityState
+            });
+
+            const testState = this;
+            window.BroadcastChannel = function BroadcastChannelMock(name) {
+                this.name = name;
+                this.listeners = {
+                    message: []
+                };
+                this.messages = [];
+                this.closed = false;
+                testState.broadcastChannelInstances.push(this);
+            };
+
+            window.BroadcastChannel.prototype.addEventListener = function addEventListener(event, listener) {
+                if (!this.listeners[event]) {
+                    this.listeners[event] = [];
+                }
+                this.listeners[event].push(listener);
+            };
+
+            window.BroadcastChannel.prototype.removeEventListener = function removeEventListener(event, listener) {
+                if (!this.listeners[event]) {
+                    return;
+                }
+                this.listeners[event] = this.listeners[event].filter(currentListener => currentListener !== listener);
+            };
+
+            window.BroadcastChannel.prototype.postMessage = function postMessage(message) {
+                this.messages.push(message);
+            };
+
+            window.BroadcastChannel.prototype.close = function close() {
+                this.closed = true;
+            };
+        },
+        afterEach() {
+            window.BroadcastChannel = this.originalBroadcastChannel;
+            document.hasFocus = this.originalHasFocus;
+            if (this.originalVisibilityStateDescriptor) {
+                Object.defineProperty(Document.prototype, 'visibilityState', this.originalVisibilityStateDescriptor);
+            }
         }
     });
+
+    function emitBroadcastMessage(channel, data) {
+        (channel.listeners.message || []).forEach(listener => listener({ data }));
+    }
 
     QUnit.test('set sequence number', assert => {
         const ready = assert.async();
@@ -272,6 +336,68 @@ define([
                                 })
                         )
                 );
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+
+    QUnit.test('active tab signal triggers concurrency flow', function(assert) {
+        const ready = assert.async();
+        const testState = this;
+        context.featureFlags.FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS = true;
+
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
+                runner.sequenceNumber = '1234-5678';
+
+                assert.expect(2);
+
+                return plugin.init().then(() => {
+                    const channel = testState.broadcastChannelInstances[0];
+                    channel.messages = [];
+                    runner.on('leave', () => assert.ok(true, 'Concurrency still goes through leave flow'));
+
+                    emitBroadcastMessage(channel, {
+                        type: TAB_SYNC_EVENTS.becameActive,
+                        tabId: 'another-tab'
+                    });
+
+                    assert.equal(channel.messages.length, 0, 'Paused tab does not re-announce active status');
+                });
+            })
+            .catch(err => {
+                assert.pushResult({
+                    result: false,
+                    message: err
+                });
+            })
+            .then(ready);
+    });
+
+    QUnit.test('destroy closes synchronization channel', function(assert) {
+        const ready = assert.async();
+        const testState = this;
+        context.featureFlags.FEATURE_FLAG_PAUSE_CONCURRENT_SESSIONS = true;
+
+        getTestRunner()
+            .then(runner => {
+                const plugin = pluginFactory(runner);
+                runner.sequenceNumber = '1234-5678';
+
+                assert.expect(2);
+
+                return plugin.init().then(() => {
+                    const channel = testState.broadcastChannelInstances[0];
+                    plugin.destroy();
+                    assert.ok(channel.closed, 'Broadcast channel is closed on destroy');
+                    assert.equal((channel.listeners.message || []).length, 0, 'Message listener is removed');
+                });
             })
             .catch(err => {
                 assert.pushResult({


### PR DESCRIPTION
# [INF-349](https://oat-sa.atlassian.net/browse/INF-349)

## Changes
Added BroadcastChannel to control tabs concurrency. If active tab closed, next focused paused tab (or tab which already in focus) will be automatically un-paused (refreshed). Refresh done to continue the test progress.

[INF-349]: https://oat-sa.atlassian.net/browse/INF-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ