### PR TITLE
chore: version bump in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@oat-sa/tao-test-runner-qti",
-    "version": "4.4.0",
+    "version": "4.4.0-4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-test-runner-qti",
-            "version": "4.4.0",
+            "version": "4.4.0-4",
             "license": "GPL-2.0",
             "devDependencies": {
                 "@babel/core": "^7.21.4",


### PR DESCRIPTION
Bump version for package-lock file